### PR TITLE
Respect the springdoc.cache.disabled setting for recalculating oauth2 redirect url

### DIFF
--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
@@ -16,6 +16,8 @@ import org.springframework.web.util.UriComponentsBuilder;
 import static org.springdoc.core.Constants.SWAGGER_UI_URL;
 
 public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
+	private String originalRelativeOauth2RedirectUrl;
+
 	/**
 	 * Instantiates a new Abstract swagger welcome.
 	 *  @param swaggerUiConfig the swagger ui config
@@ -28,7 +30,7 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 
 	protected String redirectToUi(HttpServletRequest request) {
 		buildConfigUrl(request.getContextPath(), ServletUriComponentsBuilder.fromCurrentContextPath());
-		String sbUrl =   swaggerUiConfigParameters.getUiRootPath() + SWAGGER_UI_URL;
+		String sbUrl = swaggerUiConfigParameters.getUiRootPath() + SWAGGER_UI_URL;
 		UriComponentsBuilder uriBuilder = getUriComponentsBuilder(sbUrl);
 
 		// forward all queryParams from original request
@@ -44,7 +46,11 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 
 	@Override
 	protected void calculateOauth2RedirectUrl(UriComponentsBuilder uriComponentsBuilder) {
-		if (!swaggerUiConfigParameters.isValidUrl(swaggerUiConfigParameters.getOauth2RedirectUrl()))
+		if (!swaggerUiConfigParameters.isValidUrl(swaggerUiConfigParameters.getOauth2RedirectUrl())) {
+			originalRelativeOauth2RedirectUrl = swaggerUiConfigParameters.getOauth2RedirectUrl();
 			swaggerUiConfigParameters.setOauth2RedirectUrl(uriComponentsBuilder.path(swaggerUiConfigParameters.getUiRootPath()).path(swaggerUiConfigParameters.getOauth2RedirectUrl()).build().toString());
+		} else if (springDocConfigProperties.isCacheDisabled() && originalRelativeOauth2RedirectUrl != null) {
+			swaggerUiConfigParameters.setOauth2RedirectUrl(uriComponentsBuilder.path(swaggerUiConfigParameters.getUiRootPath()).path(originalRelativeOauth2RedirectUrl).build().toString());
+		}
 	}
 }

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocOauthRedirectUrlRecalculateTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocOauthRedirectUrlRecalculateTest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app5;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {"server.forward-headers-strategy=framework", "springdoc.cache.disabled=true"})
+public class SpringDocOauthRedirectUrlRecalculateTest extends AbstractSpringDocTest {
+
+	@Test
+	public void oauth2_redirect_url_recalculation() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/swagger-config").header("X-Forwarded-Proto", "https").header("X-Forwarded-Host", "host1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("oauth2RedirectUrl", equalTo("https://host1/swagger-ui/oauth2-redirect.html")));
+
+		mockMvc.perform(get("/v3/api-docs/swagger-config").header("X-Forwarded-Proto", "http").header("X-Forwarded-Host", "host2:8080"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("oauth2RedirectUrl", equalTo("http://host2:8080/swagger-ui/oauth2-redirect.html")));
+	}
+
+	@SpringBootApplication
+	static class SpringDocTestApp {
+	}
+
+}


### PR DESCRIPTION
This pull request causes the oauth2 redirect url to be recalculated when the springdoc.cache.disabled setting is true, and the url was relative to begin with.

When springdoc is reachable under multiple host-names (e.g. through proxies & direct), the authentication-redirect-url always contains the host that was generated the first time for that specific instance. This PR will recalculate the url every time, when it was originally relative, and the configuration setting to disable caching is set (same behaviour as the generated server url in the api-docs). A unit-test was also added, to ensure this behaviour.

Legal notices below, as per company policy (sorry):
The program was tested solely for our own use cases, which might differ from yours.

Florian Roks \<florian.roks@daimler.com\>, Daimler TSS GmbH
[Imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)

Licensed under APL-2
