### PR TITLE
Add pre-loading setting to load OpenAPI early

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonView;
@@ -200,6 +201,10 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			operationCustomizers.get().removeIf(Objects::isNull);
 		this.operationCustomizers = operationCustomizers;
 		this.actuatorProvider = actuatorProvider;
+		if (springDocConfigProperties.isPreLoadingEnabled()) {
+			Executors.newSingleThreadExecutor()
+					.execute(this::getOpenApi);
+		}
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -131,6 +131,11 @@ public class SpringDocConfigProperties {
 	private boolean showLoginEndpoint;
 
 	/**
+	 * Allow for pre-loading OpenAPI
+	 */
+	private boolean preLoadingEnabled = false;
+
+	/**
 	 * Is use fqn boolean.
 	 *
 	 * @return the boolean
@@ -470,6 +475,14 @@ public class SpringDocConfigProperties {
 	 */
 	public void setWriterWithDefaultPrettyPrinter(boolean writerWithDefaultPrettyPrinter) {
 		this.writerWithDefaultPrettyPrinter = writerWithDefaultPrettyPrinter;
+	}
+
+	public void setPreLoadingEnabled(boolean preLoadingEnabled) {
+		this.preLoadingEnabled = preLoadingEnabled;
+	}
+
+	public boolean isPreLoadingEnabled() {
+		return preLoadingEnabled;
 	}
 
 	/**


### PR DESCRIPTION
Add configuration setting to `SpringDocConfigProperties` to enable pre-loading of OpenAPI. This setting is false by default. When instantiating `AbstractOpenApiResource` the OpenAPI is generated in a separate thread. Fixes #850