### PR TITLE
Add OpenApiBuilderCustomiser

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -114,11 +114,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		if (!computeDone || springDocConfigProperties.getCache().isDisabled()) {
 			Instant start = Instant.now();
 			openAPIBuilder.build();
-			Map<String, Object> restControllersMap = openAPIBuilder.getRestControllersMap();
-			Map<String, Object> requestMappingMap = openAPIBuilder.getRequestMappingMap();
-			Map<String, Object> controllerMap = openAPIBuilder.getControllersMap();
-			Map<String, Object> restControllers = Stream.of(restControllersMap, requestMappingMap, controllerMap)
-					.flatMap(mapEl -> mapEl.entrySet().stream())
+			Map<String, Object> mappingsMap = openAPIBuilder.getMappingsMap().entrySet().stream()
 					.filter(controller -> (AnnotationUtils.findAnnotation(controller.getValue().getClass(),
 							Hidden.class) == null))
 					.filter(controller -> !isHiddenRestControllers(controller.getValue().getClass()))
@@ -128,7 +124,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			// calculate generic responses
 			responseBuilder.buildGenericResponse(openAPIBuilder.getComponents(), findControllerAdvice);
 
-			getPaths(restControllers);
+			getPaths(mappingsMap);
 			openApi = openAPIBuilder.getCalculatedOpenAPI();
 
 			// run the optional customisers

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIBuilder.java
@@ -415,6 +415,10 @@ public class OpenAPIBuilder {
 		return this.mappingsMap;
 	}
 
+	public void addMappings(Map<String, Object> mappings) {
+		this.mappingsMap.putAll(mappings);
+	}
+
 	public Map<String, Object> getControllerAdviceMap() {
 		Map<String, Object> controllerAdviceMap = context.getBeansWithAnnotation(ControllerAdvice.class);
 		return Stream.of(controllerAdviceMap).flatMap(mapEl -> mapEl.entrySet().stream()).filter(

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
@@ -30,6 +30,7 @@ import org.springdoc.core.converters.AdditionalModelsConverter;
 import org.springdoc.core.converters.ModelConverterRegistrar;
 import org.springdoc.core.converters.PropertyCustomizingConverter;
 import org.springdoc.core.converters.ResponseSupportConverter;
+import org.springdoc.core.customizers.OpenApiBuilderCustomiser;
 import org.springdoc.core.customizers.PropertyCustomizer;
 
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -82,8 +83,10 @@ public class SpringDocConfiguration {
 	}
 
 	@Bean
-	public OpenAPIBuilder openAPIBuilder(Optional<OpenAPI> openAPI, ApplicationContext context, SecurityParser securityParser, Optional<SecurityOAuth2Provider> springSecurityOAuth2Provider,SpringDocConfigProperties springDocConfigProperties) {
-		return new OpenAPIBuilder(openAPI, context, securityParser, springSecurityOAuth2Provider,springDocConfigProperties);
+	public OpenAPIBuilder openAPIBuilder(Optional<OpenAPI> openAPI, ApplicationContext context, SecurityParser securityParser,
+										 Optional<SecurityOAuth2Provider> springSecurityOAuth2Provider, SpringDocConfigProperties springDocConfigProperties,
+										 List<OpenApiBuilderCustomiser> openApiBuilderCustomisers) {
+		return new OpenAPIBuilder(openAPI, context, securityParser, springSecurityOAuth2Provider,springDocConfigProperties, openApiBuilderCustomisers);
 	}
 
 	@Bean

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/customizers/OpenApiBuilderCustomiser.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/customizers/OpenApiBuilderCustomiser.java
@@ -1,0 +1,25 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package org.springdoc.core.customizers;
+
+import org.springdoc.core.OpenAPIBuilder;
+
+public interface OpenApiBuilderCustomiser {
+    void customise(OpenAPIBuilder openApiBuilder);
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/AbstractSpringDocTest.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/AbstractSpringDocTest.java
@@ -47,32 +47,31 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 public abstract class AbstractSpringDocTest {
 
-	protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractSpringDocTest.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AbstractSpringDocTest.class);
 
-	public static String className;
+    public static String className;
 
-	@Autowired
-	protected MockMvc mockMvc;
+    @Autowired
+    protected MockMvc mockMvc;
 
-	public static String getContent(String fileName) throws Exception {
-		try {
-			Path path = Paths.get(FileUtils.class.getClassLoader().getResource(fileName).toURI());
-			byte[] fileBytes = Files.readAllBytes(path);
-			return new String(fileBytes, StandardCharsets.UTF_8);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to read file: " + fileName, e);
-		}
-	}
+    public static String getContent(String fileName) throws Exception {
+        try {
+            Path path = Paths.get(FileUtils.class.getClassLoader().getResource(fileName).toURI());
+            byte[] fileBytes = Files.readAllBytes(path);
+            return new String(fileBytes, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read file: " + fileName, e);
+        }
+    }
 
-	@Test
-	public void testApp() throws Exception {
-		className = getClass().getSimpleName();
-		String testNumber = className.replaceAll("[^0-9]", "");
-		MvcResult mockMvcResult = mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL)).andExpect(status().isOk())
-				.andExpect(jsonPath("$.openapi", is("3.0.1"))).andReturn();
-		String result = mockMvcResult.getResponse().getContentAsString();
-		String expected = getContent("results/app" + testNumber + ".json");
-		assertEquals(expected, result, true);
-	}
+    @Test
+    public void testApp() throws Exception {
+        className = getClass().getSimpleName();
+        String testNumber = className.replaceAll("[^0-9]", "");
+        MvcResult mockMvcResult = mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL)).andExpect(status().isOk()).andExpect(jsonPath("$.openapi", is("3.0.1")))
+                                         .andReturn();
+        String result = mockMvcResult.getResponse().getContentAsString();
+        String expected = getContent("results/app" + testNumber + ".json");
+        assertEquals(expected, result, true);
+    }
 }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app92/SpringDocApp92Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app92/SpringDocApp92Test.java
@@ -1,0 +1,123 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+package test.org.springdoc.api.app92;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.springdoc.api.ActuatorProvider;
+import org.springdoc.api.OpenApiResource;
+import org.springdoc.core.AbstractRequestBuilder;
+import org.springdoc.core.GenericResponseBuilder;
+import org.springdoc.core.OpenAPIBuilder;
+import org.springdoc.core.OperationBuilder;
+import org.springdoc.core.SpringDocConfigProperties;
+import org.springdoc.core.customizers.OpenApiBuilderCustomiser;
+import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+import test.org.springdoc.api.AbstractSpringDocTest;
+import test.org.springdoc.api.app91.Greeting;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.springdoc.core.Constants.DEFAULT_GROUP_NAME;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@TestPropertySource(properties = "springdoc.default-produces-media-type=application/json")
+public class SpringDocApp92Test extends AbstractSpringDocTest {
+
+    @SpringBootApplication
+    static class SpringDocTestApp implements ApplicationContextAware {
+
+        private ApplicationContext applicationContext;
+
+        @Bean
+        public GreetingController greetingController() {
+            return new GreetingController();
+        }
+
+        @Bean
+        public OpenApiBuilderCustomiser customOpenAPI() {
+            return openApiBuilder -> openApiBuilder.addMappings(Collections.singletonMap("greetingController", new GreetingController()));
+        }
+
+        @Bean
+        public RequestMappingHandlerMapping defaultTestHandlerMapping(GreetingController greetingController) throws NoSuchMethodException {
+            RequestMappingHandlerMapping result = new RequestMappingHandlerMapping();
+            RequestMappingInfo requestMappingInfo =
+                            RequestMappingInfo.paths("/test").methods(RequestMethod.GET).produces(MediaType.APPLICATION_JSON_VALUE).build();
+
+            result.setApplicationContext(this.applicationContext);
+            result.registerMapping(requestMappingInfo, "greetingController", GreetingController.class.getDeclaredMethod("sayHello2"));
+            //result.handlerme
+            return result;
+        }
+
+        @Bean(name = "mvcOpenApiResource")
+        public OpenApiResource openApiResource(OpenAPIBuilder openAPIBuilder, AbstractRequestBuilder requestBuilder, GenericResponseBuilder responseBuilder,
+                                               OperationBuilder operationParser,
+                                               @Qualifier("defaultTestHandlerMapping") RequestMappingHandlerMapping requestMappingHandlerMapping,
+                                               Optional<ActuatorProvider> servletContextProvider, SpringDocConfigProperties springDocConfigProperties,
+                                               Optional<List<OpenApiCustomiser>> openApiCustomisers) {
+            return new OpenApiResource(DEFAULT_GROUP_NAME, openAPIBuilder, requestBuilder, responseBuilder, operationParser, requestMappingHandlerMapping,
+                                       servletContextProvider, openApiCustomisers, springDocConfigProperties);
+        }
+
+        @Override
+        public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+            this.applicationContext = applicationContext;
+        }
+    }
+
+    @ResponseBody
+    @Tag(name = "Demo", description = "The Demo API")
+    public static class GreetingController {
+
+        @GetMapping(produces = APPLICATION_JSON_VALUE)
+        @Operation(summary = "This API will return a random greeting.")
+        public ResponseEntity<Greeting> sayHello() {
+            return ResponseEntity.ok(new Greeting(RandomStringUtils.randomAlphanumeric(10)));
+        }
+
+        @GetMapping("/test")
+        @ApiResponses(value = { @ApiResponse(responseCode = "201", description = "item created"),
+                        @ApiResponse(responseCode = "400", description = "invalid input, object invalid"),
+                        @ApiResponse(responseCode = "409", description = "an existing item already exists") })
+        public ResponseEntity<Greeting> sayHello2() {
+            return ResponseEntity.ok(new Greeting(RandomStringUtils.randomAlphanumeric(10)));
+        }
+
+    }
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app92.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app92.json
@@ -1,0 +1,77 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Demo",
+      "description": "The Demo API"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "tags": [
+          "Demo"
+        ],
+        "operationId": "sayHello2",
+        "responses": {
+          "400": {
+            "description": "invalid input, object invalid",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Greeting"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "item created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Greeting"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "an existing item already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Greeting"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Greeting": {
+        "title": "Greeting",
+        "type": "object",
+        "properties": {
+          "payload": {
+            "type": "string",
+            "description": "The greeting value",
+            "example": "sdfsdfs"
+          }
+        },
+        "description": "An object containing a greeting message"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add OpenApiBuilderCustomiser to allow users to customize the OpenApiBuilder.
In our case we have our own custom annotation `FacadeRestResource` (much similar to spring-data-rest `RepositoryRestResource`) and we need a way to allow the OpenApiBuilder to scan beans for our annotation.
With the proposed change we introduce a new interface called `OpenApiBuilderCustomiser` and thus we can create our own customizer to provide the additional Map of mappings.