### PR TITLE
Use Forwarded and X-Forwarded-* headers when calculating server URL

### DIFF
--- a/springdoc-openapi-webflux-core/src/main/java/org/springdoc/api/MultipleOpenApiResource.java
+++ b/springdoc-openapi-webflux-core/src/main/java/org/springdoc/api/MultipleOpenApiResource.java
@@ -47,7 +47,6 @@ import org.springframework.web.reactive.result.method.RequestMappingInfoHandlerM
 import static org.springdoc.core.Constants.API_DOCS_URL;
 import static org.springdoc.core.Constants.APPLICATION_OPENAPI_YAML;
 import static org.springdoc.core.Constants.DEFAULT_API_DOCS_URL_YAML;
-import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
 @RestController
 public class MultipleOpenApiResource implements InitializingBean {
@@ -108,7 +107,7 @@ public class MultipleOpenApiResource implements InitializingBean {
 			serverHttpRequest, @Value(API_DOCS_URL) String apiDocsUrl, @PathVariable String
 			group)
 			throws JsonProcessingException {
-		return getOpenApiResourceOrThrow(group).openapiJson(serverHttpRequest, apiDocsUrl + DEFAULT_PATH_SEPARATOR + group);
+		return getOpenApiResourceOrThrow(group).openapiJson(serverHttpRequest);
 	}
 
 	@Operation(hidden = true)
@@ -116,7 +115,7 @@ public class MultipleOpenApiResource implements InitializingBean {
 	public Mono<String> openapiYaml(ServerHttpRequest serverHttpRequest,
 			@Value(DEFAULT_API_DOCS_URL_YAML) String apiDocsUrl, @PathVariable String
 			group) throws JsonProcessingException {
-		return getOpenApiResourceOrThrow(group).openapiYaml(serverHttpRequest, apiDocsUrl + DEFAULT_PATH_SEPARATOR + group);
+		return getOpenApiResourceOrThrow(group).openapiYaml(serverHttpRequest);
 	}
 
 	private OpenApiResource getOpenApiResourceOrThrow(String group) {

--- a/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app99/HelloController.java
+++ b/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app99/HelloController.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.app99;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+	@GetMapping("/persons")
+	public void persons() {
+
+	}
+
+}

--- a/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app99/SpringDocApp99Test.java
+++ b/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app99/SpringDocApp99Test.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app99;
+
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp99Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	@ComponentScan(basePackages = { "org.springdoc", "test.org.springdoc.api.app99" })
+	static class SpringDocTestApp {}
+
+	@Test
+	@Override
+	public void testApp() throws Exception {
+		String expected = getContent("results/app99.json");
+
+		webTestClient.get()
+				.uri(Constants.DEFAULT_API_DOCS_URL + groupName)
+				.header("X-Forwarded-Proto", "https")
+				.header("X-Forwarded-Host", "loadbalancer.example.com")
+				.header("X-Forwarded-Port", "8443")
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody().json(expected);
+	}
+}

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app99.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app99.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "https://loadbalancer.example.com:8443",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/persons": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "persons",
+        "responses": {
+          "200": {
+            "description": "default response"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/api/MultipleOpenApiResource.java
+++ b/springdoc-openapi-webmvc-core/src/main/java/org/springdoc/api/MultipleOpenApiResource.java
@@ -47,7 +47,6 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMappi
 import static org.springdoc.core.Constants.API_DOCS_URL;
 import static org.springdoc.core.Constants.APPLICATION_OPENAPI_YAML;
 import static org.springdoc.core.Constants.DEFAULT_API_DOCS_URL_YAML;
-import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
 @RestController
 public class MultipleOpenApiResource implements InitializingBean {
@@ -111,7 +110,7 @@ public class MultipleOpenApiResource implements InitializingBean {
 	public String openapiJson(HttpServletRequest request, @Value(API_DOCS_URL) String apiDocsUrl,
 			@PathVariable String group)
 			throws JsonProcessingException {
-		return getOpenApiResourceOrThrow(group).openapiJson(request, apiDocsUrl + DEFAULT_PATH_SEPARATOR + group);
+		return getOpenApiResourceOrThrow(group).openapiJson(request);
 	}
 
 	@Operation(hidden = true)
@@ -119,7 +118,7 @@ public class MultipleOpenApiResource implements InitializingBean {
 	public String openapiYaml(HttpServletRequest request, @Value(DEFAULT_API_DOCS_URL_YAML) String apiDocsUrl,
 			@PathVariable String group)
 			throws JsonProcessingException {
-		return getOpenApiResourceOrThrow(group).openapiYaml(request, apiDocsUrl + DEFAULT_PATH_SEPARATOR + group);
+		return getOpenApiResourceOrThrow(group).openapiYaml(request);
 	}
 
 

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app99/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app99/HelloController.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.app99;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+	@GetMapping("/persons")
+	public void persons() {
+
+	}
+
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app99/SpringDocApp99Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app99/SpringDocApp99Test.java
@@ -1,0 +1,55 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app99;
+
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import static org.hamcrest.Matchers.is;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class SpringDocApp99Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	@Override
+	public void testApp() throws Exception {
+		className = getClass().getSimpleName();
+		String testNumber = className.replaceAll("[^0-9]", "");
+		MvcResult mockMvcResult = mockMvc
+				.perform(get(Constants.DEFAULT_API_DOCS_URL)
+						.header("X-Forwarded-Proto", "https")
+						.header("X-Forwarded-Host", "loadbalancer.example.com")
+						.header("X-Forwarded-Port", "8443"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.openapi", is("3.0.1"))).andReturn();
+		String result = mockMvcResult.getResponse().getContentAsString();
+		String expected = getContent("results/app" + testNumber + ".json");
+		assertEquals(expected, result, true);
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app99.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app99.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "https://loadbalancer.example.com:8443",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/persons": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "persons",
+        "responses": {
+          "200": {
+            "description": "default response"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
When the application is served behind a proxy (e.g. for load balancing),
the proxy can provide the de-facto standard X-Forwarded-Proto, X-Forwarded-Host
and X-Forwarded-Port headers to submit the protocol, host and port of the original
request to the downstream application.

Using Spring's UriComponentsBuilder we can use this information to construct
the server URL of the original request.