### PR TITLE
Introduce magic response code constant

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractResponseBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractResponseBuilder.java
@@ -121,39 +121,39 @@ public abstract class AbstractResponseBuilder {
 	private Map<String, ApiResponse> computeResponse(Components components, Method method, ApiResponses apiResponsesOp,
 			MethodAttributes methodAttributes, boolean isGeneric) {
 		// Parsing documentation, if present
-		Set<io.swagger.v3.oas.annotations.responses.ApiResponse> responsesArray = getApiResponses(method);
-		if (!responsesArray.isEmpty()) {
+		Set<io.swagger.v3.oas.annotations.responses.ApiResponse> apiResponseAnnotations = getApiResponseAnnotations(method);
+		if (!apiResponseAnnotations.isEmpty()) {
 			methodAttributes.setWithApiResponseDoc(true);
-			for (io.swagger.v3.oas.annotations.responses.ApiResponse apiResponse2 : responsesArray) {
-				ApiResponse apiResponse1 = new ApiResponse();
-				if (StringUtils.isNotBlank(apiResponse2.ref())) {
-					apiResponse1.$ref(apiResponse2.ref());
-					apiResponsesOp.addApiResponse(apiResponse2.responseCode(), apiResponse1);
+			for (io.swagger.v3.oas.annotations.responses.ApiResponse apiResponseAnnotation : apiResponseAnnotations) {
+				ApiResponse apiResponse = new ApiResponse();
+				if (StringUtils.isNotBlank(apiResponseAnnotation.ref())) {
+					apiResponse.$ref(apiResponseAnnotation.ref());
+					apiResponsesOp.addApiResponse(apiResponseAnnotation.responseCode(), apiResponse);
 					continue;
 				}
 
-				apiResponse1.setDescription(apiResponse2.description());
-				io.swagger.v3.oas.annotations.media.Content[] contentdoc = apiResponse2.content();
+				apiResponse.setDescription(apiResponseAnnotation.description());
+				io.swagger.v3.oas.annotations.media.Content[] contentdoc = apiResponseAnnotation.content();
 				Optional<Content> optionalContent = SpringDocAnnotationsUtils.getContent(contentdoc, new String[0],
 						methodAttributes.getAllProduces(), null, components, null);
 
-				if (apiResponsesOp.containsKey(apiResponse2.responseCode())) {
+				if (apiResponsesOp.containsKey(apiResponseAnnotation.responseCode())) {
 					// Merge with the existing content
-					Content existingContent = apiResponsesOp.get(apiResponse2.responseCode()).getContent();
+					Content existingContent = apiResponsesOp.get(apiResponseAnnotation.responseCode()).getContent();
 					if (optionalContent.isPresent() && existingContent != null) {
 						Content newContent = optionalContent.get();
 						for (String mediaTypeStr : methodAttributes.getAllProduces()) {
 							io.swagger.v3.oas.models.media.MediaType mediaType = newContent.get(mediaTypeStr);
 							mergeSchema(existingContent, mediaType.getSchema(), mediaTypeStr);
 						}
-						apiResponse1.content(existingContent);
+						apiResponse.content(existingContent);
 					}
 				} else {
-					optionalContent.ifPresent(apiResponse1::content);
+					optionalContent.ifPresent(apiResponse::content);
 				}
 
-				AnnotationsUtils.getHeaders(apiResponse2.headers(), null).ifPresent(apiResponse1::headers);
-				apiResponsesOp.addApiResponse(apiResponse2.responseCode(), apiResponse1);
+				AnnotationsUtils.getHeaders(apiResponseAnnotation.headers(), null).ifPresent(apiResponse::headers);
+				apiResponsesOp.addApiResponse(apiResponseAnnotation.responseCode(), apiResponse);
 			}
 		}
 
@@ -178,7 +178,7 @@ public abstract class AbstractResponseBuilder {
 		return apiResponsesOp;
 	}
 
-	private Set<io.swagger.v3.oas.annotations.responses.ApiResponse> getApiResponses(Method method) {
+	private Set<io.swagger.v3.oas.annotations.responses.ApiResponse> getApiResponseAnnotations(Method method) {
 		Class<?> declaringClass = method.getDeclaringClass();
 
 		Set<io.swagger.v3.oas.annotations.responses.ApiResponses> apiResponsesDoc = AnnotatedElementUtils

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
@@ -42,6 +42,7 @@ public final class Constants {
 	public static final String DEFAULT_LICENSE_URL = "http://www.apache.org/licenses/LICENSE-2.0.html";
 	public static final String OPENAPI_STRING_TYPE = "string";
 	public static final String OPENAPI_ARRAY_TYPE = "array";
+	public static final String RESPONSE_CODE_FROM_METHOD = "springdoc-openapi-response-code-from-method";
 
 	private Constants() {
 		super();

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app50/SpringDocTestApp.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app50/SpringDocTestApp.java
@@ -19,17 +19,4 @@ public class SpringDocTestApp {
         SpringApplication.run(SpringDocTestApp.class, args);
     }
 
-	@Configuration
-	class OpenApiConfiguration {
-		@Bean
-		public OpenAPI defineOpenApi() {
-			OpenAPI api = new OpenAPI();
-			api.components(new Components().addResponses("Unauthorized",
-					new ApiResponse().description("Unauthorized")
-							.content(new Content().addMediaType(MediaType.APPLICATION_JSON_VALUE,
-									new io.swagger.v3.oas.models.media.MediaType().schema(new StringSchema())))));
-			return api;
-		}
-	}
-
 }

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/HelloController.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/HelloController.java
@@ -1,0 +1,80 @@
+package test.org.springdoc.api.app51;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springdoc.core.Constants;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class HelloController {
+
+	@Operation(description = "Some operation")
+	@GetMapping(value = "/hello1", produces = MediaType.APPLICATION_JSON_VALUE)
+	List<String> listWithNoApiResponse() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse
+	@GetMapping(value = "/hello2", produces = MediaType.APPLICATION_JSON_VALUE)
+	List<String> listWithEmptyApiResponse() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+	@GetMapping(value = "/hello3", produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	List<String> listWithExplicitResponseStatus() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+	@GetMapping(value = "/hello4", produces = MediaType.APPLICATION_JSON_VALUE)
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	HelloDTO1 getDTOWithExplicitResponseStatus() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+	@GetMapping(value = "/hello5", produces = MediaType.APPLICATION_JSON_VALUE)
+	List<String> listWithDefaultResponseStatus() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+	@GetMapping(value = "/hello6", produces = MediaType.APPLICATION_JSON_VALUE)
+	HelloDTO1 getDTOWithDefaultResponseStatus() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+	@GetMapping(value = "/hello7", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<HelloDTO1> getNestedDTOWithDefaultResponseStatus() {
+		return null;
+	}
+
+	static class HelloDTO1 {
+		private String message;
+
+		public HelloDTO1(String message) {
+			this.message = message;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+	}
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/HelloControllerWithGlobalApiResponse.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/HelloControllerWithGlobalApiResponse.java
@@ -1,0 +1,37 @@
+package test.org.springdoc.api.app51;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springdoc.core.Constants;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping(path = "/global")
+@ApiResponse(responseCode = Constants.RESPONSE_CODE_FROM_METHOD)
+public class HelloControllerWithGlobalApiResponse {
+
+	@Operation(description = "Some operation", responses = {
+			@ApiResponse(responseCode = "204", description = "Explicit description for this response")
+	})
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@GetMapping(value = "/hello1", produces = MediaType.APPLICATION_JSON_VALUE)
+	List<String> listWithNoApiResponse() {
+		return null;
+	}
+
+	@Operation(description = "Some operation")
+	@ApiResponse(responseCode = "200", description = "Explicit description for this response")
+	@GetMapping(value = "/hello2", produces = MediaType.APPLICATION_JSON_VALUE)
+	List<String> listWithDefaultResponseStatus() {
+		return null;
+	}
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/SpringDocApp51Test.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/SpringDocApp51Test.java
@@ -1,0 +1,8 @@
+package test.org.springdoc.api.app51;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp51Test extends AbstractSpringDocTest {
+
+
+}

--- a/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/SpringDocTestApp.java
+++ b/springdoc-openapi-core/src/test/java/test/org/springdoc/api/app51/SpringDocTestApp.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.app51;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	public static void main(String[] args) {
+        SpringApplication.run(SpringDocTestApp.class, args);
+    }
+
+}

--- a/springdoc-openapi-core/src/test/resources/results/app50.json
+++ b/springdoc-openapi-core/src/test/resources/results/app50.json
@@ -1,50 +1,37 @@
 {
-	"openapi": "3.0.1",
-	"info": {
-		"title": "OpenAPI definition",
-		"version": "v0"
-	},
-	"servers": [
-		{
-			"url": "http://localhost",
-			"description": "Generated server url"
-		}
-	],
-	"paths": {
-		"/hello": {
-			"get": {
-				"description": "Some operation",
-				"operationId": "list",
-				"responses": {
-					"401": {
-						"description": "default response",
-						"content": {
-							"application/json": {
-								"schema": {
-									"type": "array",
-									"items": {
-										"type": "string"
-									}
-								}
-							}
-						}
-					}
-				}
-			}
-		}
-	},
-	"components": {
-		"responses": {
-			"Unauthorized": {
-				"description": "Unauthorized",
-				"content": {
-					"application/json": {
-						"schema": {
-							"type": "string"
-						}
-					}
-				}
-			}
-		}
-	}
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/hello": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "list",
+        "responses": {
+          "401": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
 }

--- a/springdoc-openapi-core/src/test/resources/results/app51.json
+++ b/springdoc-openapi-core/src/test/resources/results/app51.json
@@ -1,0 +1,207 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/hello7": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "getNestedDTOWithDefaultResponseStatus",
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HelloDTO1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello5": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithDefaultResponseStatus",
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello6": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "getDTOWithDefaultResponseStatus",
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HelloDTO1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello4": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "getDTOWithExplicitResponseStatus",
+        "responses": {
+          "204": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HelloDTO1"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello2": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithEmptyApiResponse",
+        "responses": {
+          "default": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello1": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithNoApiResponse",
+        "responses": {
+          "200": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/hello3": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithExplicitResponseStatus",
+        "responses": {
+          "204": {
+            "description": "default response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/global/hello2": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithDefaultResponseStatus_1",
+        "responses": {
+          "200": {
+            "description": "Explicit description for this response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/global/hello1": {
+      "get": {
+        "description": "Some operation",
+        "operationId": "listWithNoApiResponse_1",
+        "responses": {
+          "204": {
+            "description": "Explicit description for this response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HelloDTO1": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In response to #116 this is my second attempt to improve on this.

I've added a "magic" constant which can be used with an `@ApiResponse` annotation to add a response code determined from the method. It will only do that if the response is not defined yet.

@springdoc what do you think?