### PR TITLE
Use `@Deprecated` annotation to mark API operation as deprecated

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -112,6 +112,10 @@ public abstract class AbstractOpenApiResource {
 
             Operation operation = (existingOperation != null) ? existingOperation : new Operation();
 
+            if (ReflectionUtils.getAnnotation(method, Deprecated.class) != null) {
+                operation.setDeprecated(true);
+            }
+
             // compute tags
             operation = openAPIBuilder.buildTags(handlerMethod, operation, openAPI);
 

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/HelloController.java
@@ -1,0 +1,11 @@
+package test.org.springdoc.api.app59;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+    @Deprecated
+    @GetMapping("/example")
+    public void test() {}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/SpringDocApp59Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/SpringDocApp59Test.java
@@ -1,0 +1,5 @@
+package test.org.springdoc.api.app59;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp59Test extends AbstractSpringDocTest {}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/SpringDocTestApp.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app59/SpringDocTestApp.java
@@ -1,0 +1,11 @@
+package test.org.springdoc.api.app59;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringDocTestApp {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringDocTestApp.class, args);
+    }
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app59.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app59.json
@@ -1,0 +1,30 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/example": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "test",
+        "responses": {
+          "200": {
+            "description": "default response"
+          }
+        },
+        "deprecated": true
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
We need to use `io.swagger.v3.oas.annotations.Operation#deprecated` to mark an operation as deprecated. I think supporting common annotations rather than Swagger specific annotations is more convenient.