### PR TITLE
Add link to documentation into Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 ![Octocat](https://springdoc.github.io/springdoc-openapi-demos/images/springdoc-openapi.png)
 
+# [Full documentation](https://springdoc.org)
+
 # **Introduction**
 
 The springdoc-openapi Java library helps automating the generation of API documentation using Spring Boot projects.


### PR DESCRIPTION
This is how it looks:
<img width="930" alt="Screen Shot 2020-01-03 at 10 36 29 AM" src="https://user-images.githubusercontent.com/1207414/71714053-edad4280-2e14-11ea-9511-0c12db8ab15f.png">
