### PR TITLE
support oauth2 pre-selected scopes

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiOAuthProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiOAuthProperties.java
@@ -21,6 +21,7 @@
 package org.springdoc.core;
 
 
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -28,6 +29,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
 
 import static org.springdoc.core.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
 
@@ -84,6 +86,11 @@ public class SwaggerUiOAuthProperties {
 	private Boolean usePkceWithAuthorizationCodeGrant;
 
 	/**
+	 * The Scopes selected by default upon authentication.
+	 */
+	private List<String> scopes;
+
+	/**
 	 * Gets config parameters.
 	 *
 	 * @return the config parameters
@@ -95,6 +102,9 @@ public class SwaggerUiOAuthProperties {
 		SpringDocPropertiesUtils.put("realm", realm, params);
 		SpringDocPropertiesUtils.put("scopeSeparator", scopeSeparator, params);
 		SpringDocPropertiesUtils.put("appName", appName, params);
+		if (!CollectionUtils.isEmpty(scopes)) {
+			SpringDocPropertiesUtils.put("scopes", String.join(" ", scopes), params);
+		}
 		SpringDocPropertiesUtils.put("useBasicAuthenticationWithAccessCodeGrant", useBasicAuthenticationWithAccessCodeGrant, params);
 		SpringDocPropertiesUtils.put("usePkceWithAuthorizationCodeGrant", usePkceWithAuthorizationCodeGrant, params);
 		SpringDocPropertiesUtils.put("additionalQueryStringParams", additionalQueryStringParams, params);
@@ -243,5 +253,23 @@ public class SwaggerUiOAuthProperties {
 	 */
 	public void setUsePkceWithAuthorizationCodeGrant(Boolean usePkceWithAuthorizationCodeGrant) {
 		this.usePkceWithAuthorizationCodeGrant = usePkceWithAuthorizationCodeGrant;
+	}
+
+	/**
+	 * Get the pre-selected scopes during authentication.
+	 *
+	 * @return the pre-selected scopes during authentication
+	 */
+	public List<String> getScopes() {
+		return scopes;
+	}
+
+	/**
+	 * Sets the pre-selected scopes during authentication.
+	 *
+	 * @param scopes the pre-selected scopes during authentication
+	 */
+	public void setScopes(List<String> scopes) {
+		this.scopes = scopes;
 	}
 }

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
@@ -32,7 +32,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @TestPropertySource(properties = { "springdoc.swagger-ui.oauth.clientId=myClientId",
 		"springdoc.swagger-ui.oauth.additionalQueryStringParams.test1=test1",
-		"springdoc.swagger-ui.oauth.additionalQueryStringParams.test2=test2" })
+		"springdoc.swagger-ui.oauth.additionalQueryStringParams.test2=test2",
+		"springdoc.swagger-ui.oauth.scopes=scope1,scope2" })
 public class SpringDocApp7Test extends AbstractSpringDocTest {
 
 	@Test

--- a/springdoc-openapi-ui/src/test/resources/results/app7
+++ b/springdoc-openapi-ui/src/test/resources/results/app7
@@ -55,7 +55,7 @@
 
       window.ui = ui
 ui.initOAuth(
-{"additionalQueryStringParams":{"test1":"test1","test2":"test2"},"clientId":"myClientId"})
+{"additionalQueryStringParams":{"test1":"test1","test2":"test2"},"clientId":"myClientId","scopes":"scope1 scope2"})
     }
   </script>
   </body>

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocApp5Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocApp5Test.java
@@ -28,7 +28,7 @@ import org.springframework.test.web.reactive.server.EntityExchangeResult;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@TestPropertySource(properties = "springdoc.swagger-ui.oauth.clientId=myClientId")
+@TestPropertySource(properties = {"springdoc.swagger-ui.oauth.clientId=myClientId", "springdoc.swagger-ui.oauth.scopes=scope1,scope2"})
 public class SpringDocApp5Test extends AbstractSpringDocTest {
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/resources/results/index5
+++ b/springdoc-openapi-webflux-ui/src/test/resources/results/index5
@@ -55,7 +55,7 @@
 
       window.ui = ui
 ui.initOAuth(
-{"clientId":"myClientId"})
+{"clientId":"myClientId","scopes":"scope1 scope2"})
     }
   </script>
   </body>


### PR DESCRIPTION
Builds upon https://github.com/swagger-api/swagger-ui/pull/6037 to support pre-selected scopes during OAuth authentication.

Swagger UI feature was released in [swagger-ui 3.26.1](https://github.com/swagger-api/swagger-ui/releases/tag/v3.26.1) so no upgrade needed to use this feature. 

## Tests
- the link PR shows UI behavior
- I added unit tests for servlet and reactive modes (property is a list, written in JS as space separated)
- I manually tested the result

![image](https://user-images.githubusercontent.com/3100914/88527119-22752700-cffd-11ea-9420-23526fc3dfcc.png)
