### PR TITLE
Add explode support in combination with arrayShema annotation

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericParameterService.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericParameterService.java
@@ -54,9 +54,11 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
+import static java.util.Objects.isNull;
+
 /**
  * The type Generic parameter builder.
- * @author bnasslahsen
+ * @author bnasslahsen, coutin
  */
 @SuppressWarnings("rawtypes")
 public class GenericParameterService {
@@ -397,9 +399,10 @@ public class GenericParameterService {
 	 */
 	private boolean isExplodable(io.swagger.v3.oas.annotations.Parameter p) {
 		io.swagger.v3.oas.annotations.media.Schema schema = p.schema();
+		io.swagger.v3.oas.annotations.media.ArraySchema arraySchema = p.array();
 		boolean explode = true;
 		Class<?> implementation = schema.implementation();
-		if (implementation == Void.class && !schema.type().equals("object") && !schema.type().equals("array")) {
+		if (implementation == Void.class && !schema.type().equals("object") && !schema.type().equals("array") && isNull(arraySchema)) {
 			explode = false;
 		}
 		return explode;

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app1/ItemController.java
@@ -28,7 +28,9 @@ import javax.validation.Valid;
 import javax.validation.constraints.Size;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.Explode;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -47,7 +49,8 @@ public class ItemController {
 	@GetMapping("/items")
 	public List<ItemDTO> showItems(@RequestParam("cusID") @Size(min = 4, max = 6) final String customerID,
 			@Size(min = 4, max = 6) int toto,
-			@Parameter(name = "start", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "string", format = "date-time", required = false, example = "1970-01-01T00:00:00.000Z")) @RequestParam(value = "start", required = false) Instant startDate) {
+			@Parameter(name = "start", in = ParameterIn.QUERY, required = false, schema = @Schema(type = "string", format = "date-time", required = false, example = "1970-01-01T00:00:00.000Z")) @RequestParam(value = "start", required = false) Instant startDate,
+			@Parameter(name = "filterIds", in = ParameterIn.QUERY, array = @ArraySchema(schema = @Schema(type = "string")), explode = Explode.FALSE) @RequestParam(required = false) List<String> filterIds) {
 		return new ArrayList<ItemDTO>();
 	}
 

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app1.json
@@ -230,6 +230,18 @@
               "format": "date-time",
               "example": "1970-01-01T00:00:00.000Z"
             }
+          },
+          {
+            "name": "filterIds",
+            "in": "query",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
Fix #984 

This add supports to explode open api attribute for array query parameters using the arraySchema annotation.