### PR TITLE
Extract parameters from parameter object

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+tab_width = 4
+indent_style = tab
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/annotations/ParameterObject.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/annotations/ParameterObject.java
@@ -1,0 +1,10 @@
+package org.springdoc.api.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ParameterObject {}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -18,6 +18,29 @@
 
 package org.springdoc.core;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
 import com.fasterxml.jackson.annotation.JsonView;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.models.Components;
@@ -34,6 +57,7 @@ import org.springdoc.api.annotations.ParameterObject;
 import org.springdoc.core.converters.AdditionalModelsConverter;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.customizers.ParameterCustomizer;
+
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.AnnotatedElementUtils;
@@ -41,20 +65,18 @@ import org.springframework.http.HttpMethod;
 import org.springframework.util.CollectionUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ValueConstants;
 import org.springframework.web.bind.support.SessionStatus;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.util.UriComponentsBuilder;
-
-import javax.validation.constraints.*;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.math.BigDecimal;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.springdoc.core.Constants.OPENAPI_ARRAY_TYPE;
 import static org.springdoc.core.Constants.OPENAPI_STRING_TYPE;
@@ -150,7 +172,8 @@ public abstract class AbstractRequestBuilder {
 						.map(f -> DelegatingMethodParameter.fromGetterOfField(paramClass, f))
 						.filter(Objects::nonNull)
 						.forEach(explodedParameters::add);
-			} else {
+			}
+			else {
 				String name = pNames != null ? pNames[i] : p.getParameterName();
 				explodedParameters.add(new DelegatingMethodParameter(p, name, null));
 			}
@@ -166,14 +189,12 @@ public abstract class AbstractRequestBuilder {
 			// check if query param
 			Parameter parameter = null;
 			io.swagger.v3.oas.annotations.Parameter parameterDoc = methodParameter.getParameterAnnotation(io.swagger.v3.oas.annotations.Parameter.class);
-			if (parameterDoc == null) {
+			if (parameterDoc == null)
 				parameterDoc = parametersDocMap.get(methodParameter.getParameterName());
-			}
 			// use documentation as reference
 			if (parameterDoc != null) {
-				if (parameterDoc.hidden()) {
+				if (parameterDoc.hidden())
 					continue;
-				}
 				parameter = parameterBuilder.buildParameterFromDoc(parameterDoc, null,
 						methodAttributes.getJsonViewAnnotation());
 			}
@@ -185,12 +206,11 @@ public abstract class AbstractRequestBuilder {
 				// Merge with the operation parameters
 				parameter = parameterBuilder.mergeParameter(operationParameters, parameter);
 				List<Annotation> parameterAnnotations = Arrays.asList(methodParameter.getParameterAnnotations());
-				if (isValidParameter(parameter)) {
+				if (isValidParameter(parameter))
 					applyBeanValidatorAnnotations(parameter, parameterAnnotations);
-				} else if (!RequestMethod.GET.equals(requestMethod)) {
-					if (operation.getRequestBody() != null) {
+				else if (!RequestMethod.GET.equals(requestMethod)) {
+					if (operation.getRequestBody() != null)
 						requestBodyInfo.setRequestBody(operation.getRequestBody());
-					}
 					requestBodyBuilder.calculateRequestBodyInfo(components, methodAttributes,
 							parameterInfo, requestBodyInfo);
 					applyBeanValidatorAnnotations(requestBodyInfo.getRequestBody(), parameterAnnotations);

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.api.annotations.ParameterObject;
+import org.springdoc.core.converters.AdditionalModelsConverter;
 import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.core.customizers.ParameterCustomizer;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
@@ -144,7 +145,7 @@ public abstract class AbstractRequestBuilder {
 		for (int i = 0; i < parameters.length; ++i) {
 			MethodParameter p = parameters[i];
 			if (p.hasParameterAnnotation(ParameterObject.class)) {
-				Class<?> paramClass = p.getParameterType();
+				Class<?> paramClass = AdditionalModelsConverter.getReplacement(p.getParameterType());
 				Stream.of(paramClass.getDeclaredFields())
 						.map(f -> DelegatingMethodParameter.fromGetterOfField(paramClass, f))
 						.filter(Objects::nonNull)

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
@@ -1,0 +1,120 @@
+package org.springdoc.core;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.springframework.core.MethodParameter;
+import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+class DelegatingMethodParameter extends MethodParameter {
+	private volatile MethodParameter delegate;
+	private Annotation[] additionalParameterAnnotations;
+	private String parameterName;
+
+	DelegatingMethodParameter(MethodParameter delegate, String parameterName, Annotation[] additionalParameterAnnotations) {
+		super(delegate);
+		this.delegate = delegate;
+		this.additionalParameterAnnotations = additionalParameterAnnotations;
+		this.parameterName = parameterName;
+	}
+
+	@Nullable
+	static MethodParameter fromGetterOfField(Class<?> paramClass, Field field) {
+		try {
+			return Stream.of(Introspector.getBeanInfo(paramClass).getPropertyDescriptors())
+					.filter(d -> d.getName().equals(field.getName()))
+					.map(PropertyDescriptor::getReadMethod)
+					.filter(Objects::nonNull)
+					.findFirst()
+					.map(method -> new MethodParameter(method, -1))
+					.map(param -> new DelegatingMethodParameter(param, field.getName(), field.getDeclaredAnnotations()))
+					.orElse(null);
+		} catch (IntrospectionException e) {
+			return null;
+		}
+	}
+
+	@Override
+	@NonNull
+	public Annotation[] getParameterAnnotations() {
+		return ArrayUtils.addAll(delegate.getParameterAnnotations(), additionalParameterAnnotations);
+	}
+
+	@Override
+	public String getParameterName() {
+		return parameterName;
+	}
+
+	@Override
+	public Method getMethod() {
+		return delegate.getMethod();
+	}
+
+	@Override
+	public Constructor<?> getConstructor() {
+		return delegate.getConstructor();
+	}
+
+	@Override
+	public Class<?> getDeclaringClass() {
+		return delegate.getDeclaringClass();
+	}
+
+	@Override
+	public Member getMember() {
+		return delegate.getMember();
+	}
+
+	@Override
+	public AnnotatedElement getAnnotatedElement() {
+		return delegate.getAnnotatedElement();
+	}
+
+	@Override
+	public Executable getExecutable() {
+		return delegate.getExecutable();
+	}
+
+	@Override
+	public MethodParameter withContainingClass(Class<?> containingClass) {
+		return delegate.withContainingClass(containingClass);
+	}
+
+	@Override
+	public Class<?> getContainingClass() {
+		return delegate.getContainingClass();
+	}
+
+	@Override
+	public Class<?> getParameterType() {
+		return delegate.getParameterType();
+	}
+
+	@Override
+	public Type getGenericParameterType() {
+		return delegate.getGenericParameterType();
+	}
+
+	@Override
+	public Class<?> getNestedParameterType() {
+		return delegate.getNestedParameterType();
+	}
+
+	@Override
+	public Type getNestedGenericParameterType() {
+		return delegate.getNestedGenericParameterType();
+	}
+
+	@Override
+	public void initParameterNameDiscovery(ParameterNameDiscoverer parameterNameDiscoverer) {
+		delegate.initParameterNameDiscovery(parameterNameDiscoverer);
+	}
+}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
@@ -1,22 +1,34 @@
 package org.springdoc.core;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang3.ArrayUtils;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.*;
-import java.util.Objects;
-import java.util.stream.Stream;
-
+/**
+ * @author zarebski.m
+ */
 class DelegatingMethodParameter extends MethodParameter {
 	private volatile MethodParameter delegate;
+
 	private Annotation[] additionalParameterAnnotations;
+
 	private String parameterName;
 
 	DelegatingMethodParameter(MethodParameter delegate, String parameterName, Annotation[] additionalParameterAnnotations) {
@@ -37,7 +49,8 @@ class DelegatingMethodParameter extends MethodParameter {
 					.map(method -> new MethodParameter(method, -1))
 					.map(param -> new DelegatingMethodParameter(param, field.getName(), field.getDeclaredAnnotations()))
 					.orElse(null);
-		} catch (IntrospectionException e) {
+		}
+		catch (IntrospectionException e) {
 			return null;
 		}
 	}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
@@ -18,17 +18,16 @@
 
 package org.springdoc.core.converters;
 
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class AdditionalModelsConverter implements ModelConverter {
 
@@ -44,15 +43,21 @@ public class AdditionalModelsConverter implements ModelConverter {
 		modelToSchemaMap.put(source, target);
 	}
 
+	public static Class getReplacement(Class clazz) {
+		return modelToClassMap.getOrDefault(clazz, clazz);
+	}
+
 	@Override
 	public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
 		JavaType javaType = Json.mapper().constructType(type.getType());
 		if (javaType != null) {
 			Class<?> cls = javaType.getRawClass();
-			if (modelToSchemaMap.containsKey(cls))
+			if (modelToSchemaMap.containsKey(cls)) {
 				return modelToSchemaMap.get(cls);
-			if (modelToClassMap.containsKey(cls))
+			}
+			if (modelToClassMap.containsKey(cls)) {
 				type = new AnnotatedType(modelToClassMap.get(cls)).resolveAsRef(true);
+			}
 		}
 		return (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
 	}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
@@ -18,16 +18,16 @@
 
 package org.springdoc.core.converters;
 
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
-
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
 
 public class AdditionalModelsConverter implements ModelConverter {
 
@@ -52,12 +52,10 @@ public class AdditionalModelsConverter implements ModelConverter {
 		JavaType javaType = Json.mapper().constructType(type.getType());
 		if (javaType != null) {
 			Class<?> cls = javaType.getRawClass();
-			if (modelToSchemaMap.containsKey(cls)) {
+			if (modelToSchemaMap.containsKey(cls))
 				return modelToSchemaMap.get(cls);
-			}
-			if (modelToClassMap.containsKey(cls)) {
+			if (modelToClassMap.containsKey(cls))
 				type = new AnnotatedType(modelToClassMap.get(cls)).resolveAsRef(true);
-			}
 		}
 		return (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
 	}

--- a/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
+++ b/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
@@ -18,6 +18,8 @@
 
 package org.springdoc.core.converters;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.Max;
@@ -31,14 +33,18 @@ public class Pageable {
 
 	@Nullable
 	@Min(0)
+	@Schema(description = "Zero-based page index (0..N)", defaultValue = "0")
 	private Integer page;
 
 	@Nullable
 	@Min(1)
 	@Max(2000)
+	@Schema(description = "The size of the page to be returned", defaultValue = "20")
 	private Integer size;
 
 	@Nullable
+	@ArraySchema(arraySchema = @Schema(description = "Sorting criteria in the format: property(,asc|desc). "
+			+ "Default sort order is ascending. " + "Multiple sort criteria are supported."))
 	private List<String> sort;
 
 	public Pageable(int page, int size, List<String> sort) {
@@ -47,19 +53,19 @@ public class Pageable {
 		this.sort = sort;
 	}
 
-	public int getPage() {
+	public Integer getPage() {
 		return page;
 	}
 
-	public void setPage(int page) {
+	public void setPage(Integer page) {
 		this.page = page;
 	}
 
-	public int getSize() {
+	public Integer getSize() {
 		return size;
 	}
 
-	public void setSize(int size) {
+	public void setSize(Integer size) {
 		this.size = size;
 	}
 
@@ -68,10 +74,11 @@ public class Pageable {
 	}
 
 	public void setSort(List<String> sort) {
-		if (sort == null)
+		if (sort == null) {
 			this.sort.clear();
-		else
+		} else {
 			this.sort = sort;
+		}
 	}
 
 	public void addSort(String sort) {
@@ -80,11 +87,15 @@ public class Pageable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		Pageable pageable = (Pageable) o;
-		return page == pageable.page &&
-				size == pageable.size &&
+		return Objects.equals(page, pageable.page) &&
+				Objects.equals(size, pageable.size) &&
 				Objects.equals(sort, pageable.sort);
 	}
 

--- a/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
+++ b/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
@@ -18,29 +18,30 @@
 
 package org.springdoc.core.converters;
 
-import java.util.List;
-import java.util.Objects;
+import org.springframework.lang.Nullable;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
+import java.util.List;
+import java.util.Objects;
 
 @NotNull
 public class Pageable {
 
-	@NotNull
+	@Nullable
 	@Min(0)
-	private int page;
+	private Integer page;
 
-	@NotNull
+	@Nullable
 	@Min(1)
 	@Max(2000)
-	private int size;
+	private Integer size;
 
-	@NotNull
+	@Nullable
 	private List<String> sort;
 
-	public Pageable(@NotNull @Min(0) int page, @NotNull @Min(1) @Max(2000) int size, List<String> sort) {
+	public Pageable(int page, int size, List<String> sort) {
 		this.page = page;
 		this.size = size;
 		this.sort = sort;

--- a/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
+++ b/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/Pageable.java
@@ -87,12 +87,8 @@ public class Pageable {
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
 		Pageable pageable = (Pageable) o;
 		return Objects.equals(page, pageable.page) &&
 				Objects.equals(size, pageable.size) &&

--- a/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/PageableAsQueryParam.java
+++ b/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/PageableAsQueryParam.java
@@ -18,17 +18,22 @@
 
 package org.springdoc.core.converters;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @deprecated Use {@link org.springdoc.api.annotations.ParameterObject} annotation
+ * 		on {@link org.springframework.data.domain.Pageable} method parameter instead.
+ */
+@Deprecated
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(in = ParameterIn.QUERY

--- a/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/PageableAsQueryParam.java
+++ b/springdoc-openapi-data-rest/src/main/java/org/springdoc/core/converters/PageableAsQueryParam.java
@@ -31,10 +31,10 @@ import java.lang.annotation.Target;
 
 /**
  * @deprecated Use {@link org.springdoc.api.annotations.ParameterObject} annotation
- * 		on {@link org.springframework.data.domain.Pageable} method parameter instead.
+ * on {@link org.springframework.data.domain.Pageable} method parameter instead.
  */
 @Deprecated
-@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @Parameter(in = ParameterIn.QUERY
 		, description = "Zero-based page index (0..N)"

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/HelloController.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/HelloController.java
@@ -1,0 +1,38 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app7;
+
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@RestController
+public class HelloController {
+
+	@GetMapping(value = "/search", produces = { "application/xml", "application/json" })
+	public ResponseEntity<List<PersonDTO>> getAllPets(@NotNull @ParameterObject Pageable pageable) {
+		return null;
+	}
+
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/PersonDTO.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/PersonDTO.java
@@ -1,0 +1,63 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app7;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema
+public class PersonDTO {
+	private String email;
+
+	private String firstName;
+
+	private String lastName;
+
+	public PersonDTO() {
+	}
+
+	public PersonDTO(final String email, final String firstName, final String lastName) {
+		this.email = email;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(final String email) {
+		this.email = email;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(final String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(final String lastName) {
+		this.lastName = lastName;
+	}
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/SpringDocApp7Test.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app7/SpringDocApp7Test.java
@@ -1,0 +1,29 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app7;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp7Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+}

--- a/springdoc-openapi-data-rest/src/test/resources/results/app2.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app2.json
@@ -61,16 +61,21 @@
           "page": {
             "minimum": 0,
             "type": "integer",
-            "format": "int32"
+            "description": "Zero-based page index (0..N)",
+            "format": "int32",
+            "default": 0
           },
           "size": {
             "maximum": 2000,
             "minimum": 1,
             "type": "integer",
-            "format": "int32"
+            "description": "The size of the page to be returned",
+            "format": "int32",
+            "default": 20
           },
           "sort": {
             "type": "array",
+            "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
             "items": {
               "type": "string"
             }

--- a/springdoc-openapi-data-rest/src/test/resources/results/app7.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app7.json
@@ -25,7 +25,9 @@
             "schema": {
               "minimum": 0,
               "type": "integer",
-              "format": "int32"
+              "description": "Zero-based page index (0..N)",
+              "format": "int32",
+              "default": 0
             }
           },
           {
@@ -33,11 +35,12 @@
             "in": "query",
             "required": false,
             "schema": {
-              "default": 20,
               "maximum": 2000,
               "minimum": 1,
               "type": "integer",
-              "format": "int32"
+              "description": "The size of the page to be returned",
+              "format": "int32",
+              "default": 20
             }
           },
           {
@@ -46,6 +49,7 @@
             "required": false,
             "schema": {
               "type": "array",
+              "description": "Sorting criteria in the format: property(,asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
               "items": {
                 "type": "string"
               }

--- a/springdoc-openapi-data-rest/src/test/resources/results/app7.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app7.json
@@ -19,11 +19,36 @@
         "operationId": "getAllPets",
         "parameters": [
           {
-            "name": "pageable",
+            "name": "page",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
-              "$ref": "#/components/schemas/Pageable"
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         ],
@@ -55,28 +80,6 @@
   },
   "components": {
     "schemas": {
-      "Pageable": {
-        "type": "object",
-        "properties": {
-          "page": {
-            "minimum": 0,
-            "type": "integer",
-            "format": "int32"
-          },
-          "size": {
-            "maximum": 2000,
-            "minimum": 1,
-            "type": "integer",
-            "format": "int32"
-          },
-          "sort": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
       "PersonDTO": {
         "type": "object",
         "properties": {

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
@@ -1,0 +1,29 @@
+package test.org.springdoc.api.app102;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import org.springframework.lang.Nullable;
+
+public class RequestParams {
+	@Nullable
+	@Parameter(description = "string parameter")
+	private String stringParam;
+
+	@Parameter(description = "int parameter")
+	private int intParam;
+
+	public String getStringParam() {
+		return stringParam;
+	}
+
+	public void setStringParam(String stringParam) {
+		this.stringParam = stringParam;
+	}
+
+	public int getIntParam() {
+		return intParam;
+	}
+
+	public void setIntParam(int intParam) {
+		this.intParam = intParam;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/SpringDocApp102Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/SpringDocApp102Test.java
@@ -1,0 +1,9 @@
+package test.org.springdoc.api.app102;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp102Test extends AbstractSpringDocTest {
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/TestController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/TestController.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.app102;
+
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.lang.Nullable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+	@GetMapping("test")
+	public void getTest(@RequestParam @Nullable String param, @ParameterObject RequestParams requestParams) {
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
@@ -1,0 +1,58 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "tags": [
+          "test-controller"
+        ],
+        "operationId": "getTest",
+        "parameters": [
+          {
+            "name": "param",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "stringParam",
+            "in": "query",
+            "description": "string parameter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "intParam",
+            "in": "query",
+            "description": "int parameter",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "default response"
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
Fixes #120, #268, #162, #119

This PR introduces a new Springdoc annotation `org.springdoc.api.annotations.ParameterObject`. Request parameter annotated with it are not added as a request parameter themselves, but rather each field of the parameter is added as a separate request parameter. This is compatible with Spring MVC request parameters mapping to POJO object.

See test case 102 in springdoc-openapi-webmvc-core.

Consider the following classes:

```java
class QueryParams {
    private String name;
    private String value;
}

@RestController
class TestController {
    @GetMapping("pojo-params")
    public void testMethod(@ParameterObject QueryParams queryParams) {}
}
```

In generated docs, the `/pojo-params` endpoint defines two request parameters: `name` and `value`, instead of single `queryParams` one.

This also allows deprecation of the workaround for `Pageable` with `PageableAsQueryParam` annotation – we can simply use `@ParameterObject Pageable pageable` on method parameter.

See test case 7 on springdoc-openapi-data-rest.