### PR TITLE
use MethodParameter#isOptional() instead of checking for Optional type

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -279,8 +279,7 @@ public abstract class AbstractRequestBuilder {
 
 		}
 		else if (requestParam != null && !parameterBuilder.isFile(parameterInfo.getParameter())) {
-			boolean isOptional = Optional.class.equals(methodParameter.getParameterType());
-			requestInfo = new RequestInfo(ParameterIn.QUERY.toString(), requestParam.value(), requestParam.required() && !isOptional,
+			requestInfo = new RequestInfo(ParameterIn.QUERY.toString(), requestParam.value(), requestParam.required() && !methodParameter.isOptional(),
 					requestParam.defaultValue());
 			parameter = buildParam(parameterInfo, components, requestInfo, jsonView);
 		}


### PR DESCRIPTION
Check for whether a parameter is required now uses `isOptional()` method. This improves integration with JSR-305 annotations and Kotlin nullability.

In the following Kotlin example, parameter `foo` will be mandatory, but `bar` and `baz` not:
```kotlin
@RestController
@RequestMapping
class FooController {
    @GetMapping("test")
    fun testParams(
        @RequestParam foo: String,
        @RequestParam bar: String = "default",
        @RequestParam baz: String?
    ) {}
}
```

Similarly, parameter `foo` will correctly be rendered non-mandatory in this Java example:
```java
@RestController
@RequestMapping
public class FooController {
    @GetMapping("test")
    void fooNullable(@RequestParam @Nullable String foo) {}
}
```