### PR TITLE
Typesave serialization of openapi spec

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -109,6 +109,7 @@ import static org.springdoc.core.converters.SchemaPropertyDeprecatingConverter.i
 /**
  * The type Abstract open api resource.
  * @author bnasslahsen
+ * @author kevinraddatz
  */
 public abstract class AbstractOpenApiResource extends SpecFilter {
 
@@ -1033,9 +1034,9 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		YAMLFactory factory = (YAMLFactory) objectMapper.getFactory();
 		factory.configure(Feature.USE_NATIVE_TYPE_ID, false);
 		if (!springDocConfigProperties.isWriterWithDefaultPrettyPrinter())
-			result = objectMapper.writeValueAsString(openAPI);
+			result = objectMapper.writerFor(OpenAPI.class).writeValueAsString(openAPI);
 		else
-			result = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
+			result = objectMapper.writerWithDefaultPrettyPrinter().forType(OpenAPI.class).writeValueAsString(openAPI);
 		return result;
 	}
 
@@ -1096,9 +1097,9 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		if (springDocConfigProperties.isWriterWithOrderByKeys())
 			sortOutput(objectMapper);
 		if (!springDocConfigProperties.isWriterWithDefaultPrettyPrinter())
-			result = objectMapper.writeValueAsString(openAPI);
+			result = objectMapper.writerFor(OpenAPI.class).writeValueAsString(openAPI);
 		else
-			result = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(openAPI);
+			result = objectMapper.writerWithDefaultPrettyPrinter().forType(OpenAPI.class).writeValueAsString(openAPI);
 		return result;
 	}
 


### PR DESCRIPTION
I was trying to integrate spring cloud config into our project and used the openAPI() bean for testing.
```java
@Bean
@RefreshScope
public OpenAPI openAPI() {
    return new OpenAPI()
        .info(new Info()
                    .title("title)
                    .description("description")
                    .version("1.0.0")
         );
}
```

By default spring uses the proxy method `TARGET_CLASS` to generate a refreshScope bean which adds multiple properties which will be serialized by the objectMapper. Serialization of those properties results in an infinite loop and thus in a StackOverflowError.

With these changes the openAPI object will be serialized for the OpenAPI class, ignoring the properties added by spring.