### PR TITLE
Allow to customize OpenAPI object programmatically

### DIFF
--- a/springdoc-openapi-core/pom.xml
+++ b/springdoc-openapi-core/pom.xml
@@ -33,5 +33,16 @@
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/springdoc-openapi-core/src/main/java/org/springdoc/core/InfoBuilder.java
+++ b/springdoc-openapi-core/src/main/java/org/springdoc/core/InfoBuilder.java
@@ -1,12 +1,10 @@
 package org.springdoc.core;
 
-import static org.springdoc.core.Constants.DEFAULT_TITLE;
-import static org.springdoc.core.Constants.DEFAULT_VERSION;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
+import io.swagger.v3.core.util.AnnotationsUtils;
+import io.swagger.v3.core.util.ReflectionUtils;
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,11 +16,13 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.stereotype.Component;
 
-import io.swagger.v3.core.util.AnnotationsUtils;
-import io.swagger.v3.core.util.ReflectionUtils;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springdoc.core.Constants.DEFAULT_TITLE;
+import static org.springdoc.core.Constants.DEFAULT_VERSION;
 
 @Component
 public class InfoBuilder {
@@ -31,12 +31,26 @@ public class InfoBuilder {
 
 	@Autowired
 	private ApplicationContext context;
+	@Autowired
+	private Optional<OpenAPI> openAPIBean;
 
 	private InfoBuilder() {
 		super();
 	}
 
 	public void build(OpenAPI openAPI) {
+		Optional<OpenAPIDefinition> apiDef = getOpenAPIDefinition();
+		if (apiDef.isPresent()) {
+			buildOpenAPIWithOpenAPIDefinition(openAPI, apiDef.get());
+		} else if(openAPIBean.isPresent()) {
+			buildOpenAPIWithOpenAPIBean(openAPI, openAPIBean.get());
+		} else {
+			Info infos = new Info().title(DEFAULT_TITLE).version(DEFAULT_VERSION);
+			openAPI.setInfo(infos);
+		}
+	}
+
+	private Optional<OpenAPIDefinition> getOpenAPIDefinition() {
 		// Look for OpenAPIDefinition in a spring managed bean
 		Map<String, Object> openAPIDefinitionMap = context.getBeansWithAnnotation(OpenAPIDefinition.class);
 		OpenAPIDefinition apiDef = null;
@@ -60,26 +74,33 @@ public class InfoBuilder {
 			}
 
 		}
+		return Optional.ofNullable(apiDef);
+	}
 
-		if (apiDef != null) {
-			// info
-			AnnotationsUtils.getInfo(apiDef.info()).ifPresent(openAPI::setInfo);
-			// OpenApiDefinition security requirements
-			SecurityParser.getSecurityRequirements(apiDef.security()).ifPresent(openAPI::setSecurity);
-			// OpenApiDefinition external docs
-			AnnotationsUtils.getExternalDocumentation(apiDef.externalDocs()).ifPresent(openAPI::setExternalDocs);
-			// OpenApiDefinition tags
-			AnnotationsUtils.getTags(apiDef.tags(), false).ifPresent(tags -> openAPI.setTags(new ArrayList<>(tags)));
-			// OpenApiDefinition servers
-			AnnotationsUtils.getServers(apiDef.servers()).ifPresent(openAPI::setServers);
-			// OpenApiDefinition extensions
-			if (apiDef.extensions().length > 0) {
-				openAPI.setExtensions(AnnotationsUtils.getExtensions(apiDef.extensions()));
-			}
-		} else {
-			Info infos = new Info().title(DEFAULT_TITLE).version(DEFAULT_VERSION);
-			openAPI.setInfo(infos);
+	private static void buildOpenAPIWithOpenAPIDefinition(OpenAPI openAPI, OpenAPIDefinition apiDef) {
+		// info
+		AnnotationsUtils.getInfo(apiDef.info()).ifPresent(openAPI::setInfo);
+		// OpenApiDefinition security requirements
+		SecurityParser.getSecurityRequirements(apiDef.security()).ifPresent(openAPI::setSecurity);
+		// OpenApiDefinition external docs
+		AnnotationsUtils.getExternalDocumentation(apiDef.externalDocs()).ifPresent(openAPI::setExternalDocs);
+		// OpenApiDefinition tags
+		AnnotationsUtils.getTags(apiDef.tags(), false).ifPresent(tags -> openAPI.setTags(new ArrayList<>(tags)));
+		// OpenApiDefinition servers
+		AnnotationsUtils.getServers(apiDef.servers()).ifPresent(openAPI::setServers);
+		// OpenApiDefinition extensions
+		if (apiDef.extensions().length > 0) {
+			openAPI.setExtensions(AnnotationsUtils.getExtensions(apiDef.extensions()));
 		}
+	}
+
+	private static void buildOpenAPIWithOpenAPIBean(OpenAPI destinationOpenAPI, OpenAPI sourceOpenAPI) {
+		destinationOpenAPI.setInfo(sourceOpenAPI.getInfo());
+		destinationOpenAPI.setSecurity(sourceOpenAPI.getSecurity());
+		destinationOpenAPI.setExternalDocs(sourceOpenAPI.getExternalDocs());
+		destinationOpenAPI.setTags(sourceOpenAPI.getTags());
+		destinationOpenAPI.setServers(sourceOpenAPI.getServers());
+		destinationOpenAPI.setExtensions(sourceOpenAPI.getExtensions());
 	}
 
 	private OpenAPIDefinition getApiDefClass(ClassPathScanningCandidateComponentProvider scanner,

--- a/springdoc-openapi-core/src/test/java/ext/springdoc/bean/CustomOpenAPIConfig.java
+++ b/springdoc-openapi-core/src/test/java/ext/springdoc/bean/CustomOpenAPIConfig.java
@@ -1,0 +1,19 @@
+package ext.springdoc.bean;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.tags.Tag;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CustomOpenAPIConfig {
+  @Bean
+  public OpenAPI customOpenAPI() {
+    return new OpenAPI()
+        .info(new Info()
+            .title("Custom API")
+            .version("100"))
+        .addTagsItem(new Tag().name("mytag"));
+  }
+}

--- a/springdoc-openapi-core/src/test/java/org/springdoc/SpringDocSpringDocTestApplication.java
+++ b/springdoc-openapi-core/src/test/java/org/springdoc/SpringDocSpringDocTestApplication.java
@@ -1,0 +1,11 @@
+package org.springdoc;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringDocSpringDocTestApplication {
+  public static void main(String[] args) {
+    SpringApplication.run(SpringDocSpringDocTestApplication.class, args);
+  }
+}

--- a/springdoc-openapi-core/src/test/java/org/springdoc/api/OpenApiResourceCustomConfigurationTests.java
+++ b/springdoc-openapi-core/src/test/java/org/springdoc/api/OpenApiResourceCustomConfigurationTests.java
@@ -1,0 +1,50 @@
+package org.springdoc.api;
+
+import ext.springdoc.bean.CustomOpenAPIConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springdoc.SpringDocSpringDocTestApplication;
+import org.springdoc.config.SpringDocConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SpringDocSpringDocTestApplication.class)
+@Import(CustomOpenAPIConfig.class)
+@ActiveProfiles("test")
+@TestPropertySource(properties = "springdoc.api-docs.path=/api-docs")
+@AutoConfigureMockMvc
+public class OpenApiResourceCustomConfigurationTests {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  /**
+   * should return
+   * {"openapi":"3.0.1","info":{"title":"Custom API","version":"100"},"paths":{},"components":{}}
+   */
+  @Test
+  public void givenNoConfiguration_whenGetApiJson_returnsDefaultEmptyDocs() throws Exception {
+    mockMvc
+        .perform(get("/api-docs"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", is("3.0.1")))
+        .andExpect(jsonPath("$.info.title", is("Custom API")))
+        .andExpect(jsonPath("$.info.version", is("100")))
+        .andExpect(jsonPath("$.paths").isEmpty())
+        .andExpect(jsonPath("$.components").isEmpty())
+        .andExpect(jsonPath("$.tags").isNotEmpty())
+        .andExpect(jsonPath("$.tags[0].name", is("mytag")));
+  }
+}

--- a/springdoc-openapi-core/src/test/java/org/springdoc/api/OpenApiResourceNoConfigurationTests.java
+++ b/springdoc-openapi-core/src/test/java/org/springdoc/api/OpenApiResourceNoConfigurationTests.java
@@ -1,0 +1,45 @@
+package org.springdoc.api;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springdoc.SpringDocSpringDocTestApplication;
+import org.springdoc.config.SpringDocConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = SpringDocSpringDocTestApplication.class)
+@ActiveProfiles("test")
+@TestPropertySource(properties = "springdoc.api-docs.path=/api-docs")
+@AutoConfigureMockMvc
+public class OpenApiResourceNoConfigurationTests {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  /**
+   * should return
+   * {"openapi":"3.0.1","info":{"title":"OpenAPI definition","version":"v0"},"paths":{},"components":{}}
+   */
+  @Test
+  public void givenNoConfiguration_whenGetApiJson_returnsDefaultEmptyDocs() throws Exception {
+    mockMvc
+        .perform(get("/api-docs"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", is("3.0.1")))
+        .andExpect(jsonPath("$.info.title", is("OpenAPI definition")))
+        .andExpect(jsonPath("$.info.version", is("v0")))
+        .andExpect(jsonPath("$.paths").isEmpty())
+        .andExpect(jsonPath("$.components").isEmpty());
+  }
+}

--- a/springdoc-openapi-core/src/test/resources/application-test.yml
+++ b/springdoc-openapi-core/src/test/resources/application-test.yml
@@ -1,0 +1,1 @@
+spring.main.banner-mode: "off"

--- a/springdoc-openapi-core/src/test/resources/logback-test.xml
+++ b/springdoc-openapi-core/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <root level="off"/>
+</configuration>


### PR DESCRIPTION
This PR allows to customize the OpenAPI object programmatically, by declaring a bean of type OpenAPI.

Additionally, I started with unit tests :)

Ref. #4