### PR TITLE
Fix certain `WebConversionServiceProvider#convert` calls by supplying contextual information

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterInfo.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterInfo.java
@@ -26,6 +26,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -101,7 +102,7 @@ public class ParameterInfo {
 		if (this.defaultValue !=null && !ValueConstants.DEFAULT_NONE.equals(this.defaultValue.toString())){
 			this.defaultValue = propertyResolverUtils.resolve(this.defaultValue.toString());
 			parameterBuilder.getOptionalWebConversionServiceProvider()
-					.ifPresent(conversionService ->this.defaultValue= conversionService.convert(this.defaultValue, methodParameter.getParameterType()));
+					.ifPresent(conversionService ->this.defaultValue= conversionService.convert(this.defaultValue, new TypeDescriptor(methodParameter)));
 		}
 
 		this.required = this.required && !methodParameter.isOptional();

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/WebConversionServiceProvider.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/WebConversionServiceProvider.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.boot.autoconfigure.web.format.DateTimeFormatters;
 import org.springframework.boot.autoconfigure.web.format.WebConversionService;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties.Format;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.lang.Nullable;
 
 /**
@@ -34,15 +35,14 @@ public class WebConversionServiceProvider {
 	}
 
 	/**
-	 * Convert t.
+	 * Attempts to convert {@code source} into the target type as described by {@code targetTypeDescriptor}.
 	 *
-	 * @param <T>  the type parameter
 	 * @param source the source
-	 * @param targetType the target type
-	 * @return the t
+	 * @param targetTypeDescriptor the target type descriptor
+	 * @return the converted source
 	 */
 	@Nullable
-	public <T> T convert(@Nullable Object source, Class<T> targetType) {
-		return webConversionService.convert(source, targetType);
+	public Object convert(@Nullable Object source, TypeDescriptor targetTypeDescriptor) {
+		return webConversionService.convert(source, targetTypeDescriptor);
 	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app150/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app150/HelloController.java
@@ -18,12 +18,16 @@
 
 package test.org.springdoc.api.app150;
 
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE;
+
+import java.time.LocalDate;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -51,6 +55,13 @@ public class HelloController {
 	@ApiResponse(responseCode = "204", description = "No content")
 	@ResponseStatus(value = HttpStatus.NO_CONTENT)
 	public void test3(@RequestParam(defaultValue = "users,123") List<String> toto) {
+
+	}
+
+	@GetMapping("/test4")
+	@ApiResponse(responseCode = "204", description = "No content")
+	@ResponseStatus(value = HttpStatus.NO_CONTENT)
+	public void test4(@DateTimeFormat(iso = DATE) @RequestParam(defaultValue = "2021-03-08") LocalDate localDate) {
 
 	}
 

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app150.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app150.json
@@ -11,6 +11,30 @@
     }
   ],
   "paths": {
+    "/test4": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "test4",
+        "parameters": [
+          {
+            "name": "localDate",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
+    },
     "/test3": {
       "get": {
         "tags": [


### PR DESCRIPTION
This provides contextual information (such as `@DateTimeFormat`) to the `WebConversionService`, such that conversions can be performed correctly. Without passing the `TypeDescriptor` these default values cannot be converted otherwise, and OpenAPI generation will fail altogether.