### PR TITLE
fix: prevent swagger-ui default validation

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
@@ -178,7 +178,8 @@ public class SwaggerUiConfigProperties {
 		final Map<String, Object> params = new TreeMap<>();
 		SpringDocPropertiesUtils.put("layout", layout, params);
 		SpringDocPropertiesUtils.put(CONFIG_URL_PROPERTY, configUrl, params);
-		SpringDocPropertiesUtils.put("validatorUrl", validatorUrl, params);
+		// empty-string prevents swagger-ui default validation
+		params.put("validatorUrl", validatorUrl != null ? validatorUrl : "");
 		SpringDocPropertiesUtils.put("filter", filter, params);
 		SpringDocPropertiesUtils.put("deepLinking", this.deepLinking, params);
 		SpringDocPropertiesUtils.put("displayOperationId", displayOperationId, params);

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
@@ -35,6 +35,9 @@ public class SpringDocApp1RedirectDefaultTest extends AbstractSpringDocTest {
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config"));
 
+		webTestClient.get().uri("/v3/api-docs/swagger-config").exchange()
+				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl").isEqualTo("");
+
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
@@ -41,7 +41,7 @@ public class SpringDocApp1RedirectWithConfigTest extends AbstractSpringDocTest {
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/baf/batz/swagger-config"));
 
 		webTestClient.get().uri("/baf/batz/swagger-config").exchange()
-				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl", "/foo/validate");
+				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl").isEqualTo("/foo/validate");
 	}
 
 	@SpringBootApplication


### PR DESCRIPTION
Not providing the validatorUrl currently enables the default validation for swagger.
This brings back the better default.
Not sure if this is the right place to fix it

fixes #394