### PR TITLE
Allow swagger-ui property filter to be an empty string

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
@@ -139,8 +139,9 @@ public abstract class AbstractSwaggerWelcome implements InitializingBean {
 			uriBuilder.queryParam(SwaggerUiConfigParameters.CONFIG_URL_PROPERTY, swaggerUiConfigParameters.getConfigUrl());
 			if (StringUtils.isNotEmpty(swaggerUiConfigParameters.getLayout()))
 				uriBuilder.queryParam(SwaggerUiConfigParameters.LAYOUT_PROPERTY, swaggerUiConfigParameters.getLayout());
-			if (StringUtils.isNotEmpty(swaggerUiConfigParameters.getFilter()))
+			if (swaggerUiConfigParameters.getFilter() != null) {
 				uriBuilder.queryParam(SwaggerUiConfigParameters.FILTER_PROPERTY, swaggerUiConfigParameters.getFilter());
+			}
 		}
 		return uriBuilder;
 	}


### PR DESCRIPTION
At the moment if we set the swagger-ui property filter to `true` then it is not working as expected.
I already reported this to the swagger-ui team at:
https://github.com/swagger-api/swagger-ui/issues/6276
We should be able to set the filter property to empty string because in that case the filter is working properly.