### PR TITLE
Support for x-forward-prefix when using ForwardedHeaderFilter.

### DIFF
--- a/springdoc-openapi-core/src/main/java/org/springdoc/api/OpenAPICloner.java
+++ b/springdoc-openapi-core/src/main/java/org/springdoc/api/OpenAPICloner.java
@@ -1,0 +1,37 @@
+package org.springdoc.api;
+
+import static org.springdoc.core.Constants.DEFAULT_SERVER_DESCRIPTION;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.springdoc.core.Constants;
+import org.springframework.stereotype.Component;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Component
+public class OpenAPICloner {
+
+	public OpenAPI cloneOpenApi(OpenAPI from, String serverBaseUrl) {
+		OpenAPI to = new OpenAPI();
+		to.components(from.getComponents()).extensions(from.getExtensions()).externalDocs(from.getExternalDocs())
+				.info(from.getInfo()).openapi(from.getOpenapi()).paths(from.getPaths()).security(from.getSecurity())
+				.tags(from.getTags());
+		List<Server> fromServers = from.getServers();
+		List<Server> toServers = fromServers == null ? new ArrayList<>() : new ArrayList<>(from.getServers());
+		to.servers(toServers);
+		Iterator<Server> it = toServers.iterator();
+		while (it.hasNext()) {
+			Server server = it.next();
+			if (Constants.DEFAULT_SERVER_DESCRIPTION.equals(server.getDescription())) {
+				it.remove();
+			}
+		}
+		Server server = new Server().url(serverBaseUrl).description(DEFAULT_SERVER_DESCRIPTION);
+		to.addServersItem(server);
+		return to;
+	}
+}

--- a/springdoc-openapi-core/src/main/java/org/springdoc/api/OpenApiResource.java
+++ b/springdoc-openapi-core/src/main/java/org/springdoc/api/OpenApiResource.java
@@ -45,6 +45,9 @@ public class OpenApiResource extends AbstractOpenApiResource {
 	@Autowired(required = false)
 	private ActuatorProvider servletContextProvider;
 
+	@Autowired
+	OpenAPICloner openAPICloner;
+	
 	@Value(SPRINGDOC_SHOW_ACTUATOR_VALUE)
 	private boolean showActuator;
 
@@ -60,8 +63,9 @@ public class OpenApiResource extends AbstractOpenApiResource {
 	@GetMapping(value = API_DOCS_URL, produces = MediaType.APPLICATION_JSON_VALUE)
 	public String openapiJson(HttpServletRequest request, @Value(API_DOCS_URL) String apiDocsUrl)
 			throws JsonProcessingException {
-		calculateServerUrl(request, apiDocsUrl);
-		OpenAPI openAPI = this.getOpenApi();
+		String serverBaseUrl = calculateServerUrl(request, apiDocsUrl);
+		OpenAPI template = this.getOpenApi();
+		OpenAPI openAPI = openAPICloner.cloneOpenApi(template, serverBaseUrl);
 		return Json.mapper().writeValueAsString(openAPI);
 	}
 
@@ -69,8 +73,9 @@ public class OpenApiResource extends AbstractOpenApiResource {
 	@GetMapping(value = DEFAULT_API_DOCS_URL_YAML, produces = APPLICATION_OPENAPI_YAML)
 	public String openapiYaml(HttpServletRequest request, @Value(DEFAULT_API_DOCS_URL_YAML) String apiDocsUrl)
 			throws JsonProcessingException {
-		calculateServerUrl(request, apiDocsUrl);
-		OpenAPI openAPI = this.getOpenApi();
+		String serverBaseUrl = calculateServerUrl(request, apiDocsUrl);
+		OpenAPI template = this.getOpenApi();
+		OpenAPI openAPI = openAPICloner.cloneOpenApi(template, serverBaseUrl);
 		return Yaml.mapper().writeValueAsString(openAPI);
 	}
 
@@ -111,9 +116,10 @@ public class OpenApiResource extends AbstractOpenApiResource {
 		return result;
 	}
 
-	private void calculateServerUrl(HttpServletRequest request, String apiDocsUrl) {
+	private String calculateServerUrl(HttpServletRequest request, String apiDocsUrl) {
 		StringBuffer requestUrl = request.getRequestURL();
 		String serverBaseUrl = requestUrl.substring(0, requestUrl.length() - apiDocsUrl.length());
 		generalInfoBuilder.setServerBaseUrl(serverBaseUrl);
+		return serverBaseUrl;
 	}
 }


### PR DESCRIPTION
I have multiple context roots for the application.  The default context root is **/myapp**, and the other path is **/dev-myapp** using **x-forward-prefix** .  Spring handles this correctly when using **ForwardHeaderFilter**.  GeneralInfoBuilder caches the context root in Server.url when the first request is made to the application.

The OpenAPI object is a singleton, so is impossible to correctly send back the Server.url for individual clients.   I solved my multiple context root problem by creating a new OpenAPI object for each request using a shallow copy and always getting the baseurl value in context of the current request.

Given this implementation, it probably makes more sense to remove lines 70-73 of GeneralInfoBuilder:
```
		// default server value
		if (CollectionUtils.isEmpty(openAPI.getServers())) {
			Server server = new Server().url(serverBaseUrl).description(DEFAULT_SERVER_DESCRIPTION);
			openAPI.addServersItem(server);
		}
```

More generally, I recommend that the OpenAPI template object be calculated during startup only.  Currently the processing to configure OpenAPI is run during each request.