### PR TITLE
Open up for customisation

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractParameterBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractParameterBuilder.java
@@ -1,27 +1,7 @@
 package org.springdoc.core;
 
-import java.io.IOException;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
-import org.apache.commons.lang3.ClassUtils;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.web.method.HandlerMethod;
-
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-
 import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.ParameterProcessor;
@@ -33,6 +13,24 @@ import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.FileSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
+import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.web.method.HandlerMethod;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 @SuppressWarnings("rawtypes")
 public abstract class AbstractParameterBuilder {
@@ -202,9 +200,9 @@ public abstract class AbstractParameterBuilder {
 		return requestBodyInfo != null && requestBodyInfo.getMergedSchema() != null;
 	}
 
-	abstract boolean isFile(ParameterizedType parameterizedType);
+	protected abstract boolean isFile(ParameterizedType parameterizedType);
 
-	abstract boolean isFile(JavaType ct);
+	protected abstract boolean isFile(JavaType ct);
 
 	public <A extends Annotation> A getParameterAnnotation(HandlerMethod handlerMethod,
 			java.lang.reflect.Parameter parameter, int i, Class<A> annotationType) {

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -1,23 +1,9 @@
 package org.springdoc.core;
 
-import static org.springdoc.core.Constants.*;
-
-import java.lang.annotation.Annotation;
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.validation.constraints.DecimalMax;
-import javax.validation.constraints.DecimalMin;
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
-
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.util.CollectionUtils;
@@ -28,10 +14,26 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.method.HandlerMethod;
 
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.oas.models.parameters.Parameter;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import java.lang.annotation.Annotation;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springdoc.core.Constants.HEADER_PARAM;
+import static org.springdoc.core.Constants.OPENAPI_ARRAY_TYPE;
+import static org.springdoc.core.Constants.OPENAPI_STRING_TYPE;
+import static org.springdoc.core.Constants.PATH_PARAM;
+import static org.springdoc.core.Constants.QUERY_PARAM;
 
 public abstract class AbstractRequestBuilder {
 
@@ -98,10 +100,16 @@ public abstract class AbstractRequestBuilder {
 		}
 
 		setParams(operation, operationParameters, requestBodyInfo);
+
+		// allow for customisation
+		operation = customiseOperation(operation, handlerMethod);
+
 		return operation;
 	}
 
-	private boolean isParamToIgnore(java.lang.reflect.Parameter parameter) {
+	protected abstract Operation customiseOperation(Operation operation, HandlerMethod handlerMethod);
+
+	protected boolean isParamToIgnore(java.lang.reflect.Parameter parameter) {
 		if (parameter.isAnnotationPresent(PathVariable.class)) {
 			return false;
 		}

--- a/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/RequestBuilder.java
+++ b/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/RequestBuilder.java
@@ -1,6 +1,8 @@
 package org.springdoc.core;
 
+import io.swagger.v3.oas.models.Operation;
 import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
 
 @Component
 public class RequestBuilder extends AbstractRequestBuilder {
@@ -13,5 +15,10 @@ public class RequestBuilder extends AbstractRequestBuilder {
 	@Override
 	protected boolean isParamTypeToIgnore(Class<?> paramType) {
 		return false;
+	}
+
+	@Override
+	protected Operation customiseOperation(Operation operation, HandlerMethod handlerMethod) {
+		return operation;
 	}
 }

--- a/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/core/RequestBuilder.java
+++ b/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/core/RequestBuilder.java
@@ -1,5 +1,6 @@
 package org.springdoc.core;
 
+import io.swagger.v3.oas.models.Operation;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.BindingResult;
@@ -7,6 +8,7 @@ import org.springframework.validation.Errors;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -35,5 +37,10 @@ public class RequestBuilder extends AbstractRequestBuilder {
 				|| org.springframework.ui.ModelMap.class.equals(paramType) || RedirectAttributes.class.equals(paramType)
 				|| Errors.class.equals(paramType) || BindingResult.class.equals(paramType)
 				|| SessionStatus.class.equals(paramType) || UriComponentsBuilder.class.equals(paramType);
+	}
+
+	@Override
+	protected Operation customiseOperation(Operation operation, HandlerMethod handlerMethod) {
+		return operation;
 	}
 }


### PR DESCRIPTION
* Change signatures on some methods in AbstractParameterBuilder and AbstractRequestBuilder to allow for a custom implementation outside of 'org.springdocs' package.

* Add 'customiseOperation' to AbstractRequestBuilder to allow for customisation of operations.