### PR TITLE
Fixes #418 by adjusting the output for Links.

### DIFF
--- a/springdoc-openapi-data-rest/src/test/resources/results/app2.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app2.json
@@ -123,23 +123,6 @@
   },
   "components": {
     "schemas": {
-      "CollectionModelEntityModelEmployee": {
-        "type": "object",
-        "properties": {
-          "_embedded": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EntityModelEmployee"
-            }
-          },
-          "_links": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Link"
-            }
-          }
-        }
-      },
       "Employee": {
         "type": "object",
         "properties": {
@@ -175,10 +158,27 @@
             "type": "string"
           },
           "_links": {
+            "$ref": "#/components/schemas/Links"
+          }
+        }
+      },
+      "Links": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Link"
+        }
+      },
+      "CollectionModelEntityModelEmployee": {
+        "type": "object",
+        "properties": {
+          "_embedded": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/Link"
+              "$ref": "#/components/schemas/EntityModelEmployee"
             }
+          },
+          "_links": {
+            "$ref": "#/components/schemas/Links"
           }
         }
       },

--- a/springdoc-openapi-data-rest/src/test/resources/results/app3.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app3.json
@@ -68,5 +68,7 @@
       }
     }
   },
-  "components": {}
+  "components": {
+    "schemas": {}
+  }
 }


### PR DESCRIPTION
There is a custom serializer for the Links object which creates a sorted map of all links. That map is then passed to jackson for serialization, thus some manual work is needed to fix the schema.