### PR TITLE
Never ignore @PathVariable parameters

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -47,6 +47,10 @@ public abstract class AbstractRequestBuilder {
 		this.operationBuilder = operationBuilder;
 	}
 
+    protected boolean isParamToIgnore(java.lang.reflect.Parameter parameter) {
+        return isParamTypeToIgnore(parameter.getType());
+    }
+
 	protected abstract boolean isParamTypeToIgnore(Class<?> paramType);
 
 	public Operation build(Components components, HandlerMethod handlerMethod, RequestMethod requestMethod,
@@ -70,7 +74,6 @@ public abstract class AbstractRequestBuilder {
 			// check if query param
 			Parameter parameter = null;
 			final String pName = pNames[i];
-			Class<?> paramType = parameters[i].getType();
 			io.swagger.v3.oas.annotations.Parameter parameterDoc = parameterBuilder.getParameterAnnotation(
 					handlerMethod, parameters[i], i, io.swagger.v3.oas.annotations.Parameter.class);
 
@@ -82,7 +85,7 @@ public abstract class AbstractRequestBuilder {
 				parameter = parameterBuilder.buildParameterFromDoc(parameterDoc, null);
 			}
 
-			if (!isParamTypeToIgnore(paramType)) {
+            if (!isParamToIgnore(parameters[i])) {
 				parameter = buildParams(pName, components, parameters[i], i, parameter, handlerMethod, requestMethod);
 				// Merge with the operation parameters
 				parameter = parameterBuilder.mergeParameter(existingParamDoc, parameter);

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -47,9 +47,12 @@ public abstract class AbstractRequestBuilder {
 		this.operationBuilder = operationBuilder;
 	}
 
-    protected boolean isParamToIgnore(java.lang.reflect.Parameter parameter) {
-        return isParamTypeToIgnore(parameter.getType());
-    }
+	protected boolean isParamToIgnore(java.lang.reflect.Parameter parameter) {
+		if (parameter.isAnnotationPresent(PathVariable.class)) {
+			return false;
+		}
+		return isParamTypeToIgnore(parameter.getType());
+	}
 
 	protected abstract boolean isParamTypeToIgnore(Class<?> paramType);
 
@@ -85,7 +88,7 @@ public abstract class AbstractRequestBuilder {
 				parameter = parameterBuilder.buildParameterFromDoc(parameterDoc, null);
 			}
 
-            if (!isParamToIgnore(parameters[i])) {
+			if (!isParamToIgnore(parameters[i])) {
 				parameter = buildParams(pName, components, parameters[i], i, parameter, handlerMethod, requestMethod);
 				// Merge with the operation parameters
 				parameter = parameterBuilder.mergeParameter(existingParamDoc, parameter);

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/HelloController.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/HelloController.java
@@ -1,0 +1,18 @@
+package test.org.springdoc.api.app47;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Locale;
+
+@RestController
+public class HelloController {
+	@GetMapping(path = "/documents/{locale}")
+	public ResponseEntity<String> getDocumentsWithLocale(@Parameter(schema = @Schema(type = "string")) @PathVariable("locale") Locale locale) {
+		return null;
+	}
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/SpringDocApp47Test.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/SpringDocApp47Test.java
@@ -1,0 +1,8 @@
+package test.org.springdoc.api.app47;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp47Test extends AbstractSpringDocTest {
+
+
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/SpringDocTestApp.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app47/SpringDocTestApp.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app47;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	public static void main(String[] args) {
+        SpringApplication.run(SpringDocTestApp.class, args);
+    }
+}

--- a/springdoc-openapi-core/src/test/resources/results/app47.json
+++ b/springdoc-openapi-core/src/test/resources/results/app47.json
@@ -1,0 +1,43 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/documents/{locale}": {
+      "get": {
+        "operationId": "getDocumentsWithLocale",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
Given a controller like
```
@RestController
public class HelloController {
    @GetMapping(path = "/documents/{locale}")
    public ResponseEntity<String> getDocumentsWithLocale(@Parameter(schema = @Schema(type = "string")) @PathVariable("locale") Locale locale) {
        return null;
    }
}
```
where a parameter with type `Locale` is used as a `@PathVariable`, the parameter still ignored although it's required to have a valid spec generated.

This PR fixes this and adds a test case which fails without the fix applied. It also improves the control over which parameter is supposed to be ignored by providing a new method `protected boolean isParamToIgnore(java.lang.reflect.Parameter parameter)` which can be overridden by custom RequestBuilder implementations.