### PR TITLE
Fix syntax highlight configuration sub-properties

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractSwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractSwaggerUiConfigProperties.java
@@ -155,7 +155,7 @@ public abstract class AbstractSwaggerUiConfigProperties {
 	/**
 	 * The Syntax highlight.
 	 */
-	protected SyntaxHighlight syntaxHighlight;
+	protected final SyntaxHighlight syntaxHighlight = new SyntaxHighlight();
 
 	/**
 	 * Gets syntax highlight.
@@ -164,15 +164,6 @@ public abstract class AbstractSwaggerUiConfigProperties {
 	 */
 	public SyntaxHighlight getSyntaxHighlight() {
 		return syntaxHighlight;
-	}
-
-	/**
-	 * Sets syntax highlight.
-	 *
-	 * @param syntaxHighlight the syntax highlight
-	 */
-	public void setSyntaxHighlight(SyntaxHighlight syntaxHighlight) {
-		this.syntaxHighlight = syntaxHighlight;
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -50,12 +50,12 @@ public class SpringDocConfigProperties {
 	/**
 	 * The Webjars.
 	 */
-	private Webjars webjars = new Webjars();
+	private final Webjars webjars = new Webjars();
 
 	/**
 	 * The Api docs.
 	 */
-	private ApiDocs apiDocs = new ApiDocs();
+	private final ApiDocs apiDocs = new ApiDocs();
 
 	/**
 	 * The Packages to scan.
@@ -95,7 +95,7 @@ public class SpringDocConfigProperties {
 	/**
 	 * The Cache.
 	 */
-	private Cache cache = new Cache();
+	private final Cache cache = new Cache();
 
 	/**
 	 * The Group configs.
@@ -366,30 +366,12 @@ public class SpringDocConfigProperties {
 	}
 
 	/**
-	 * Sets webjars.
-	 *
-	 * @param webjars the webjars
-	 */
-	public void setWebjars(Webjars webjars) {
-		this.webjars = webjars;
-	}
-
-	/**
 	 * Gets api docs.
 	 *
 	 * @return the api docs
 	 */
 	public ApiDocs getApiDocs() {
 		return apiDocs;
-	}
-
-	/**
-	 * Sets api docs.
-	 *
-	 * @param apiDocs the api docs
-	 */
-	public void setApiDocs(ApiDocs apiDocs) {
-		this.apiDocs = apiDocs;
 	}
 
 	/**
@@ -417,15 +399,6 @@ public class SpringDocConfigProperties {
 	 */
 	public Cache getCache() {
 		return cache;
-	}
-
-	/**
-	 * Sets cache.
-	 *
-	 * @param cache the cache
-	 */
-	public void setCache(Cache cache) {
-		this.cache = cache;
 	}
 
 	/**
@@ -598,7 +571,7 @@ public class SpringDocConfigProperties {
 		/**
 		 * The Deprecating converter.
 		 */
-		private DeprecatingConverter deprecatingConverter = new DeprecatingConverter();
+		private final DeprecatingConverter deprecatingConverter = new DeprecatingConverter();
 
 		/**
 		 * Gets deprecating converter.
@@ -607,15 +580,6 @@ public class SpringDocConfigProperties {
 		 */
 		public DeprecatingConverter getDeprecatingConverter() {
 			return deprecatingConverter;
-		}
-
-		/**
-		 * Sets deprecating converter.
-		 *
-		 * @param deprecatingConverter the deprecating converter
-		 */
-		public void setDeprecatingConverter(DeprecatingConverter deprecatingConverter) {
-			this.deprecatingConverter = deprecatingConverter;
 		}
 
 		/**
@@ -700,7 +664,7 @@ public class SpringDocConfigProperties {
 		/**
 		 * The Groups.
 		 */
-		private Groups groups = new Groups();
+		private final Groups groups = new Groups();
 
 		/**
 		 * Gets path.
@@ -745,15 +709,6 @@ public class SpringDocConfigProperties {
 		 */
 		public Groups getGroups() {
 			return groups;
-		}
-
-		/**
-		 * Sets groups.
-		 *
-		 * @param groups the groups
-		 */
-		public void setGroups(Groups groups) {
-			this.groups = groups;
 		}
 
 		/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
@@ -58,7 +58,7 @@ public class SwaggerUiConfigProperties extends AbstractSwaggerUiConfigProperties
 	/**
 	 * The Csrf configuration.
 	 */
-	private Csrf csrf = new Csrf();
+	private final Csrf csrf = new Csrf();
 
 	/**
 	 * Whether to generate and serve an OpenAPI document.
@@ -219,15 +219,6 @@ public class SwaggerUiConfigProperties extends AbstractSwaggerUiConfigProperties
 	 */
 	public Csrf getCsrf() {
 		return csrf;
-	}
-
-	/**
-	 * Sets csrf.
-	 *
-	 * @param csrf the csrf
-	 */
-	public void setCsrf(Csrf csrf) {
-		this.csrf = csrf;
 	}
 
 	/**


### PR DESCRIPTION
Expose `springdoc.swagger-ui.syntax-highlight.theme` and `springdoc.swagger-ui.syntax-highlight.activate` configuration properties.

May fix #948