### PR TITLE
Delegate parameter primitive type generation to swagger-core

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
@@ -42,14 +42,7 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 
 	public static Schema resolveSchemaFromType(Class<?> schemaImplementation, Components components,
 			JsonView jsonView) {
-		Schema schemaObject;
-		PrimitiveType primitiveType = PrimitiveType.fromType(schemaImplementation);
-		if (primitiveType != null) {
-			schemaObject = primitiveType.createProperty();
-		}
-		else {
-			schemaObject = extractSchema(components, schemaImplementation, jsonView);
-		}
+		Schema schemaObject = extractSchema(components, schemaImplementation, jsonView);
 		if (schemaObject != null && StringUtils.isBlank(schemaObject.get$ref())
 				&& StringUtils.isBlank(schemaObject.getType())) {
 			// default to string


### PR DESCRIPTION
Originally we derived the schema ourselves when a primitive type was detected. The underlying `swagger-core` library (and in specific the `ModelResolver`) also does this for us, thus making this piece of code superfluous. Additionally this helps converge schema generation behavior for different generation paths (parameters, response bodies, etc.). A benefit of this is that any additional configuration like custom `ModelConverter`s are now applied.

**Some extra background**
We have configured a custom `ModelConverter` that can rewrite certain types for us on the fly. This works well for responses, but we noticed that this did not work for parameters that were primitive types, as they bypassed the normal code path for schema generation. One such example is an `Instant`, which Swagger expects to be a `long`, but which we have configured to be a date time string. So our `ModelConverter` correctly transforms the type for model properties, but not parameters which is a bit unexpected. This PR aims to correct that behavior.