### PR TITLE
Fix NPE when using management port and spring.application.name is set

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ActuatorProvider.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ActuatorProvider.java
@@ -30,6 +30,7 @@ import org.springdoc.api.AbstractOpenApiResource;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.web.context.WebServerApplicationContext;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.boot.web.server.WebServer;
 import org.springframework.context.ApplicationContext;
@@ -102,12 +103,11 @@ public abstract class ActuatorProvider  implements ApplicationListener<WebServer
 
 	@Override
 	public void onApplicationEvent(WebServerInitializedEvent event) {
-		if ("application".equals(event.getApplicationContext().getId())) {
-			applicationWebServer = event.getWebServer();
-		}
-		else if ("application:management".equals(event.getApplicationContext().getId())) {
+		if (WebServerApplicationContext.hasServerNamespace(event.getApplicationContext(), "management")) {
 			managementApplicationContext = event.getApplicationContext();
 			actuatorWebServer = event.getWebServer();
+		} else {
+			applicationWebServer = event.getWebServer();
 		}
 	}
 


### PR DESCRIPTION
The previous code attempts to differentiate between the application and the management servers by comparing event.getApplicationContext().getId(). This ID does contain the value of the spring.application.name property though. This property defaults to "application" and thus the IDs default to "application" and "application:management". The previous code does look for these default values. But this means that ActuatorProvider isn't initialized properly when spring.application.name is not set to the default value but to the application's name.

This fix checks the server namespace instead.

Fixes #996