### PR TITLE
Update CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -88,7 +88,7 @@ then select the root `build.gradle` file to import the code.
 
 Alternatively, you can let IntellIJ IDEA checkout the code for you. Use "`File`" ->
 "`New`" -> "`Project from Version Control`" and
-`https://github.com/spring-projects/spring-boot` for the URL. Once the checkout has
+`https://github.com/springdoc/springdoc-openapi.git` for the URL. Once the checkout has
 completed, a pop-up will suggest to open the project.
 
 


### PR DESCRIPTION
Hey,

I wanted to contribute to the project, so I have started reading the CONTRIBUTING doc. I believe I've found small mistake there. When I was following instructions regarding setting up the IDE, I noticed that the URL for the repo points to the Spring Boot repository, not this one.

Cheers,
Maciej