### PR TITLE
Permit to enforce calculated server scheme to run on a https proxy

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -61,6 +61,11 @@ public class SpringDocConfigProperties {
 
 	private String defaultProducesMediaType = MediaType.ALL_VALUE;
 
+	/**
+	 * To override calculated server scheme in order to permit run on a https proxy
+	 */
+	private String calculatedServerScheme;
+
 	public boolean isAutoTagClasses() {
 		return autoTagClasses;
 	}
@@ -139,6 +144,14 @@ public class SpringDocConfigProperties {
 
 	public void setCache(Cache cache) {
 		this.cache = cache;
+	}
+
+	public String getCalculatedServerScheme() {
+		return calculatedServerScheme;
+	}
+
+	public void setCalculatedServerScheme(String calculatedServerScheme) {
+		this.calculatedServerScheme = calculatedServerScheme;
 	}
 
 	public static class Webjars {

--- a/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/api/OpenApiResource.java
+++ b/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/api/OpenApiResource.java
@@ -45,6 +45,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -54,6 +55,7 @@ import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMapping;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.springdoc.core.Constants.API_DOCS_URL;
 import static org.springdoc.core.Constants.APPLICATION_OPENAPI_YAML;
@@ -153,6 +155,9 @@ public class OpenApiResource extends AbstractOpenApiResource {
 	private void calculateServerUrl(HttpServletRequest request, String apiDocsUrl) {
 		String requestUrl = decode(request.getRequestURL().toString());
 		String calculatedUrl = requestUrl.substring(0, requestUrl.length() - apiDocsUrl.length());
+		if (!StringUtils.isEmpty(springDocConfigProperties.getCalculatedServerScheme())) {
+			calculatedUrl = UriComponentsBuilder.fromHttpUrl(calculatedUrl).scheme(springDocConfigProperties.getCalculatedServerScheme()).toUriString();
+		}
 		openAPIBuilder.setServerBaseUrl(calculatedUrl);
 	}
 }


### PR DESCRIPTION
add a new property `springdoc.calculated-server-scheme` to enforce overriding the calculated server scheme. In case of running a http swagger on a https proxy