### PR TITLE
Marker interface for swagger ui index transformer

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerIndexTransformer.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerIndexTransformer.java
@@ -31,6 +31,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.Constants;
 import org.springdoc.core.SwaggerUiConfigProperties;
 import org.springdoc.core.SwaggerUiOAuthProperties;
+import org.springframework.core.io.Resource;
+import org.springframework.util.CollectionUtils;
 
 /**
  * The type Abstract swagger index transformer.
@@ -108,5 +110,22 @@ public class AbstractSwaggerIndexTransformer {
 	 */
 	protected String overwriteSwaggerDefaultUrl(String html) {
 		return html.replace(Constants.SWAGGER_UI_DEFAULT_URL, StringUtils.EMPTY);
+	}
+
+	protected boolean hasDefaultTransformations() {
+		boolean oauth2Configured = !CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters());
+		return oauth2Configured || swaggerUiConfig.isDisableSwaggerDefaultUrl();
+	}
+
+	protected String defaultTransformations(InputStream inputStream) throws IOException {
+		String html = readFullyAsString(inputStream);
+		if (!CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters())) {
+			html = addInitOauth(html);
+		}
+		if (swaggerUiConfig.isDisableSwaggerDefaultUrl()) {
+			html = overwriteSwaggerDefaultUrl(html);
+		}
+
+		return html;
 	}
 }

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
@@ -69,7 +69,7 @@ public class SwaggerConfig {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	SwaggerIndexTransformer indexPageTransformer(SwaggerUiConfigProperties swaggerUiConfig, SwaggerUiOAuthProperties swaggerUiOAuthProperties, ObjectMapper objectMapper) {
+	SwaggerIndexPageTransformer indexPageTransformer(SwaggerUiConfigProperties swaggerUiConfig, SwaggerUiOAuthProperties swaggerUiOAuthProperties, ObjectMapper objectMapper) {
 		return new SwaggerIndexTransformer(swaggerUiConfig, swaggerUiOAuthProperties, objectMapper);
 	}
 
@@ -82,7 +82,7 @@ public class SwaggerConfig {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	SwaggerWebMvcConfigurer swaggerWebMvcConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerIndexTransformer swaggerIndexTransformer) {
+	SwaggerWebMvcConfigurer swaggerWebMvcConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerIndexPageTransformer swaggerIndexTransformer) {
 		return new SwaggerWebMvcConfigurer(swaggerUiConfigParameters, swaggerIndexTransformer);
 	}
 

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexPageTransformer.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexPageTransformer.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2019-2020 the original author or authors.
+ *  *  *
+ *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  * you may not use this file except in compliance with the License.
+ *  *  * You may obtain a copy of the License at
+ *  *  *
+ *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the License for the specific language governing permissions and
+ *  *  * limitations under the License.
+ *  *
+ *
+ */
+
+package org.springdoc.webmvc.ui;
+
+import org.springframework.web.servlet.resource.ResourceTransformer;
+
+/**
+ * The type Swagger index page transformer.
+ * @author pverdage
+ */
+public interface SwaggerIndexPageTransformer extends ResourceTransformer {
+
+}

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexTransformer.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexTransformer.java
@@ -57,20 +57,9 @@ public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer imp
 			ResourceTransformerChain transformerChain) throws IOException {
 		final AntPathMatcher antPathMatcher = new AntPathMatcher();
 		boolean isIndexFound = antPathMatcher.match("**/swagger-ui/**/index.html", resource.getURL().toString());
-		if (isIndexFound && !CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters()) && swaggerUiConfig.isDisableSwaggerDefaultUrl()) {
-			String html = readFullyAsString(resource.getInputStream());
-			html = addInitOauth(html);
-			html = overwriteSwaggerDefaultUrl(html);
-			return new TransformedResource(resource, html.getBytes());
-		}
-		else if (isIndexFound && !CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters())) {
-			String html = readFullyAsString(resource.getInputStream());
-			html = addInitOauth(html);
-			return new TransformedResource(resource, html.getBytes());
-		}
-		else if (isIndexFound && swaggerUiConfig.isDisableSwaggerDefaultUrl()) {
-			String html = readFullyAsString(resource.getInputStream());
-			html = overwriteSwaggerDefaultUrl(html);
+
+		if (isIndexFound && hasDefaultTransformations()) {
+			String html = defaultTransformations(resource.getInputStream());
 			return new TransformedResource(resource, html.getBytes());
 		}
 		else

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexTransformer.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerIndexTransformer.java
@@ -32,7 +32,6 @@ import org.springdoc.ui.AbstractSwaggerIndexTransformer;
 import org.springframework.core.io.Resource;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.servlet.resource.ResourceTransformer;
 import org.springframework.web.servlet.resource.ResourceTransformerChain;
 import org.springframework.web.servlet.resource.TransformedResource;
 
@@ -40,7 +39,7 @@ import org.springframework.web.servlet.resource.TransformedResource;
  * The type Swagger index transformer.
  * @author bnasslahsen
  */
-public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer implements ResourceTransformer {
+public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer implements SwaggerIndexPageTransformer {
 
 	/**
 	 * Instantiates a new Swagger index transformer.

--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
@@ -44,7 +44,7 @@ public class SwaggerWebMvcConfigurer extends WebMvcConfigurerAdapter { // NOSONA
 	/**
 	 * The Swagger index transformer.
 	 */
-	private SwaggerIndexTransformer swaggerIndexTransformer;
+	private SwaggerIndexPageTransformer swaggerIndexTransformer;
 
 	/**
 	 * Instantiates a new Swagger web mvc configurer.
@@ -52,7 +52,7 @@ public class SwaggerWebMvcConfigurer extends WebMvcConfigurerAdapter { // NOSONA
 	 * @param swaggerUiConfigParameters the swagger ui calculated config
 	 * @param swaggerIndexTransformer the swagger index transformer
 	 */
-	public SwaggerWebMvcConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerIndexTransformer swaggerIndexTransformer) {
+	public SwaggerWebMvcConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerIndexPageTransformer swaggerIndexTransformer) {
 		this.swaggerPath = swaggerUiConfigParameters.getPath();
 		this.swaggerIndexTransformer = swaggerIndexTransformer;
 	}

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
@@ -56,7 +56,7 @@ public class SwaggerConfig implements WebFluxConfigurer {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	SwaggerWebFluxConfigurer swaggerWebFluxConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SpringDocConfigProperties springDocConfigProperties, SwaggerIndexTransformer swaggerIndexTransformer) {
+	SwaggerWebFluxConfigurer swaggerWebFluxConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SpringDocConfigProperties springDocConfigProperties, SwaggerIndexPageTransformer swaggerIndexTransformer) {
 		return new SwaggerWebFluxConfigurer(swaggerUiConfigParameters, springDocConfigProperties, swaggerIndexTransformer);
 	}
 
@@ -70,7 +70,7 @@ public class SwaggerConfig implements WebFluxConfigurer {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	SwaggerIndexTransformer indexPageTransformer(SwaggerUiConfigProperties swaggerUiConfig ,SwaggerUiOAuthProperties swaggerUiOAuthProperties, ObjectMapper objectMapper) {
+	SwaggerIndexPageTransformer indexPageTransformer(SwaggerUiConfigProperties swaggerUiConfig ,SwaggerUiOAuthProperties swaggerUiOAuthProperties, ObjectMapper objectMapper) {
 		return new SwaggerIndexTransformer(swaggerUiConfig, swaggerUiOAuthProperties, objectMapper);
 	}
 

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexPageTransformer.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexPageTransformer.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2019-2020 the original author or authors.
+ *  *  *
+ *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  * you may not use this file except in compliance with the License.
+ *  *  * You may obtain a copy of the License at
+ *  *  *
+ *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the License for the specific language governing permissions and
+ *  *  * limitations under the License.
+ *  *
+ *
+ */
+
+package org.springdoc.webflux.ui;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springdoc.core.SwaggerUiConfigProperties;
+import org.springdoc.core.SwaggerUiOAuthProperties;
+import org.springdoc.ui.AbstractSwaggerIndexTransformer;
+import org.springdoc.ui.SpringDocUIException;
+import reactor.core.publisher.Mono;
+
+import org.springframework.core.io.Resource;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.reactive.resource.ResourceTransformer;
+import org.springframework.web.reactive.resource.ResourceTransformerChain;
+import org.springframework.web.reactive.resource.TransformedResource;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * The type Swagger index transformer.
+ * @author pverdage
+ */
+public interface SwaggerIndexPageTransformer extends ResourceTransformer {
+
+}

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexTransformer.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexTransformer.java
@@ -54,23 +54,11 @@ public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer imp
 	@Override
 	public Mono<Resource> transform(ServerWebExchange serverWebExchange, Resource resource, ResourceTransformerChain resourceTransformerChain) {
 		final AntPathMatcher antPathMatcher = new AntPathMatcher();
-		boolean isIndexFound = false;
+
 		try {
-			isIndexFound = antPathMatcher.match("**/swagger-ui/**/index.html", resource.getURL().toString());
-			if (isIndexFound && !CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters()) && swaggerUiConfig.isDisableSwaggerDefaultUrl()) {
-				String html = readFullyAsString(resource.getInputStream());
-				html = addInitOauth(html);
-				html = overwriteSwaggerDefaultUrl(html);
-				return Mono.just(new TransformedResource(resource, html.getBytes()));
-			}
-			else if (isIndexFound && !CollectionUtils.isEmpty(swaggerUiOAuthProperties.getConfigParameters())) {
-				String html = readFullyAsString(resource.getInputStream());
-				html = addInitOauth(html);
-				return Mono.just(new TransformedResource(resource, html.getBytes()));
-			}
-			else if (isIndexFound && swaggerUiConfig.isDisableSwaggerDefaultUrl()) {
-				String html = readFullyAsString(resource.getInputStream());
-				html = overwriteSwaggerDefaultUrl(html);
+			boolean isIndexFound = antPathMatcher.match("**/swagger-ui/**/index.html", resource.getURL().toString());
+			if (isIndexFound && hasDefaultTransformations()) {
+				String html = defaultTransformations(resource.getInputStream());
 				return Mono.just(new TransformedResource(resource, html.getBytes()));
 			}
 			else {

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexTransformer.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerIndexTransformer.java
@@ -30,7 +30,6 @@ import reactor.core.publisher.Mono;
 import org.springframework.core.io.Resource;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.reactive.resource.ResourceTransformer;
 import org.springframework.web.reactive.resource.ResourceTransformerChain;
 import org.springframework.web.reactive.resource.TransformedResource;
 import org.springframework.web.server.ServerWebExchange;
@@ -39,7 +38,7 @@ import org.springframework.web.server.ServerWebExchange;
  * The type Swagger index transformer.
  * @author bnasslahsen
  */
-public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer implements ResourceTransformer {
+public class SwaggerIndexTransformer extends AbstractSwaggerIndexTransformer implements SwaggerIndexPageTransformer {
 
 	/**
 	 * Instantiates a new Swagger index transformer.

--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
@@ -49,7 +49,7 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 	/**
 	 * The Swagger index transformer.
 	 */
-	private SwaggerIndexTransformer swaggerIndexTransformer;
+	private SwaggerIndexPageTransformer swaggerIndexTransformer;
 
 	/**
 	 * Instantiates a new Swagger web flux configurer.
@@ -58,7 +58,7 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 	 * @param springDocConfigProperties the spring doc config properties
 	 * @param swaggerIndexTransformer the swagger index transformer
 	 */
-	public SwaggerWebFluxConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SpringDocConfigProperties springDocConfigProperties, SwaggerIndexTransformer swaggerIndexTransformer) {
+	public SwaggerWebFluxConfigurer(SwaggerUiConfigParameters swaggerUiConfigParameters, SpringDocConfigProperties springDocConfigProperties, SwaggerIndexPageTransformer swaggerIndexTransformer) {
 		this.swaggerPath = swaggerUiConfigParameters.getPath();
 		this.webJarsPrefixUrl = springDocConfigProperties.getWebjars().getPrefix();
 		this.swaggerIndexTransformer = swaggerIndexTransformer;


### PR DESCRIPTION
close #745

as explained [here](https://github.com/springdoc/springdoc-openapi/issues/745#issuecomment-651041778) it eases providing a custom SwaggerIndexTransformer by introducing an intermediary interface.

@bnasslahsen please note the 2nd commit. I factorized some behavior in the abstract class. The rationale is that if you have to duplicate this in mvc and reactive implementations then application creating a new transformation (for instance the [linked example](https://github.com/springdoc/springdoc-openapi/issues/745#issuecomment-651041778)) will face the same issue and may have to rewrite same code.
If you're not comfortable with it I don't mind dropping this part; since you have `overwriteSwaggerDefaultUrl` and  `addInitOauth` I supposed we can add other methods related to the default implementation.

Since you rely on integration tests I did not add specific unit tests on the autoconfiguration but I can if you wish (I've done a few lately so it won't take long)