### PR TITLE
GroupedOpenApi: replace array parameter with vararg

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/GroupedOpenApi.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/GroupedOpenApi.java
@@ -60,12 +60,12 @@ public class GroupedOpenApi {
             return this;
         }
 
-        public Builder pathsToMatch(String[] pathsToMatch) {
+        public Builder pathsToMatch(String... pathsToMatch) {
             this.pathsToMatch = Arrays.asList(pathsToMatch);
             return this;
         }
 
-        public Builder packagesToScan(String[] packagesToScan) {
+        public Builder packagesToScan(String... packagesToScan) {
             this.packagesToScan = Arrays.asList(packagesToScan);
             return this;
         }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app68/SpringDocTestApp.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app68/SpringDocTestApp.java
@@ -18,30 +18,34 @@ public class SpringDocTestApp {
 
     @Bean
     public GroupedOpenApi storeOpenApi() {
-        String paths[] = {"/store/**"};
-        return GroupedOpenApi.builder().setGroup("stores").pathsToMatch(paths)
+        return GroupedOpenApi.builder()
+                .setGroup("stores")
+                .pathsToMatch("/store/**")
                 .build();
     }
 
     @Bean
     public GroupedOpenApi userOpenApi() {
-        String packagesToscan[] = {"test.org.springdoc.api.app68.api.user"};
-        return GroupedOpenApi.builder().setGroup("users").packagesToScan(packagesToscan)
+        return GroupedOpenApi.builder()
+                .setGroup("users")
+                .packagesToScan("test.org.springdoc.api.app68.api.user")
                 .build();
     }
 
     @Bean
     public GroupedOpenApi petOpenApi() {
-        String paths[] = {"/pet/**"};
-        return GroupedOpenApi.builder().setGroup("pets").pathsToMatch(paths)
+        return GroupedOpenApi.builder()
+                .setGroup("pets")
+                .pathsToMatch("/pet/**")
                 .build();
     }
 
     @Bean
     public GroupedOpenApi groupOpenApi() {
-        String paths[] = {"/v1/**"};
-        String packagesToscan[] = {"test.org.springdoc.api.app68.api.user", "test.org.springdoc.api.app68.api.store"};
-        return GroupedOpenApi.builder().setGroup("groups").pathsToMatch(paths).packagesToScan(packagesToscan)
+        return GroupedOpenApi.builder()
+                .setGroup("groups")
+                .pathsToMatch("/v1/**")
+                .packagesToScan("test.org.springdoc.api.app68.api.user", "test.org.springdoc.api.app68.api.store")
                 .build();
     }
 


### PR DESCRIPTION
This change is backward compatible, but allows more convenient usage of `GroupedOpenApi` api.
Instead of:
```
	String paths[] = {"/store/**", "/admin/**"};
	return GroupedOpenApi.builder()
                   .setGroup("stores")
                   .pathsToMatch(paths)
		  .build();
```
now you can use:
```
	return GroupedOpenApi.builder()
                   .setGroup("stores")
                   .pathsToMatch("/store/**", "/admin/**")
		  .build();
```