### PR TITLE
Add support for swagger-ui-property 'urls.primaryName'.

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
@@ -160,6 +160,8 @@ public class SwaggerUiConfigProperties {
 
 	private Direction groupsOrder = Direction.ASC;
 
+	private String urlsPrimaryName;
+
 	public void addGroup(String group) {
 		SwaggerUrl swaggerUrl = new SwaggerUrl(group);
 		urls.add(swaggerUrl);
@@ -204,6 +206,7 @@ public class SwaggerUiConfigProperties {
 		SpringDocPropertiesUtils.put("oauth2RedirectUrl", oauth2RedirectUrl, params);
 		SpringDocPropertiesUtils.put("url", url, params);
 		put("urls", urls, params);
+		SpringDocPropertiesUtils.put("urls.primaryName", urlsPrimaryName, params);
 		return params;
 	}
 
@@ -405,6 +408,14 @@ public class SwaggerUiConfigProperties {
 		public boolean isAscending() {
 			return this.equals(ASC);
 		}
+	}
+
+	public String getUrlsPrimaryName() {
+		return urlsPrimaryName;
+	}
+
+	public void setUrlsPrimaryName(String urlsPrimaryName) {
+		this.urlsPrimaryName = urlsPrimaryName;
 	}
 
 	static class SwaggerUrl {

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocApp4Test.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocApp4Test.java
@@ -28,7 +28,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@TestPropertySource(properties = "springdoc.swagger-ui.groups-order=DESC")
+@TestPropertySource(properties = {"springdoc.swagger-ui.groups-order=DESC", "springdoc.swagger-ui.urlsPrimaryName=pets"})
 public class SpringDocApp4Test extends AbstractSpringDocTest {
 
 	@Test
@@ -40,6 +40,7 @@ public class SpringDocApp4Test extends AbstractSpringDocTest {
 				.andExpect(jsonPath("urls[0].url", equalTo("/v3/api-docs/stores")))
 				.andExpect(jsonPath("urls[0].name", equalTo("stores")))
 				.andExpect(jsonPath("urls[1].url", equalTo("/v3/api-docs/pets")))
-				.andExpect(jsonPath("urls[1].name", equalTo("pets")));
+				.andExpect(jsonPath("urls[1].name", equalTo("pets")))
+				.andExpect(jsonPath("$['urls.primaryName']", equalTo("pets")));
 	}
 }


### PR DESCRIPTION
New spring-boot-property 'springdoc.swagger-ui.urlsPrimaryName' which maps to swagger-ui-property 'urls.primaryName'. Fixes #572