### PR TITLE
Migrate to Jakarta from EE and update POM versions

### DIFF
--- a/springdoc-openapi-common/pom.xml
+++ b/springdoc-openapi-common/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<dependency>

--- a/springdoc-openapi-data-rest/pom.xml
+++ b/springdoc-openapi-data-rest/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-kotlin/pom.xml
+++ b/springdoc-openapi-kotlin/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!-- springdoc-common -->

--- a/springdoc-openapi-security/pom.xml
+++ b/springdoc-openapi-security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 
@@ -36,8 +36,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/springdoc-openapi-ui/pom.xml
+++ b/springdoc-openapi-ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!-- springdoc-core -->
@@ -15,8 +15,8 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<!-- swagger-ui dependencies -->

--- a/springdoc-openapi-webflux-core/pom.xml
+++ b/springdoc-openapi-webflux-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!-- springdoc-common -->

--- a/springdoc-openapi-webflux-ui/pom.xml
+++ b/springdoc-openapi-webflux-ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!-- springdoc-core -->

--- a/springdoc-openapi-webmvc-core/pom.xml
+++ b/springdoc-openapi-webmvc-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi</artifactId>
-		<version>1.2.31-SNAPSHOT</version>
+		<version>1.2.32-SNAPSHOT</version>
 	</parent>
 	<dependencies>
 		<!-- springdoc-common -->
@@ -25,8 +25,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
In Java 11 EE was dropped from the JDK, after which the dependencies were subsequently moved under the [Jakarta umbrella](https://jakarta.ee/). These are (currently) exact duplicates of the original `javax.*` dependencies, except renamed. To avoid conflicts with (newer) downstream projects we should also apply the Jakarta dependencies.

While there, I also fixed the build as the parent POM's version had drifted from the children POMs.