### PR TITLE
New configuration properties

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -89,6 +89,7 @@ import static org.springdoc.core.converters.SchemaPropertyDeprecatingConverter.i
 /**
  * The type Abstract open api resource.
  * @author bnasslahsen
+ * @author Maciej Kopeć
  */
 public abstract class AbstractOpenApiResource extends SpecFilter {
 
@@ -215,16 +216,26 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 * @param classes the classes
 	 */
 	public static void addHiddenRestControllers(String... classes) {
-		Set<Class<?>> hiddenClasses =new HashSet<>();
+		Set<Class<?>> hiddenClasses = new HashSet<>();
 		for (String aClass : classes) {
 			try {
 				hiddenClasses.add(Class.forName(aClass));
 			}
 			catch (ClassNotFoundException e) {
-				LOGGER.warn("The following class doesn't exist and cannot be hidden: {}",  aClass);
+				LOGGER.warn("The following class doesn't exist and cannot be hidden: {}", aClass);
 			}
 		}
 		HIDDEN_REST_CONTROLLERS.addAll(hiddenClasses);
+	}
+
+	/**
+	 * Is hidden rest controllers boolean.
+	 *
+	 * @param rawClass the raw class
+	 * @return the boolean
+	 */
+	public static boolean isHiddenRestControllers(Class<?> rawClass) {
+		return HIDDEN_REST_CONTROLLERS.stream().anyMatch(clazz -> clazz.isAssignableFrom(rawClass));
 	}
 
 	/**
@@ -252,7 +263,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			// run the optional customisers
 			openApiCustomisers.ifPresent(apiCustomisers -> apiCustomisers.forEach(openApiCustomiser -> openApiCustomiser.customise(openApi)));
 			if (!CollectionUtils.isEmpty(openApi.getServers()))
-				openAPIBuilder.setServersPresent(true);
+				openAPIBuilder.setServersPresent(!springDocConfigProperties.isAlwaysAddGeneratedServer());
 			openAPIBuilder.updateServers(openApi);
 
 			if (springDocConfigProperties.isRemoveBrokenReferenceDefinitions())
@@ -588,16 +599,6 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 */
 	protected boolean isAdditionalRestController(Class<?> rawClass) {
 		return ADDITIONAL_REST_CONTROLLERS.stream().anyMatch(clazz -> clazz.isAssignableFrom(rawClass));
-	}
-
-	/**
-	 * Is hidden rest controllers boolean.
-	 *
-	 * @param rawClass the raw class
-	 * @return the boolean
-	 */
-	public static boolean isHiddenRestControllers(Class<?> rawClass) {
-		return HIDDEN_REST_CONTROLLERS.stream().anyMatch(clazz -> clazz.isAssignableFrom(rawClass));
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIBuilder.java
@@ -49,6 +49,7 @@ import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,7 @@ import static org.springdoc.core.Constants.DEFAULT_VERSION;
 /**
  * The type Open api builder.
  * @author bnasslahsen
+ * @author Maciej Kopeć
  */
 public class OpenAPIBuilder {
 
@@ -223,10 +225,15 @@ public class OpenAPIBuilder {
 	public OpenAPI updateServers(OpenAPI openAPI) {
 		if (!isServersPresent)        // default server value
 		{
-			Server server = new Server().url(serverBaseUrl).description(DEFAULT_SERVER_DESCRIPTION);
-			List<Server> servers = new ArrayList();
-			servers.add(server);
-			openAPI.setServers(servers);
+			final Server generatedServer = new Server()
+					.url(serverBaseUrl + springDocConfigProperties.getGeneratedServerSuffix())
+					.description(DEFAULT_SERVER_DESCRIPTION);
+
+			final List<Server> servers = ObjectUtils.defaultIfNull(openAPI.getServers(), new ArrayList<>());
+
+			if (!servers.contains(generatedServer)) {
+				openAPI.addServersItem(generatedServer);
+			}
 		}
 		return openAPI;
 	}

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -34,6 +34,7 @@ import static org.springdoc.core.Constants.SPRINGDOC_ENABLED;
 /**
  * The type Spring doc config properties.
  * @author bnasslahsen
+ * @author Maciej Kopeć
  */
 @Configuration
 @ConfigurationProperties(prefix = Constants.SPRINGDOC_PREFIX)
@@ -119,6 +120,16 @@ public class SpringDocConfigProperties {
 	 * The Default produces media type.
 	 */
 	private String defaultProducesMediaType = MediaType.ALL_VALUE;
+
+	/**
+	 * Always add a generated server to server's list
+	 */
+	private boolean alwaysAddGeneratedServer = false;
+
+	/**
+	 * Add a suffix to a generated server's host.
+	 */
+	private String generatedServerSuffix = "";
 
 	/**
 	 * Is auto tag classes boolean.
@@ -424,6 +435,22 @@ public class SpringDocConfigProperties {
 	 */
 	public void setWriterWithDefaultPrettyPrinter(boolean writerWithDefaultPrettyPrinter) {
 		this.writerWithDefaultPrettyPrinter = writerWithDefaultPrettyPrinter;
+	}
+
+	public boolean isAlwaysAddGeneratedServer() {
+		return alwaysAddGeneratedServer;
+	}
+
+	public void setAlwaysAddGeneratedServer(boolean alwaysAddGeneratedServer) {
+		this.alwaysAddGeneratedServer = alwaysAddGeneratedServer;
+	}
+
+	public String getGeneratedServerSuffix() {
+		return generatedServerSuffix;
+	}
+
+	public void setGeneratedServerSuffix(String generatedServerSuffix) {
+		this.generatedServerSuffix = generatedServerSuffix;
 	}
 
 	/**

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app124/SpringDocApp124Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app124/SpringDocApp124Test.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app124;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static test.org.springdoc.api.app124.SpringDocTestApp.SERVER_HOSTNAME;
+
+/**
+ * @author Maciej Kopeć
+ */
+@TestPropertySource(properties = "springdoc.always-add-generated-server=true")
+public class SpringDocApp124Test extends AbstractSpringDocTest {
+
+	@Test
+	public void testAlwaysAddGeneratedServer() throws Exception {
+		mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.openapi", is("3.0.1")))
+				.andExpect(jsonPath("$.servers", hasSize(2)))
+				.andExpect(jsonPath("$.servers[0].url", is(SERVER_HOSTNAME)))
+				.andExpect(jsonPath("$.servers[1].url", is("http://localhost")));
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app124/SpringDocTestApp.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app124/SpringDocTestApp.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app124;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * @author Maciej Kopeć
+ */
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	public static final String SERVER_HOSTNAME = "https:://hostname.org/";
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringDocTestApp.class, args);
+	}
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+				.addServersItem(
+						new Server()
+								.url(SERVER_HOSTNAME)
+								.description("Super API")
+				);
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app125/SpringDocApp125Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app125/SpringDocApp125Test.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app125;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author Maciej Kopeć
+ */
+@TestPropertySource(properties = "springdoc.generated-server-suffix=/suffix")
+public class SpringDocApp125Test extends AbstractSpringDocTest {
+
+	@Test
+	public void testAddSuffixToGeneratedServer() throws Exception {
+		mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.openapi", is("3.0.1")))
+				.andExpect(jsonPath("$.servers", hasSize(1)))
+				.andExpect(jsonPath("$.servers[0].url", is("http://localhost/suffix")));
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app125/SpringDocTestApp.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app125/SpringDocTestApp.java
@@ -1,0 +1,33 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app125;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * @author Maciej Kopeć
+ */
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	public static void main(String[] args) {
+		SpringApplication.run(SpringDocTestApp.class, args);
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app124.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app124.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url":"https:://hostname.org/",
+      "description":"Super API"
+    },
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {},
+  "components": {}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app125.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app125.json
@@ -1,0 +1,15 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost/suffix",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {},
+  "components": {}
+}


### PR DESCRIPTION
Hey,

In my project, we run into the following challenges when using this awesome library:
1) We wanted to have the possibility to add a generated server to the server's list even if we've already defined a list of our own servers. Reson why is this important in our case is the following. We have a set of well-known environments (dev, stage, perf, pre-prod, and prod). However, on top of those, some of our teams have their own instances. Obviously, we don't want to keep list of all of them in our swagger documentation, but at the same time, it is extremely useful for those teams to use Swagger UI and have ability to send requests to their instance. 

This issue address first new property, called `alwaysAddGeneratedServer`

2) One of our standards requires to remove common suffixes from endpoints, e.g.:
instead of:
`/cms/posts/`
`/cms/categories/`
we should define our hostname as: `http://hostname/cms` and then endpoints should be define as follow:
`/posts`
`/categories`

Because of this, we couldn't just add a prefix to the endpoints, but we need possibility to add a suffix to the server. This is addressed by the new property: `generatedServerSuffix `

Both properties are optional. 