### PR TITLE
Ignore ServerHttpRequest and ServerHttpResponse Webflux

### DIFF
--- a/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/RequestBuilder.java
+++ b/springdoc-openapi-webflux-core/src/main/java/org/springdoc/core/RequestBuilder.java
@@ -1,6 +1,8 @@
 package org.springdoc.core;
 
 import io.swagger.v3.oas.models.Operation;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.server.ServerWebExchange;
@@ -15,6 +17,8 @@ public class RequestBuilder extends AbstractRequestBuilder {
 
     static {
         PARAM_TYPES_TO_IGNORE.add(ServerWebExchange.class);
+        PARAM_TYPES_TO_IGNORE.add(ServerHttpRequest.class);
+        PARAM_TYPES_TO_IGNORE.add(ServerHttpResponse.class);
     }
 
     @Override


### PR DESCRIPTION
Hi,

from the issue #228 the ServerWebExchange is already excluded, but ServerHttpRequest and ServerHttpResponse are not yet excluded in v1.2.18.

Want to exclude those 2 in this PR.

Thank you.