### PR TITLE
fix spring Pageable

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/PageableSupportConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/PageableSupportConverter.java
@@ -1,0 +1,30 @@
+package org.springdoc.core;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.replacements.Pageable;
+
+import java.util.Iterator;
+
+public class PageableSupportConverter implements ModelConverter {
+
+    private static final String PAGEABLE_TO_REPLACE = "org.springframework.data.domain.Pageable";
+    private static final String PAGE_REQUEST_TO_REPLACE = "org.springframework.data.domain.PageRequest";
+    private static final AnnotatedType PAGEABLE = new AnnotatedType(Pageable.class);
+
+    @Override
+    public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain)
+    {
+        String typeName = type.getType().getTypeName();
+        if (PAGEABLE_TO_REPLACE.equals(typeName) || PAGE_REQUEST_TO_REPLACE.equals(typeName)) {
+            type = PAGEABLE;
+        }
+        if (chain.hasNext()) {
+            return chain.next().resolve(type, context, chain);
+        } else {
+            return null;
+        }
+    }
+}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
@@ -25,6 +25,7 @@ import java.util.Optional;
     static final String COMPONENTS_REF = "#/components/schemas/";
 
     static {
+        ModelConverters.getInstance().addConverter(new PageableSupportConverter());
         ModelConverters.getInstance().addConverter(new ObjectNodeConverter());
     }
 

--- a/springdoc-openapi-common/src/main/java/org/springdoc/replacements/Pageable.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/replacements/Pageable.java
@@ -10,14 +10,15 @@ import java.util.Objects;
 @NotNull
 public class Pageable {
 
+    @NotNull
     @Min(0)
     private int page;
 
+    @NotNull
     @Min(1)
     @Max(2000)
     private int size;
 
-    @NotNull
     private List<String> sort = new ArrayList<>() ;
 
     public Pageable() {

--- a/springdoc-openapi-common/src/main/java/org/springdoc/replacements/Pageable.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/replacements/Pageable.java
@@ -1,0 +1,80 @@
+package org.springdoc.replacements;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@NotNull
+public class Pageable {
+
+    @Min(0)
+    private int page;
+
+    @Min(1)
+    @Max(2000)
+    private int size;
+
+    @NotNull
+    private List<String> sort = new ArrayList<>() ;
+
+    public Pageable() {
+    }
+
+    public int getPage() {
+        return page;
+    }
+
+    public void setPage(int page) {
+        this.page = page;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public List<String> getSort() {
+        return sort;
+    }
+
+    public void setSort(List<String> sort) {
+        if (sort == null) {
+            this.sort.clear();
+        }
+        this.sort = sort;
+    }
+
+    public void addSort(String sort) {
+        this.sort.add(sort);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Pageable pageable = (Pageable) o;
+        return page == pageable.page &&
+                size == pageable.size &&
+                Objects.equals(sort, pageable.sort);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(page, size, sort);
+    }
+
+    @Override
+    public String toString() {
+        return "Pageable{" +
+                "page=" + page +
+                ", size=" + size +
+                ", sort=" + sort +
+                '}';
+    }
+}


### PR DESCRIPTION
springdoc-openapi maps the spring `Pageable` like any other scheme. However according to [1] this type needs special handling.

I have fixed that by implementing the ModelConverter `PageableSupportConverter` that will replace the 'real' type `org.springframework.data.domain.Pageable` with an appropriate replacement type.

[1] https://docs.spring.io/spring-data/rest/docs/3.2.1.RELEASE/reference/html/#paging-and-sorting