### PR TITLE
Make use of @Deprecated annotations for parameters and model fields

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -53,6 +53,7 @@ import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
 import org.apache.commons.lang3.StringUtils;
+import org.springdoc.api.AbstractOpenApiResource;
 import org.springdoc.core.customizers.ParameterCustomizer;
 
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
@@ -337,6 +338,10 @@ public abstract class AbstractRequestBuilder {
 
 		if (required != null && parameter.getRequired() == null)
 			parameter.setRequired(required);
+
+		if (AbstractOpenApiResource.containsDeprecatedAnnotation(parameterInfo.getMethodParameter().getParameterAnnotations())) {
+			parameter.setDeprecated(true);
+		}
 
 		if (parameter.getSchema() == null) {
 			Schema<?> schema = parameterBuilder.calculateSchema(components, parameterInfo, null,

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.converters.AdditionalModelsConverter;
+import org.springdoc.core.converters.SchemaPropertyDeprecatingConverter;
 import org.springdoc.core.converters.FileSupportConverter;
 import org.springdoc.core.converters.ModelConverterRegistrar;
 import org.springdoc.core.converters.PropertyCustomizingConverter;
@@ -103,6 +104,13 @@ public class SpringDocConfiguration {
 	@Lazy(false)
 	ResponseSupportConverter responseSupportConverter() {
 		return new ResponseSupportConverter();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Lazy(false)
+	SchemaPropertyDeprecatingConverter schemaPropertyDeprecatingConverter() {
+		return new SchemaPropertyDeprecatingConverter();
 	}
 
 	@Bean

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUtils.java
@@ -18,6 +18,7 @@
 
 package org.springdoc.core;
 
+import java.lang.annotation.Annotation;
 import java.util.function.Predicate;
 
 import io.swagger.v3.oas.models.media.Schema;
@@ -36,7 +37,7 @@ public class SpringDocUtils {
 		return springDocConfig;
 	}
 
-	public SpringDocUtils addDeprecatedType(Class<?> cls) {
+	public SpringDocUtils addDeprecatedType(Class<? extends Annotation> cls) {
 		AbstractOpenApiResource.addDeprecatedType(cls);
 		return this;
 	}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/SchemaPropertyDeprecatingConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/SchemaPropertyDeprecatingConverter.java
@@ -1,0 +1,23 @@
+package org.springdoc.core.converters;
+
+import java.util.Iterator;
+
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.media.Schema;
+import org.springdoc.api.AbstractOpenApiResource;
+
+public class SchemaPropertyDeprecatingConverter implements ModelConverter {
+	@Override
+	public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+		if (chain.hasNext()) {
+			Schema<?> resolvedSchema = chain.next().resolve(type, context, chain);
+			if (type.isSchemaProperty() && AbstractOpenApiResource.containsDeprecatedAnnotation(type.getCtxAnnotations())) {
+				resolvedSchema.setDeprecated(true);
+			}
+			return resolvedSchema;
+		}
+		return null;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemDTO.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemDTO.java
@@ -45,6 +45,9 @@ public class ItemDTO implements Serializable {
 	 */
 	private int price;
 
+	@Deprecated
+	private int deprecatedPrice;
+
 	/**
 	 *
 	 */
@@ -113,4 +116,11 @@ public class ItemDTO implements Serializable {
 		this.price = price;
 	}
 
+	public int getDeprecatedPrice() {
+		return deprecatedPrice;
+	}
+
+	public void setDeprecatedPrice(int deprecatedPrice) {
+		this.deprecatedPrice = deprecatedPrice;
+	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemLightDTO.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemLightDTO.java
@@ -40,6 +40,9 @@ public class ItemLightDTO implements Serializable {
 	 */
 	private int price;
 
+	@Deprecated
+	private int deprecatedPrice;
+
 	/**
 	 *
 	 */
@@ -80,4 +83,11 @@ public class ItemLightDTO implements Serializable {
 		this.price = price;
 	}
 
+	public int getDeprecatedPrice() {
+		return deprecatedPrice;
+	}
+
+	public void setDeprecatedPrice(int deprecatedPrice) {
+		this.deprecatedPrice = deprecatedPrice;
+	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app102/RequestParams.java
@@ -13,6 +13,7 @@ public class RequestParams {
 	@Parameter(description = "string parameter")
 	private String stringParam;
 
+	@Deprecated
 	private String stringParam1;
 
 	@Parameter(description = "string parameter2", required = true)

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
@@ -561,6 +561,23 @@
           }
         }
       },
+      "ItemLightDTO": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deprecatedPrice": {
+            "type": "integer",
+            "format": "int32",
+            "deprecated": true
+          }
+        }
+      },
       "ItemDTO": {
         "type": "object",
         "properties": {
@@ -573,18 +590,11 @@
           "price": {
             "type": "integer",
             "format": "int32"
-          }
-        }
-      },
-      "ItemLightDTO": {
-        "type": "object",
-        "properties": {
-          "description": {
-            "type": "string"
           },
-          "price": {
+          "deprecatedPrice": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "deprecated": true
           }
         }
       },

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app102.json
@@ -48,6 +48,7 @@
             "name": "stringParam1",
             "in": "query",
             "required": false,
+            "deprecated": true,
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
Currently `@Deprecated` annotation affects only whole API operations.

Within this PR I'm introducing a mechanism to mark model attributes and operation parameters as deprecated as well, using the standard `@Deprecated` annotation.