### PR TITLE
Issue #159: Support for Kotlin Coroutines added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 
     <modules>
         <module>springdoc-openapi-common</module>
+        <module>springdoc-openapi-kotlin-coroutines</module>
         <module>springdoc-openapi-webmvc-core</module>
         <module>springdoc-openapi-webflux-core</module>
         <module>springdoc-openapi-ui</module>

--- a/springdoc-openapi-common/src/main/java/org/springdoc/config/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/config/SpringDocConfiguration.java
@@ -1,16 +1,10 @@
 package org.springdoc.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 
 @Configuration
 @ComponentScan(basePackages = {"org.springdoc"})
 public class SpringDocConfiguration {
 
-    @Bean
-    LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer() {
-        return new LocalVariableTableParameterNameDiscoverer();
-    }
 }

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractParameterBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractParameterBuilder.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.web.method.HandlerMethod;
 
@@ -30,16 +29,6 @@ import java.util.*;
 
 @SuppressWarnings("rawtypes")
 public abstract class AbstractParameterBuilder {
-
-    private final LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer;
-
-    protected AbstractParameterBuilder(LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer) {
-        this.localSpringDocParameterNameDiscoverer = localSpringDocParameterNameDiscoverer;
-    }
-
-    public LocalVariableTableParameterNameDiscoverer getLocalSpringDocParameterNameDiscoverer() {
-        return localSpringDocParameterNameDiscoverer;
-    }
 
     Parameter mergeParameter(List<Parameter> existingParamDoc, Parameter paramCalcul) {
         Parameter result = paramCalcul;

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.RequestInfo.ParameterType;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.method.HandlerMethod;
@@ -47,12 +46,8 @@ public abstract class AbstractRequestBuilder {
 
         operation.setOperationId(operationId);
         // requests
-        LocalVariableTableParameterNameDiscoverer d = parameterBuilder.getLocalSpringDocParameterNameDiscoverer();
-        String[] pNames = d.getParameterNames(handlerMethod.getMethod());
         java.lang.reflect.Parameter[] parameters = handlerMethod.getMethod().getParameters();
-        if (pNames == null) {
-            pNames = Arrays.stream(parameters).map(java.lang.reflect.Parameter::getName).toArray(String[]::new);
-        }
+        String[] pNames = Arrays.stream(parameters).map(java.lang.reflect.Parameter::getName).toArray(String[]::new);
         RequestBodyInfo requestBodyInfo = new RequestBodyInfo(methodAttributes);
         List<Parameter> operationParameters = (operation.getParameters() != null) ? operation.getParameters()
                 : new ArrayList<>();

--- a/springdoc-openapi-common/src/test/java/org/springdoc/subclass/ParameterBuilder.java
+++ b/springdoc-openapi-common/src/test/java/org/springdoc/subclass/ParameterBuilder.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.AbstractParameterBuilder;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -14,10 +13,6 @@ import java.lang.reflect.Type;
  * Class which sub class AbstractParameterBuilder in a different package and makes sure base class access is not changed. .
  */
 public class ParameterBuilder extends AbstractParameterBuilder {
-
-    public ParameterBuilder(LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer) {
-        super(localSpringDocParameterNameDiscoverer);
-    }
 
     @Override
     protected Schema calculateSchemaFromParameterizedType(Components components, Type returnType, JsonView jsonView) {

--- a/springdoc-openapi-kotlin-coroutines/.gitignore
+++ b/springdoc-openapi-kotlin-coroutines/.gitignore
@@ -1,0 +1,144 @@
+######################
+# Project Specific
+######################
+/target/www/**
+/src/test/javascript/coverage/
+
+######################
+# Node
+######################
+/node/
+node_tmp/
+node_modules/
+npm-debug.log.*
+/.awcache/*
+/.cache-loader/*
+
+######################
+# SASS
+######################
+.sass-cache/
+
+######################
+# Eclipse
+######################
+*.pydevproject
+.project
+.metadata
+tmp/
+tmp/**/*
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.classpath
+.settings/
+.loadpath
+.factorypath
+/src/main/resources/rebel.xml
+
+# External tool builders
+.externalToolBuilders/**
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# CDT-specific
+.cproject
+
+# PDT-specific
+.buildpath
+
+######################
+# Intellij
+######################
+.idea/
+*.iml
+*.iws
+*.ipr
+*.ids
+*.orig
+classes/
+out/
+
+######################
+# Visual Studio Code
+######################
+.vscode/
+
+######################
+# Maven
+######################
+/log/
+/target/
+
+######################
+# Gradle
+######################
+.gradle/
+/build/
+
+######################
+# Package Files
+######################
+*.jar
+*.war
+*.ear
+*.db
+
+######################
+# Windows
+######################
+# Windows image file caches
+Thumbs.db
+
+# Folder config file
+Desktop.ini
+
+######################
+# Mac OSX
+######################
+.DS_Store
+.svn
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+######################
+# Directories
+######################
+/bin/
+/deploy/
+
+######################
+# Logs
+######################
+*.log*
+
+######################
+# Others
+######################
+*.class
+*.*~
+*~
+.merge_file*
+
+######################
+# Gradle Wrapper
+######################
+!gradle/wrapper/gradle-wrapper.jar
+
+######################
+# Maven Wrapper
+######################
+!.mvn/wrapper/maven-wrapper.jar
+
+######################
+# ESLint
+######################
+.eslintcache

--- a/springdoc-openapi-kotlin-coroutines/pom.xml
+++ b/springdoc-openapi-kotlin-coroutines/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>springdoc-openapi-kotlin-coroutines</artifactId>
+    <name>${project.artifactId}</name>
+    <parent>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi</artifactId>
+        <version>1.2.10-SNAPSHOT</version>
+    </parent>
+    <dependencies>
+        <!-- springdoc-common -->
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-webflux-core</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/springdoc-openapi-kotlin-coroutines/src/main/java/org/springdoc/core/KotlinCoroutinesRequestBuilder.java
+++ b/springdoc-openapi-kotlin-coroutines/src/main/java/org/springdoc/core/KotlinCoroutinesRequestBuilder.java
@@ -1,0 +1,32 @@
+package org.springdoc.core;
+
+import io.swagger.v3.oas.models.Operation;
+import kotlin.coroutines.Continuation;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+
+@Primary
+@Component
+public class KotlinCoroutinesRequestBuilder extends AbstractRequestBuilder {
+
+    private List<AbstractRequestBuilder> requestBuilders;
+
+    public KotlinCoroutinesRequestBuilder(AbstractParameterBuilder parameterBuilder, RequestBodyBuilder requestBodyBuilder,
+                          OperationBuilder operationBuilder, List<AbstractRequestBuilder> requestBuilders) {
+        super(parameterBuilder, requestBodyBuilder, operationBuilder);
+        this.requestBuilders = requestBuilders;
+    }
+
+    @Override
+    protected boolean isParamTypeToIgnore(Class<?> paramType) {
+        return paramType.isAssignableFrom(Continuation.class) || requestBuilders.stream().anyMatch(builder -> builder.isParamTypeToIgnore(paramType));
+    }
+
+    @Override
+    protected Operation customiseOperation(Operation operation, HandlerMethod handlerMethod) {
+        return operation;
+    }
+}

--- a/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/AbstractSpringDocTest.java
+++ b/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/AbstractSpringDocTest.java
@@ -1,0 +1,47 @@
+package test.org.springdoc.api;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springdoc.core.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(SpringRunner.class)
+@WebFluxTest
+@ActiveProfiles("test")
+public abstract class AbstractSpringDocTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    public void testApp() throws Exception {
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri(Constants.DEFAULT_API_DOCS_URL).exchange()
+                .expectStatus().isOk().expectBody().returnResult();
+
+        String result = new String(getResult.getResponseBody());
+        String className = getClass().getSimpleName();
+        String testNumber = className.replaceAll("[^0-9]", "");
+
+        Path path = Paths.get(getClass().getClassLoader().getResource("results/app" + testNumber + ".json").toURI());
+        byte[] fileBytes = Files.readAllBytes(path);
+        String expected = new String(fileBytes);
+
+        assertEquals(objectMapper.readTree(expected), objectMapper.readTree(result));
+    }
+
+}

--- a/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/ControllerWithContinuationParameter.java
+++ b/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/ControllerWithContinuationParameter.java
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.app1;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import kotlin.coroutines.Continuation;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.multipart.FilePart;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class ControllerWithContinuationParameter {
+
+    @Operation(summary = "Ignore Continuation parameter")
+    @GetMapping(value = "/test/{id}", produces = {MediaType.APPLICATION_JSON_VALUE})
+    public Mono<String> get(@PathVariable(value = "id") String key, Continuation continuation) {
+        return null;
+    }
+}

--- a/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/SpringDocApp1Test.java
+++ b/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/SpringDocApp1Test.java
@@ -1,0 +1,7 @@
+package test.org.springdoc.api.app1;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp1Test extends AbstractSpringDocTest {
+
+}

--- a/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/SpringDocTestApp.java
+++ b/springdoc-openapi-kotlin-coroutines/src/test/java/test/org/springdoc/api/app1/SpringDocTestApp.java
@@ -1,0 +1,26 @@
+package test.org.springdoc.api.app1;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = {"org.springdoc", "test.org.springdoc.api.app1"})
+public class SpringDocTestApp {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringDocTestApp.class, args);
+    }
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Kotlin API").version("v1")
+                        .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+    }
+}

--- a/springdoc-openapi-kotlin-coroutines/src/test/resources/application-test.yml
+++ b/springdoc-openapi-kotlin-coroutines/src/test/resources/application-test.yml
@@ -1,0 +1,1 @@
+spring.main.banner-mode: "off"

--- a/springdoc-openapi-kotlin-coroutines/src/test/resources/logback-test.xml
+++ b/springdoc-openapi-kotlin-coroutines/src/test/resources/logback-test.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <root level="off"/>
+</configuration>

--- a/springdoc-openapi-kotlin-coroutines/src/test/resources/results/app1.json
+++ b/springdoc-openapi-kotlin-coroutines/src/test/resources/results/app1.json
@@ -1,0 +1,48 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Kotlin API",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://springdoc.org"
+    },
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/test/{id}": {
+      "get": {
+        "summary": "Ignore Continuation parameter",
+        "operationId": "get",
+        "parameters":[
+          {
+            "name":"id",
+            "in":"path",
+            "required":true,
+            "schema": {
+              "type":"string"
+            }
+          }
+        ],
+        "responses":{
+          "200":{
+            "description":"default response",
+            "content":{
+              "application/json":{
+                "schema":{
+                  "type":"string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components":{}
+}

--- a/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/ParameterBuilder.java
+++ b/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/ParameterBuilder.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,10 +16,6 @@ import java.lang.reflect.WildcardType;
 
 @Component
 public class ParameterBuilder extends AbstractParameterBuilder {
-
-    public ParameterBuilder(LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer) {
-        super(localSpringDocParameterNameDiscoverer);
-    }
 
     @Override
     protected Schema calculateSchemaFromParameterizedType(Components components, Type paramType, JsonView jsonView) {

--- a/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/core/ParameterBuilder.java
+++ b/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/core/ParameterBuilder.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
-import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -14,10 +13,6 @@ import java.lang.reflect.WildcardType;
 
 @Component
 public class ParameterBuilder extends AbstractParameterBuilder {
-
-    public ParameterBuilder(LocalVariableTableParameterNameDiscoverer localSpringDocParameterNameDiscoverer) {
-        super(localSpringDocParameterNameDiscoverer);
-    }
 
     @Override
     protected Schema calculateSchemaFromParameterizedType(Components components, Type paramType, JsonView jsonView) {


### PR DESCRIPTION
I've added support for Kotlin Coroutines by ignoring `Continuation` parameter (which is automatically added to a suspending function, aka controller method). I've decided to create an additional module so that only people using Kotlin Coroutines have additional code in their projects.
Additionally, I've changed the way you were getting the names of the parameters because using `LocalVariableTableParameterNameDiscoverer` was not working with the example I have. We already have the name of the parameters at that point via Parameters array, so I've decided to make it simpler. Was there any reason why you were using `LocalVariableTableParameterNameDiscoverer`?
I hope you find the code good enough to be added to the library!