### PR TITLE
Add Spring Boot metadata for config properties.

### DIFF
--- a/springdoc-openapi-common/pom.xml
+++ b/springdoc-openapi-common/pom.xml
@@ -13,6 +13,11 @@
             <artifactId>spring-boot-autoconfigure</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
         </dependency>

--- a/springdoc-openapi-common/src/main/java/org/springdoc/config/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/config/SpringDocConfiguration.java
@@ -1,11 +1,13 @@
 package org.springdoc.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 
 @Configuration
+@EnableConfigurationProperties
 @ComponentScan(basePackages = {"org.springdoc"})
 public class SpringDocConfiguration {
 

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -1,0 +1,76 @@
+package org.springdoc.core;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "springdoc")
+public class SpringDocConfigProperties {
+
+    private Boolean showActuator = false;
+    private Webjars webjars = new Webjars();
+    private ApiDocs apiDocs = new ApiDocs();
+
+    public static class Webjars {
+        private String prefix = "/webjars";
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public void setPrefix(String prefix) {
+            this.prefix = prefix;
+        }
+    }
+
+    public static class ApiDocs {
+        /**
+         * Path to the generated OpenAPI documentation. For a yaml file, append ".yaml" to the path.
+         */
+        private String path = "/v3/api-docs";
+        /**
+         * Weather to generate and serve a OpenAPI document.
+         */
+        private Boolean enabled = true;
+
+        public String getPath() {
+            return path;
+        }
+
+        public void setPath(String path) {
+            this.path = path;
+        }
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    public Boolean getShowActuator() {
+        return showActuator;
+    }
+
+    public void setShowActuator(Boolean showActuator) {
+        this.showActuator = showActuator;
+    }
+
+    public Webjars getWebjars() {
+        return webjars;
+    }
+
+    public void setWebjars(Webjars webjars) {
+        this.webjars = webjars;
+    }
+
+    public ApiDocs getApiDocs() {
+        return apiDocs;
+    }
+
+    public void setApiDocs(ApiDocs apiDocs) {
+        this.apiDocs = apiDocs;
+    }
+}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
@@ -9,47 +9,88 @@ import java.util.Map;
 import java.util.TreeMap;
 
 /**
- * Please refer to https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md
+ * Please refer to the swagger
+ * <a href="https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md">configuration.md</a>
  * to get the idea what each parameter does.
  */
 @Configuration
 @ConfigurationProperties(prefix = "springdoc.swagger-ui")
 public class SwaggerUiConfigProperties {
-    // URL to fetch external configuration document from.
+    /**
+     * The path for the Swagger UI pages to load. Will redirect to the springdoc.webjars.prefix property.
+     */
+    private String path = "/swagger-ui.html";
+
+    /**
+     * The name of a component available via the plugin system to use as the top-level layout for Swagger UI.
+     */
+    private String layout;
+    /**
+     * URL to fetch external configuration document from.
+     */
     private String configUrl;
-    // If set, enables filtering. The top bar will show an edit box that
-    // could be used to filter the tagged operations that are shown.
+    /**
+     * If set, enables filtering. The top bar will show an edit box that
+     * could be used to filter the tagged operations that are shown.
+     */
     private String filter;
 
-    // Apply a sort to the operation list of each API
+    /**
+     * Apply a sort to the operation list of each API
+     */
     private String operationsSorter;
-    // Apply a sort to the tag list of each API
+    /**
+     * Apply a sort to the tag list of each API
+     */
     private String tagsSorter;
 
-    // Enables or disables deep linking for tags and operations.
+    /**
+     * Enables or disables deep linking for tags and operations.
+     *
+     * @see <a href="https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md">deep-linking.md</a>
+     */
     private Boolean deepLinking;
-    //  Controls the display of operationId in operations list.
+    /**
+     * Controls the display of operationId in operations list.
+     */
     private Boolean displayOperationId;
-    // The default expansion depth for models (set to -1 completely hide the models).
+    /**
+     * The default expansion depth for models (set to -1 completely hide the models).
+     */
     private Integer defaultModelsExpandDepth;
-    // The default expansion depth for the model on the model-example section.
+    /**
+     * The default expansion depth for the model on the model-example section.
+     */
     private Integer defaultModelExpandDepth;
 
-    // Controls how the model is shown when the API is first rendered.
+    /**
+     * Controls how the model is shown when the API is first rendered.
+     */
     private String defaultModelRendering;
-    // Controls the display of the request duration (in milliseconds) for Try-It-Out requests.
+    /**
+     * Controls the display of the request duration (in milliseconds) for Try-It-Out requests.
+     */
     private Boolean displayRequestDuration;
-    // Controls the default expansion setting for the operations and tags.
+    /**
+     * Controls the default expansion setting for the operations and tags.
+     */
     private String docExpansion;
-    //  If set, limits the number of tagged operations displayed to at most this many.
+    /**
+     * If set, limits the number of tagged operations displayed to at most this many.
+     */
     private Integer maxDisplayedTags;
-    // Controls the display of vendor extension (x-) fields and values.
+    /**
+     * Controls the display of vendor extension (x-) fields and values.
+     */
     private Boolean showExtensions;
-    // Controls the display of extensions
+    /**
+     * Controls the display of extensions
+     */
     private Boolean showCommonExtensions;
 
     public Map<String, String> getConfigParameters() {
         final Map<String, String> params = new TreeMap<>();
+        put("layout", layout, params);
         put("configUrl", configUrl, params);
         put("filter", filter, params);
         put("deepLinking", this.deepLinking, params);
@@ -85,6 +126,22 @@ public class SwaggerUiConfigProperties {
         }
     }
 
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getLayout() {
+        return layout;
+    }
+
+    public void setLayout(String layout) {
+        this.layout = layout;
+    }
+
     public String getConfigUrl() {
         return configUrl;
     }
@@ -99,6 +156,22 @@ public class SwaggerUiConfigProperties {
 
     public void setFilter(String filter) {
         this.filter = filter;
+    }
+
+    public String getOperationsSorter() {
+        return operationsSorter;
+    }
+
+    public void setOperationsSorter(String operationsSorter) {
+        this.operationsSorter = operationsSorter;
+    }
+
+    public String getTagsSorter() {
+        return tagsSorter;
+    }
+
+    public void setTagsSorter(String tagsSorter) {
+        this.tagsSorter = tagsSorter;
     }
 
     public Boolean getDeepLinking() {
@@ -179,21 +252,5 @@ public class SwaggerUiConfigProperties {
 
     public void setShowCommonExtensions(Boolean showCommonExtensions) {
         this.showCommonExtensions = showCommonExtensions;
-    }
-
-    public String getOperationsSorter() {
-        return operationsSorter;
-    }
-
-    public void setOperationsSorter(String operationsSorter) {
-        this.operationsSorter = operationsSorter;
-    }
-
-    public String getTagsSorter() {
-        return tagsSorter;
-    }
-
-    public void setTagsSorter(String tagsSorter) {
-        this.tagsSorter = tagsSorter;
     }
 }


### PR DESCRIPTION
On compile, generate the spring-configuration-metadata.json described in the [configuration-metadata](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-configuration-metadata.html#configuration-metadata-annotation-processor) documentation.

This is helpful for IDEs to autocomplete and give documentation for properties in the application.properties file.

![1](https://user-images.githubusercontent.com/6401427/69924681-408c8680-1472-11ea-953f-2cf003d7d497.png)
![2](https://user-images.githubusercontent.com/6401427/69924683-41bdb380-1472-11ea-8ba9-1ca5ff6cf70f.png)
