### PR TITLE
Generate a default tag name if no tag specified

### DIFF
--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
@@ -17,6 +17,9 @@
   "paths": {
     "/hello/{numTelco}": {
       "get": {
+        "tags": [
+          "hello-controller"
+        ],
         "operationId": "index",
         "parameters": [
           {
@@ -558,9 +561,12 @@
           }
         }
       },
-      "ItemLightDTO": {
+      "ItemDTO": {
         "type": "object",
         "properties": {
+          "itemID": {
+            "type": "string"
+          },
           "description": {
             "type": "string"
           },
@@ -570,12 +576,9 @@
           }
         }
       },
-      "ItemDTO": {
+      "ItemLightDTO": {
         "type": "object",
         "properties": {
-          "itemID": {
-            "type": "string"
-          },
           "description": {
             "type": "string"
           },


### PR DESCRIPTION
Relates to https://github.com/springdoc/springdoc-openapi/issues/173

One of the nice features of Springfox is that it generates default tags. So that we can see endpoints grouped by controller name. It is handy for applications with a bunch of controllers. I think springdoc should also provide a default tag name. WDYT?

Please note that I haven't fixed all of the tests.