### PR TITLE
Make webjars prefix configurable

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
@@ -12,9 +12,9 @@ public final class Constants {
     public static final String SPRINGDOC_SHOW_ACTUATOR = "springdoc.show.actuator";
     public static final String SPRINGDOC_SHOW_ACTUATOR_VALUE = "${" + SPRINGDOC_SHOW_ACTUATOR + ":false}";
     public static final String SPRINGDOC_ACTUATOR_TAG = "Actuator";
-    public static final String WEB_JARS_PREFIX_URL = "/webjars";
+    public static final String DEFAULT_WEB_JARS_PREFIX_URL = "/webjars";
+    public static final String WEB_JARS_PREFIX_URL = "${springdoc.webjars.prefix:#{T(org.springdoc.core.Constants).DEFAULT_WEB_JARS_PREFIX_URL}}";
     public static final String SWAGGER_UI_URL = "/swagger-ui/index.html?url=";
-    public static final String WEB_JARS_URL = WEB_JARS_PREFIX_URL + SWAGGER_UI_URL;
     public static final String DEFAULT_VALIDATOR_URL = "&validatorUrl=";
     public static final String APPLICATION_OPENAPI_YAML = "application/vnd.oai.openapi";
     public static final String DEFAULT_SWAGGER_UI_PATH = DEFAULT_PATH_SEPARATOR + "swagger-ui.html";

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/ui/SwaggerConfig.java
@@ -17,13 +17,16 @@ public class SwaggerConfig extends WebMvcConfigurerAdapter { // NOSONAR
     @Value(SWAGGER_UI_PATH)
     private String swaggerPath;
 
+    @Value(WEB_JARS_PREFIX_URL)
+    private String webJarsPrefixUrl;
+
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         String uiRootPath = "";
         if (swaggerPath.contains("/")) {
             uiRootPath = swaggerPath.substring(0, swaggerPath.lastIndexOf('/'));
         }
-        registry.addResourceHandler(uiRootPath + "/**").addResourceLocations(WEB_JARS_PREFIX_URL + "/")
+        registry.addResourceHandler(uiRootPath + "/**").addResourceLocations(webJarsPrefixUrl + "/")
                 .resourceChain(false);
     }
 }

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/ui/SwaggerWelcome.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/ui/SwaggerWelcome.java
@@ -17,17 +17,21 @@ public class SwaggerWelcome {
 
     @Value(API_DOCS_URL)
     private String apiDocsUrl;
+
     @Value(SWAGGER_UI_PATH)
     private String uiPath;
 
+    @Value(WEB_JARS_PREFIX_URL)
+    private String webJarsPrefixUrl;
 
     @Bean
     RouterFunction<ServerResponse> routerFunction() {
-        String sbUrl = WEB_JARS_URL +
+        String url = webJarsPrefixUrl +
+                SWAGGER_UI_URL +
                 apiDocsUrl +
                 DEFAULT_VALIDATOR_URL;
-        return route(GET(uiPath),
-                req -> ServerResponse.temporaryRedirect(URI.create(sbUrl)).build());
-    }
 
+        return route(GET(uiPath),
+                req -> ServerResponse.temporaryRedirect(URI.create(url)).build());
+    }
 }


### PR DESCRIPTION
Fixes #168 

I am not sure what to change in webmvc because `WEB_JARS_URL` usage was dropped in https://github.com/springdoc/springdoc-openapi/commit/f345b15c5d8d4c263b5dbe9cecc7131c7e861f99#diff-8181c5655a920523cb8059828358a637L32 Should I add before this line:
https://github.com/springdoc/springdoc-openapi/blob/54fc8a1b783cb2f6c3d835c2c32e6ad8fcd158bf/springdoc-openapi-ui/src/main/java/org/springdoc/ui/SwaggerWelcome.java#L34