### PR TITLE
Update spring-boot-starter-parent to 2.2.5.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.4.RELEASE</version>
+		<version>2.2.5.RELEASE</version>
 	</parent>
 
 	<licenses>


### PR DESCRIPTION
I'm having problems resolving the latest version of Springdoc with Gradle 5.4. See for example https://github.com/spring-projects/spring-boot/issues/19783. This seems to be workarounded in 2.2.5.RELEASE