### PR TITLE
Prevent API component schema description from being overwritten Fixes #852

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericParameterBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericParameterBuilder.java
@@ -304,7 +304,10 @@ public class GenericParameterBuilder {
 			if (schemaN.get$ref() != null && schemaN.get$ref().contains(AnnotationsUtils.COMPONENTS_REF)) {
 				String key = schemaN.get$ref().substring(21);
 				Schema existingSchema = components.getSchemas().get(key);
-				existingSchema.setDescription(description);
+
+				if (StringUtils.isEmpty(existingSchema.getDescription())) {
+					existingSchema.setDescription(description);
+				}
 			}
 			else
 				schemaN.setDescription(description);


### PR DESCRIPTION
This fixes #852 by only overwriting the shared schema description if one is not already present.