### PR TITLE
Updated project url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<packaging>pom</packaging>
 	<name>Spring openapi documentation generator</name>
 	<description>Spring openapi documentation generator</description>
-	<url>http://www.example.com/example-application</url>
+	<url>https://github.com/springdoc/springdoc-openapi</url>
 
 	<parent>
 		<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
It's annoying to see wrong address in one of the command line tools I use.
![image](https://user-images.githubusercontent.com/402625/75659583-8243ed80-5c6a-11ea-8a1b-68f6886cee7e.png)
