### PR TITLE
Feature/forward query params when redirecting to swagger UI

### DIFF
--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
@@ -30,6 +30,10 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 		buildConfigUrl(request.getContextPath(), ServletUriComponentsBuilder.fromCurrentContextPath());
 		String sbUrl =   swaggerUiConfigParameters.getUiRootPath() + SWAGGER_UI_URL;
 		UriComponentsBuilder uriBuilder = getUriComponentsBuilder(sbUrl);
+
+		// forward all queryParams from original request
+		request.getParameterMap().forEach(uriBuilder::queryParam);
+
 		return UrlBasedViewResolver.REDIRECT_URL_PREFIX + uriBuilder.build().encode().toString();
 	}
 

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java
@@ -19,34 +19,33 @@
 package test.org.springdoc.ui.app1;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import test.org.springdoc.ui.AbstractSpringDocTest;
 
-import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.test.web.servlet.MvcResult;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 public class SpringDocApp1Test extends AbstractSpringDocTest {
 
-	@Test
-	public void shouldDisplaySwaggerUiPage() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui/index.html")).andExpect(status().isOk()).andReturn();
-		String contentAsString = mvcResult.getResponse().getContentAsString();
-		assertTrue(contentAsString.contains("Swagger UI"));
-	}
+    @Test
+    public void shouldDisplaySwaggerUiPage() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Swagger UI")));
+    }
 
-	@Test
-	public void originalIndex() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui/index.html")).andExpect(status().isOk()).andReturn();
-		String transformedIndex = mvcResult.getResponse().getContentAsString();
-		assertTrue(transformedIndex.contains("Swagger UI"));
-		assertEquals(getExpectedResult(), transformedIndex);
-	}
+    @Test
+    public void originalIndex() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Swagger UI")))
+                .andExpect(content().string(getExpectedResult()));
+    }
 
-	@SpringBootApplication
-	static class SpringDocTestApp {}
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
 }

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocConfigPathsTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocConfigPathsTest.java
@@ -19,31 +19,32 @@
 package test.org.springdoc.ui.app1;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = {
-		"springdoc.swagger-ui.path=/test/swagger.html",
-		"server.servlet.context-path=/context-path",
-		"spring.mvc.servlet.path=/servlet-path"
+        "springdoc.swagger-ui.path=/test/swagger.html",
+        "server.servlet.context-path=/context-path",
+        "spring.mvc.servlet.path=/servlet-path"
 })
 public class SpringDocConfigPathsTest extends AbstractSpringDocTest {
 
-	@Test
-	public void should_display_swaggerui_page() throws Exception {
-		mockMvc.perform(get("/context-path/servlet-path/test/swagger.html").contextPath("/context-path").servletPath("/servlet-path")).andExpect(status().isFound()).andReturn();
-		MvcResult mvcResult = mockMvc.perform(get("/context-path/servlet-path/test/swagger-ui/index.html").contextPath("/context-path").servletPath("/servlet-path")).andExpect(status().isOk()).andReturn();
-		String contentAsString = mvcResult.getResponse().getContentAsString();
-		assertTrue(contentAsString.contains("Swagger UI"));
-	}
+    @Test
+    public void should_display_swaggerui_page() throws Exception {
+        mockMvc.perform(get("/context-path/servlet-path/test/swagger.html").contextPath("/context-path").servletPath("/servlet-path"))
+                .andExpect(status().isFound());
+        mockMvc.perform(get("/context-path/servlet-path/test/swagger-ui/index.html").contextPath("/context-path").servletPath("/servlet-path"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("Swagger UI")));
+    }
 
-	@SpringBootApplication
-	static class SpringDocTestApp {}
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
 }

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectConfigUrlTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectConfigUrlTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = {
@@ -37,11 +38,9 @@ public class SpringDocRedirectConfigUrlTest extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?configUrl=/foo/bar", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?configUrl=/foo/bar"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectDefaultTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectDefaultTest.java
@@ -26,17 +26,16 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class SpringDocRedirectDefaultTest extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithDefaultQueryParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectFilterTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectFilterTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "springdoc.swagger-ui.filter=false")
@@ -34,11 +35,9 @@ public class SpringDocRedirectFilterTest extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&filter=false", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&filter=false"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectLayoutTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectLayoutTest.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "springdoc.swagger-ui.layout=BaseLayout")
@@ -34,11 +35,9 @@ public class SpringDocRedirectLayoutTest extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&layout=BaseLayout", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&layout=BaseLayout"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectOriginalQueryParamsTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectOriginalQueryParamsTest.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app1;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class SpringDocRedirectOriginalQueryParamsTest extends AbstractSpringDocTest {
+
+    @Test
+    public void shouldRedirectWithOriginalQueryParams() throws Exception {
+        mockMvc.perform(get("/swagger-ui.html").queryParam("paramA", "123").queryParam("paramB", "e n c o d e d ! % &"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location",
+                        "/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&paramA=123&paramB=e%20n%20c%20o%20d%20e%20d%20!%20%25%20%26"));
+    }
+
+    @Test
+    public void shouldRedirectWithOriginalQueryParamsHavingMultipleValues() throws Exception {
+        mockMvc.perform(get("/swagger-ui.html").queryParam("paramA", "1", "2", "3"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location",
+                        "/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&paramA=1&paramA=2&paramA=3"));
+    }
+
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
+
+}

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectQueryParams1Test.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectQueryParams1Test.java
@@ -27,6 +27,7 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "springdoc.swagger-ui.display-query-params-without-oauth2=true")
@@ -34,11 +35,9 @@ public class SpringDocRedirectQueryParams1Test extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithQueryParamsWithoutOauth2() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?url=/v3/api-docs", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?url=/v3/api-docs"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectQueryParams2Test.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectQueryParams2Test.java
@@ -19,14 +19,12 @@
 package test.org.springdoc.ui.app1;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @TestPropertySource(properties = "springdoc.swagger-ui.display-query-params=true")
@@ -34,11 +32,9 @@ public class SpringDocRedirectQueryParams2Test extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithQueryParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?oauth2RedirectUrl=http://localhost/swagger-ui/oauth2-redirect.html&url=/v3/api-docs", locationHeader);
+        mockMvc.perform(get("/swagger-ui.html"))
+                .andExpect(status().isFound())
+                .andExpect(header().string("Location", "/swagger-ui/index.html?oauth2RedirectUrl=http://localhost/swagger-ui/oauth2-redirect.html&url=/v3/api-docs"));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectWithConfigTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocRedirectWithConfigTest.java
@@ -19,17 +19,13 @@
 package test.org.springdoc.ui.app1;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.validatorUrl=/foo/validate",
@@ -39,14 +35,12 @@ public class SpringDocRedirectWithConfigTest extends AbstractSpringDocTest {
 
 	@Test
 	public void shouldRedirectWithConfiguredParams() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get("/swagger-ui.html"))
-				.andExpect(status().isFound()).andReturn();
-
-		String locationHeader = mvcResult.getResponse().getHeader("Location");
-		assertEquals("/swagger-ui/index.html?configUrl=/baf/batz/swagger-config", locationHeader);
+		mockMvc.perform(get("/swagger-ui.html"))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/swagger-ui/index.html?configUrl=/baf/batz/swagger-config"));
 
 		mockMvc.perform(get("/baf/batz/swagger-config"))
-				.andExpect(status().isOk()).andExpect(jsonPath("$.validatorUrl", is("/foo/validate"))).andReturn();
+				.andExpect(status().isOk()).andExpect(jsonPath("$.validatorUrl", is("/foo/validate")));
 
 	}
 


### PR DESCRIPTION
This would allow to link to one of multiple api-groups in the swagger-ui using the redirect in SwaggerWelcome:

```
https://localhost:8443/swagger-ui.html?urls.primaryName=my-group-2
```

which would now redirect to 

```
https://localhost:8443/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&urls.primaryName=my-group-2
```

fixes https://github.com/springdoc/springdoc-openapi/issues/1013