### PR TITLE
Remove @EnableWebMvc from SwaggerConfig

### DIFF
--- a/springdoc-openapi-ui/src/main/java/org/springdoc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/ui/SwaggerConfig.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -13,7 +12,6 @@ import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
 
 @Configuration
-@EnableWebMvc
 @ConditionalOnProperty(name = SPRINGDOC_SWAGGER_UI_ENABLED, matchIfMissing = true)
 @SuppressWarnings("deprecation")
 public class SwaggerConfig extends WebMvcConfigurerAdapter { // NOSONAR


### PR DESCRIPTION
Remove `@EnableWebMvc` from `org.springdoc.ui.SwaggerConfig` as not needed for Spring Boot Web Mvc applications.

fixes #236 #150