### PR TITLE
Support nested parameter objects

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
@@ -10,7 +10,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -18,76 +23,50 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.apache.commons.lang3.ArrayUtils;
 
 import org.springframework.core.MethodParameter;
-import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
 class MethodParameterPojoExtractor {
-	private static final Set<Class<?>> SIMPLE_TYPES;
-	private static final Set<Class<?>> COLLECTION_TYPES;
-
-	static {
-		Set<Class<?>> simpleTypes = new HashSet<>();
-		simpleTypes.add(boolean.class);
-		simpleTypes.add(char.class);
-		simpleTypes.add(byte.class);
-		simpleTypes.add(short.class);
-		simpleTypes.add(int.class);
-		simpleTypes.add(long.class);
-		simpleTypes.add(float.class);
-		simpleTypes.add(double.class);
-
-		simpleTypes.add(Boolean.class);
-		simpleTypes.add(Character.class);
-		simpleTypes.add(Byte.class);
-		simpleTypes.add(Short.class);
-		simpleTypes.add(Integer.class);
-		simpleTypes.add(Long.class);
-		simpleTypes.add(Float.class);
-		simpleTypes.add(Double.class);
-
-		simpleTypes.add(CharSequence.class);
-		simpleTypes.add(Number.class);
-
-		SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
-
-		Set<Class<?>> collectionTypes = new HashSet<>();
-		collectionTypes.add(Iterable.class);
-
-		COLLECTION_TYPES = Collections.unmodifiableSet(collectionTypes);
+	static Stream<MethodParameter> extractFrom(Class<?> clazz) {
+		return extractFrom(clazz, "");
 	}
 
-	private static final Nullable NULLABLE_ANNOTATION = new Nullable() {
-		@Override
-		public Class<? extends Annotation> annotationType() {
-			return Nullable.class;
-		}
-	};
-
-	@NonNull
-	static Stream<MethodParameter> extractFrom(Class<?> clazz) {
+	private static Stream<MethodParameter> extractFrom(Class<?> clazz, String fieldNamePrefix) {
 		return allFieldsOf(clazz).stream()
-				.flatMap(f -> fromGetterOfField(clazz, f))
+				.flatMap(f -> fromGetterOfField(clazz, f, fieldNamePrefix))
 				.filter(Objects::nonNull);
 	}
 
-	private static Stream<MethodParameter> fromGetterOfField(Class<?> paramClass, Field field) {
+	private static Stream<MethodParameter> fromGetterOfField(Class<?> paramClass, Field field, String fieldNamePrefix) {
+		if (isSimpleType(field.getType())) {
+			return fromSimpleClass(paramClass, field, fieldNamePrefix);
+		}
+		else {
+			return extractFrom(field.getType(), fieldNamePrefix + field.getName() + ".");
+		}
+	}
+
+	private static Stream<MethodParameter> fromSimpleClass(Class<?> paramClass, Field field, String fieldNamePrefix) {
+		Annotation[] fieldAnnotations = field.getDeclaredAnnotations();
+		if (isOptional(field)) {
+			fieldAnnotations = ArrayUtils.add(fieldAnnotations, NULLABLE_ANNOTATION);
+		}
 		try {
-			Annotation[] filedAnnotations = field.getDeclaredAnnotations();
-			Parameter parameter = field.getAnnotation(Parameter.class);
-			if (parameter != null && !parameter.required()) {
-				filedAnnotations = ArrayUtils.add(filedAnnotations, NULLABLE_ANNOTATION);
-			}
-			Annotation[] filedAnnotationsNew = filedAnnotations;
+			Annotation[] finalFieldAnnotations = fieldAnnotations;
 			return Stream.of(Introspector.getBeanInfo(paramClass).getPropertyDescriptors())
 					.filter(d -> d.getName().equals(field.getName()))
 					.map(PropertyDescriptor::getReadMethod)
 					.filter(Objects::nonNull)
 					.map(method -> new MethodParameter(method, -1))
-					.map(param -> new DelegatingMethodParameter(param, field.getName(), filedAnnotationsNew));
+					.map(param -> new DelegatingMethodParameter(param, fieldNamePrefix + field.getName(), finalFieldAnnotations));
 		}
 		catch (IntrospectionException e) {
 			return Stream.of();
 		}
+	}
+
+	private static boolean isOptional(Field field) {
+		Parameter parameter = field.getAnnotation(Parameter.class);
+		return parameter == null || !parameter.required();
 	}
 
 	private static List<Field> allFieldsOf(Class<?> clazz) {
@@ -97,5 +76,38 @@ class MethodParameterPojoExtractor {
 			clazz = clazz.getSuperclass();
 		} while (clazz != null);
 		return fields;
+	}
+
+	private static boolean isSimpleType(Class<?> clazz) {
+		if (clazz.isPrimitive()) return true;
+		if (clazz.isArray()) return true;
+		if (clazz.isEnum()) return true;
+		return SIMPLE_TYPES.stream().anyMatch(c -> c.isAssignableFrom(clazz));
+	}
+
+	private static final Nullable NULLABLE_ANNOTATION = new Nullable() {
+		@Override
+		public Class<? extends Annotation> annotationType() {
+			return Nullable.class;
+		}
+	};
+
+	private static final Set<Class<?>> SIMPLE_TYPES;
+
+	static {
+		Set<Class<?>> simpleTypes = new HashSet<>();
+		simpleTypes.add(Boolean.class);
+		simpleTypes.add(Character.class);
+		simpleTypes.add(Number.class);
+		simpleTypes.add(CharSequence.class);
+		simpleTypes.add(Optional.class);
+		simpleTypes.add(OptionalInt.class);
+		simpleTypes.add(OptionalLong.class);
+		simpleTypes.add(OptionalDouble.class);
+
+		simpleTypes.add(Map.class);
+		simpleTypes.add(Iterable.class);
+
+		SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
 	}
 }

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
@@ -1,0 +1,101 @@
+package org.springdoc.core;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import org.apache.commons.lang3.ArrayUtils;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+class MethodParameterPojoExtractor {
+	private static final Set<Class<?>> SIMPLE_TYPES;
+	private static final Set<Class<?>> COLLECTION_TYPES;
+
+	static {
+		Set<Class<?>> simpleTypes = new HashSet<>();
+		simpleTypes.add(boolean.class);
+		simpleTypes.add(char.class);
+		simpleTypes.add(byte.class);
+		simpleTypes.add(short.class);
+		simpleTypes.add(int.class);
+		simpleTypes.add(long.class);
+		simpleTypes.add(float.class);
+		simpleTypes.add(double.class);
+
+		simpleTypes.add(Boolean.class);
+		simpleTypes.add(Character.class);
+		simpleTypes.add(Byte.class);
+		simpleTypes.add(Short.class);
+		simpleTypes.add(Integer.class);
+		simpleTypes.add(Long.class);
+		simpleTypes.add(Float.class);
+		simpleTypes.add(Double.class);
+
+		simpleTypes.add(CharSequence.class);
+		simpleTypes.add(Number.class);
+
+		SIMPLE_TYPES = Collections.unmodifiableSet(simpleTypes);
+
+		Set<Class<?>> collectionTypes = new HashSet<>();
+		collectionTypes.add(Iterable.class);
+
+		COLLECTION_TYPES = Collections.unmodifiableSet(collectionTypes);
+	}
+
+	private static final Nullable NULLABLE_ANNOTATION = new Nullable() {
+		@Override
+		public Class<? extends Annotation> annotationType() {
+			return Nullable.class;
+		}
+	};
+
+	@NonNull
+	static Stream<MethodParameter> extractFrom(Class<?> clazz) {
+		return allFieldsOf(clazz).stream()
+				.flatMap(f -> fromGetterOfField(clazz, f))
+				.filter(Objects::nonNull);
+	}
+
+	private static Stream<MethodParameter> fromGetterOfField(Class<?> paramClass, Field field) {
+		try {
+			Annotation[] filedAnnotations = field.getDeclaredAnnotations();
+			Parameter parameter = field.getAnnotation(Parameter.class);
+			if (parameter != null && !parameter.required()) {
+				filedAnnotations = ArrayUtils.add(filedAnnotations, NULLABLE_ANNOTATION);
+			}
+			Annotation[] filedAnnotationsNew = filedAnnotations;
+			return Stream.of(Introspector.getBeanInfo(paramClass).getPropertyDescriptors())
+					.filter(d -> d.getName().equals(field.getName()))
+					.map(PropertyDescriptor::getReadMethod)
+					.filter(Objects::nonNull)
+					.map(method -> new MethodParameter(method, -1))
+					.map(param -> new DelegatingMethodParameter(param, field.getName(), filedAnnotationsNew));
+		}
+		catch (IntrospectionException e) {
+			return Stream.of();
+		}
+	}
+
+	private static List<Field> allFieldsOf(Class<?> clazz) {
+		List<Field> fields = new ArrayList<>();
+		do {
+			fields.addAll(Arrays.asList(clazz.getDeclaredFields()));
+			clazz = clazz.getSuperclass();
+		} while (clazz != null);
+		return fields;
+	}
+}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUtils.java
@@ -18,6 +18,8 @@
 
 package org.springdoc.core;
 
+import java.util.function.Predicate;
+
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.api.AbstractOpenApiResource;
 import org.springdoc.core.converters.AdditionalModelsConverter;
@@ -111,6 +113,21 @@ public class SpringDocUtils {
 
 	public SpringDocUtils removeFluxWrapperToIgnore(Class<?> cls) {
 		ConverterUtils.removeFluxWrapperToIgnore(cls);
+		return this;
+	}
+
+	public SpringDocUtils addSimpleTypesForParameterObject(Class<?>... classes) {
+		MethodParameterPojoExtractor.addSimpleTypes(classes);
+		return this;
+	}
+
+	public SpringDocUtils removeSimpleTypesForParameterObject(Class<?>... classes) {
+		MethodParameterPojoExtractor.removeSimpleTypes(classes);
+		return this;
+	}
+
+	public SpringDocUtils addSimpleTypePredicateForParameterObject(Predicate<Class<?>> predicate) {
+		MethodParameterPojoExtractor.addSimpleTypePredicate(predicate);
 		return this;
 	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/InheritedRequestParams.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/InheritedRequestParams.java
@@ -1,9 +1,12 @@
 package test.org.springdoc.api.app102;
 
+import javax.validation.constraints.NotBlank;
+
 import io.swagger.v3.oas.annotations.Parameter;
 
 public class InheritedRequestParams extends RequestParams {
 	@Parameter(description = "parameter from child of RequestParams")
+	@NotBlank
 	private String childParam;
 
 	public String getChildParam() {

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
@@ -1,5 +1,7 @@
 package test.org.springdoc.api.app102;
 
+import java.math.BigInteger;
+import java.util.List;
 import java.util.Optional;
 
 import io.swagger.v3.oas.annotations.Parameter;
@@ -7,6 +9,29 @@ import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.lang.Nullable;
 
 public class RequestParams {
+
+	public static class Nested {
+		private String param1;
+		private BigInteger param2;
+
+		@Parameter(description = "nested string parameter")
+		public String getParam1() {
+			return param1;
+		}
+
+		public void setParam1(String param1) {
+			this.param1 = param1;
+		}
+
+		@Parameter(description = "nested BigInteger parameter")
+		public BigInteger getParam2() {
+			return param2;
+		}
+
+		public void setParam2(BigInteger param2) {
+			this.param2 = param2;
+		}
+	}
 
 	@Parameter(description = "string parameter")
 	private String stringParam;
@@ -23,6 +48,10 @@ public class RequestParams {
 
 	@Nullable
 	private String intParam3;
+
+	private Nested nested;
+
+	private List<Nested> nestedList;
 
 	public String getStringParam() {
 		return stringParam;
@@ -71,5 +100,21 @@ public class RequestParams {
 
 	public void setStringParam2(String stringParam2) {
 		this.stringParam2 = stringParam2;
+	}
+
+	public Nested getNested() {
+		return nested;
+	}
+
+	public void setNested(Nested nested) {
+		this.nested = nested;
+	}
+
+	public List<Nested> getNestedList() {
+		return nestedList;
+	}
+
+	public void setNestedList(List<Nested> nestedList) {
+		this.nestedList = nestedList;
 	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
@@ -30,7 +30,7 @@
             "name": "childParam",
             "in": "query",
             "description": "parameter from child of RequestParams",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "string"
             }
@@ -47,7 +47,7 @@
           {
             "name": "stringParam1",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "string"
             }
@@ -86,6 +86,33 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "nested.param1",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nested.param2",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "nestedList",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Nested"
+              }
+            }
           }
         ],
         "responses": {
@@ -96,5 +123,19 @@
       }
     }
   },
-  "components": {}
+  "components": {
+    "schemas": {
+      "Nested": {
+        "type": "object",
+        "properties": {
+          "param1": {
+            "type": "string"
+          },
+          "param2": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Partially fixes #590 

This is partial fix because it does not deal with collections, arrays, and maps. Actually I don't really know how to approach collections just yet.

Support for collections in parameter objects can be added iteratively at later time.

I'd like to also start a discussion about what constitutes a _simple type_ – i.e. a type that is not “exploded” by its nested fields. Obviously all primitives, numbers, strings, optionals, and enums are simple types. For now as simple types are treated also arrays, iterables, and maps.

I think that e.g. `java.time` classes as well as `java.util.Date` _et al._ also deserve status of simple types, but I'd like to know your opinion. In any case, simple types can be adjusted with `SpringDocUtils` builder. Nothing stops a user from adding or removing simple types as they please.