### PR TITLE
Fix Null Safety in  ParameterBuilder.buildParameterFromDoc

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterBuilder.java
@@ -132,11 +132,9 @@ public class ParameterBuilder {
 			parameter.$ref(parameterDoc.ref());
 		} else {
 			Type type = ParameterProcessor.getParameterType(parameterDoc);
-			Schema schema = null;
-			if (parameterDoc.schema() != null)
-				schema = AnnotationsUtils.getSchemaFromAnnotation(parameterDoc.schema(), components, null).orElse(null);
-			else
-				schema = this.calculateSchema(components, null, parameter.getName(), type, null);
+			Schema schema = Optional.ofNullable(parameterDoc.schema())
+					.map(schemaDoc -> AnnotationsUtils.getSchemaFromAnnotation(schemaDoc, components, null).orElse(null))
+					.orElseGet(() -> this.calculateSchema(components, null, parameter.getName(), type, null));
 			parameter.setSchema(schema);
 		}
 


### PR DESCRIPTION
In commit [14ce3c6](https://github.com/springdoc/springdoc-openapi/commit/14ce3c6c7d20cf01d06c2baf2215bd807cb905e9), `schema` may be `null` if `AnnotationsUtils.getSchemaFromAnnotation` returns an empty `Optional`. This change provides a way taking preference in the provided documentation and calculates the schema as a fallback.