### PR TITLE
Extend search for `@ApiResponse` annotations and merge everything together

### DIFF
--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/AbstractHelloController.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/AbstractHelloController.java
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.app48;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@ApiResponse(responseCode = "410")
+@ApiResponses({
+		@ApiResponse(responseCode = "411")
+})
+public class AbstractHelloController {
+
+	@GetMapping(path = "/documents/{locale}")
+	@ApiResponse(responseCode = "412")
+	@ApiResponses({
+			@ApiResponse(responseCode = "413")
+	})
+	public ResponseEntity<String> getDocuments() {
+		return null;
+	}
+
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/HelloController.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/HelloController.java
@@ -1,0 +1,26 @@
+package test.org.springdoc.api.app48;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+
+@ApiResponse(responseCode = "400")
+@ApiResponses({
+		@ApiResponse(responseCode = "401")
+})
+public class HelloController extends AbstractHelloController {
+
+	@Override
+	@GetMapping(path = "/documents/{locale}")
+	@ApiResponse(responseCode = "402")
+	@ApiResponses({
+			@ApiResponse(responseCode = "403")
+	})
+	public ResponseEntity<String> getDocuments() {
+		return null;
+	}
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/SpringDocApp48Test.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/SpringDocApp48Test.java
@@ -1,0 +1,8 @@
+package test.org.springdoc.api.app48;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp48Test extends AbstractSpringDocTest {
+
+
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/SpringDocTestApp.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app48/SpringDocTestApp.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app48;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	public static void main(String[] args) {
+        SpringApplication.run(SpringDocTestApp.class, args);
+    }
+}

--- a/springdoc-openapi-core/src/test/resources/results/app48.json
+++ b/springdoc-openapi-core/src/test/resources/results/app48.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/documents/{locale}": {
+      "get": {
+        "operationId": "getDocuments",
+        "responses": {
+          "410": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "402": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "411": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "default response",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
This PR extends how `@ApiResponse(s)` annotations are found when building the OpenAPI. 

I'd like to put this to discussions and I'm open for feedback on this one. It basically enables putting `@ApiResponse` annotations on abstract base controllers and as such having more "globally" defined responses for all methods. This is helpful (at least for me) in larger projects. If there's another way of doing things like this, please notify me and this PR could be closed.