### PR TITLE
Spring Security support out of the box

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestBuilder.java
@@ -130,6 +130,11 @@ public abstract class AbstractRequestBuilder {
 		PARAM_TYPES_TO_IGNORE.add(SessionStatus.class);
 		PARAM_TYPES_TO_IGNORE.add(UriComponentsBuilder.class);
 		PARAM_TYPES_TO_IGNORE.add(RequestAttribute.class);
+		try {
+			PARAM_TYPES_TO_IGNORE.add(Class.forName("org.springframework.security.core.Authentication"));
+		} catch (ClassNotFoundException e) {
+			// Spring security not present
+		}
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
@@ -73,6 +73,11 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 	static {
 		ANNOTATIONS_TO_IGNORE.add(Hidden.class);
 		ANNOTATIONS_TO_IGNORE.add(RequestAttribute.class);
+		try {
+			ANNOTATIONS_TO_IGNORE.add(Class.forName("org.springframework.security.core.annotation.AuthenticationPrincipal"));
+		} catch (ClassNotFoundException e) {
+			// Spring security not present
+		}
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ConverterUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ConverterUtils.java
@@ -57,6 +57,14 @@ public class ConverterUtils {
 		RESULT_WRAPPERS_TO_IGNORE.add(CompletionStage.class);
 	}
 
+	static {
+		try {
+			RESPONSE_TYPES_TO_IGNORE.add(Class.forName("org.springframework.security.core.Authentication"));
+		} catch (ClassNotFoundException e) {
+			// Spring security not present
+		}
+	}
+
 	/**
 	 * Instantiates a new Converter utils.
 	 */

--- a/springdoc-openapi-security/src/main/java/org/springdoc/security/SpringDocSecurityConfiguration.java
+++ b/springdoc-openapi-security/src/main/java/org/springdoc/security/SpringDocSecurityConfiguration.java
@@ -64,12 +64,6 @@ import static org.springdoc.core.SpringDocUtils.getConfig;
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 public class SpringDocSecurityConfiguration {
 
-	static {
-		getConfig().addRequestWrapperToIgnore(Authentication.class)
-				.addResponseTypeToIgnore(Authentication.class)
-				.addAnnotationsToIgnore(AuthenticationPrincipal.class);
-	}
-
 	/**
 	 * The type Spring security o auth 2 provider configuration.
 	 * @author bnasslahsen


### PR DESCRIPTION
It would be easier if Springdoc does not need extra dependencies to support standard Spring Security conventions