### PR TITLE
Add support for @NotNull annotations emitted via Kotlin compiler

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -81,7 +81,10 @@ public abstract class AbstractRequestBuilder {
 	private static final List<Class> PARAM_TYPES_TO_IGNORE = new ArrayList<>();
 
 	// using string litterals to support both validation-api v1 and v2
-	private static final String[] ANNOTATIONS_FOR_REQUIRED = { NotNull.class.getName(), "javax.validation.constraints.NotBlank", "javax.validation.constraints.NotEmpty" };
+	private static final String[] ANNOTATIONS_FOR_REQUIRED = {
+		NotNull.class.getName(), "javax.validation.constraints.NotBlank", "javax.validation.constraints.NotEmpty",
+		"org.jetbrains.annotations.NotNull"
+	};
 
 	private static final String POSITIVE_OR_ZERO = "javax.validation.constraints.PositiveOrZero";
 


### PR DESCRIPTION
The kotlin compiler does not emit JSR-305 annotations, which is what `AbstractRequestBuilder` looks for when marking any specific type/parameter as "required". This causes kotlin developers to additionally add a `@NotNull` annotation to each property (from the JSR package), as the kotlin compiler emits `org.jetbrains.annotations.NotNull`.

This PR adds the kotlin specific annotation to the list of annotations that qualify a type/param to be marked as "required" in a schema.