### PR TITLE
use HTTP 302 status for UI redirect

### DIFF
--- a/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
@@ -75,7 +75,7 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 		String contextPath = this.fromCurrentContextPath(request);
 		String sbUrl = this.buildUrl(contextPath, swaggerUiConfigParameters.getUiRootPath() + springDocConfigProperties.getWebjars().getPrefix() + SWAGGER_UI_URL);
 		UriComponentsBuilder uriBuilder = getUriComponentsBuilder(sbUrl);
-		response.setStatusCode(HttpStatus.TEMPORARY_REDIRECT);
+		response.setStatusCode(HttpStatus.FOUND);
 		response.getHeaders().setLocation(URI.create(uriBuilder.build().encode().toString()));
 		return response.setComplete();
 	}

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirecFilterTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirecFilterTest.java
@@ -31,10 +31,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirecFilterTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
+	public void shouldRedirectWithConfigUrlIgnoringQueryParams() {
 
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&filter=false"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectConfigUrlTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectConfigUrlTest.java
@@ -34,10 +34,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectConfigUrlTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
+	public void shouldRedirectWithConfigUrlIgnoringQueryParams() {
 
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/foo/bar"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
@@ -29,9 +29,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectDefaultTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithDefaultQueryParams() throws Exception {
+	public void shouldRedirectWithDefaultQueryParams() {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectLayoutTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectLayoutTest.java
@@ -31,10 +31,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectLayoutTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithConfigUrlIgnoringQueryParams() throws Exception {
+	public void shouldRedirectWithConfigUrlIgnoringQueryParams() {
 
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config&layout=BaseLayout"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectQueryParams1Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectQueryParams1Test.java
@@ -31,10 +31,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectQueryParams1Test extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithQueryParamsWithoutOauth2() throws Exception {
+	public void shouldRedirectWithQueryParamsWithoutOauth2() {
 
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?url=/v3/api-docs"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectQueryParams2Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectQueryParams2Test.java
@@ -31,10 +31,10 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectQueryParams2Test extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithQueryParams() throws Exception {
+	public void shouldRedirectWithQueryParams() {
 
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?oauth2RedirectUrl=/webjars/swagger-ui/oauth2-redirect.html&url=/v3/api-docs"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
@@ -33,9 +33,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp1RedirectWithConfigTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithConfiguredParams() throws Exception {
+	public void shouldRedirectWithConfiguredParams() {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/webjars/swagger-ui/index.html?configUrl=/baf/batz/swagger-config"));

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1Test.java
@@ -27,9 +27,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class SpringDocApp1Test extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldDisplaySwaggerUiPage() throws Exception {
+	public void shouldDisplaySwaggerUiPage() {
 		webTestClient.get().uri("/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app13/SpringDocApp13Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app13/SpringDocApp13Test.java
@@ -27,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -42,22 +42,21 @@ class SpringDocApp13Test extends AbstractSpringDocActuatorTest {
 	static class SpringDocTestApp {}
 
 	@Test
-	void testIndex() throws Exception {
-
+	void testIndex() {
 		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
-
+		assertThat(getResult.getResponseBody()).isNotNull();
 		String result = new String(getResult.getResponseBody());
-		assertTrue(result.contains("Swagger UI"));
+		assertThat(result).contains("Swagger UI");
 	}
 
 	@Test
 	public void testIndexActuator() {
 		HttpStatus httpStatusMono = webClient.get().uri("/application/swaggerui")
 				.exchangeToMono( clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 	}
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app14/SpringDocApp14Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app14/SpringDocApp14Test.java
@@ -27,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -41,21 +41,21 @@ class SpringDocApp14Test extends AbstractSpringDocActuatorTest {
 
 
 	@Test
-	void testIndex() throws Exception {
+	void testIndex() {
 		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
-
+		assertThat(getResult.getResponseBody()).isNotNull();
 		String contentAsString = new String(getResult.getResponseBody());
-		assertTrue(contentAsString.contains("Swagger UI"));
+		assertThat(contentAsString).contains("Swagger UI");
 	}
 
 	@Test
 	public void testIndexActuator() {
 		HttpStatus httpStatusMono = webClient.get().uri("/application/swaggerui")
 				.exchangeToMono( clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 	}
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app15/SpringDocApp15Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app15/SpringDocApp15Test.java
@@ -27,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -49,15 +49,16 @@ class SpringDocApp15Test extends AbstractSpringDocActuatorTest {
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
+		assertThat(getResult.getResponseBody()).isNotNull();
 		String contentAsString = new String(getResult.getResponseBody());
-		assertTrue(contentAsString.contains("Swagger UI"));
+		assertThat(contentAsString).contains("Swagger UI");
 	}
 
 	@Test
 	public void testIndexActuator() {
 		HttpStatus httpStatusMono = webClient.get().uri("/test/application/swaggerui")
 				.exchangeToMono( clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 	}
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app16/SpringDocApp16Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app16/SpringDocApp16Test.java
@@ -27,7 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -43,20 +43,21 @@ class SpringDocApp16Test extends AbstractSpringDocActuatorTest {
 	static class SpringDocTestApp {}
 
 	@Test
-	void testIndex() throws Exception {
+	void testIndex() {
 		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
+		assertThat(getResult.getResponseBody()).isNotNull();
 		String contentAsString = new String(getResult.getResponseBody());
-		assertTrue(contentAsString.contains("Swagger UI"));
+		assertThat(contentAsString).contains("Swagger UI");
 	}
 
 	@Test
 	public void testIndexActuator() {
 		HttpStatus httpStatusMono = webClient.get().uri("/test/application/swaggerui")
 				.exchangeToMono( clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 	}
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app18/SpringDocApp18Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app18/SpringDocApp18Test.java
@@ -31,7 +31,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -62,11 +62,11 @@ class SpringDocApp18Test extends AbstractCommonTest {
 	public void testIndexActuator() throws Exception {
 		HttpStatus httpStatusMono = webClient.get().uri("/test/documentation/swagger-ui.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
 		httpStatusMono = webClient.get().uri("/test/documentation/webjars-pref/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.OK));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 
 		String contentAsString  = webClient.get().uri("/test/documentation/v3/api-docs/swagger-config").retrieve()
 				.bodyToMono(String.class).block();

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app19/SpringDocApp19Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app19/SpringDocApp19Test.java
@@ -31,7 +31,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -58,11 +58,11 @@ class SpringDocApp19Test extends AbstractCommonTest {
 	public void testIndex() throws Exception {
 		HttpStatus httpStatusMono = webClient.get().uri("/")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
 		httpStatusMono = webClient.get().uri("/webjars/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		assertTrue(httpStatusMono.equals(HttpStatus.OK));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 
 		String contentAsString  = webClient.get().uri("/v3/api-docs/swagger-config").retrieve()
 				.bodyToMono(String.class).block();

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app20/SpringDocApp20Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app20/SpringDocApp20Test.java
@@ -21,7 +21,6 @@ package test.org.springdoc.ui.app20;
 
 import javax.annotation.PostConstruct;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import test.org.springdoc.ui.AbstractCommonTest;
@@ -33,6 +32,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
@@ -58,11 +58,11 @@ class SpringDocApp20Test extends AbstractCommonTest {
 	public void testIndex() throws Exception {
 		HttpStatus httpStatusMono = webClient.get().uri("/test/swagger-ui.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		Assertions.assertTrue(httpStatusMono.equals(HttpStatus.TEMPORARY_REDIRECT));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
 		httpStatusMono = webClient.get().uri("/webjars/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
-		Assertions.assertTrue(httpStatusMono.equals(HttpStatus.OK));
+		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 
 		String contentAsString  = webClient.get().uri("/test/v3/api-docs/swagger-config").retrieve()
 				.bodyToMono(String.class).block();

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectDefaultTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectDefaultTest.java
@@ -34,9 +34,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp3RedirectDefaultTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithDefaultQueryParams() throws Exception {
+	public void shouldRedirectWithDefaultQueryParams() {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/documentation/webjars/swagger-ui/index.html?configUrl=/documentation/v3/api-docs/swagger-config"));
 

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectWithPrefixTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectWithPrefixTest.java
@@ -34,9 +34,9 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 public class SpringDocApp3RedirectWithPrefixTest extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldRedirectWithPrefix() throws Exception {
+	public void shouldRedirectWithPrefix() {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		responseSpec.expectHeader()
 				.value("Location", Matchers.is("/documentation/webjars-pref/swagger-ui/index.html?configUrl=/documentation/v3/api-docs/swagger-config"));
 		webTestClient.get().uri("/documentation/webjars-pref/swagger-ui/index.html").exchange()

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3Test.java
@@ -31,9 +31,9 @@ import org.springframework.test.context.TestPropertySource;
 public class SpringDocApp3Test extends AbstractSpringDocTest {
 
 	@Test
-	public void shouldDisplaySwaggerUiPage() throws Exception {
+	public void shouldDisplaySwaggerUiPage() {
 		webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
-				.expectStatus().isTemporaryRedirect();
+				.expectStatus().isFound();
 		webTestClient.get().uri("/documentation/webjars/swagger-ui/index.html").exchange()
 				.expectStatus().isOk();
 	}


### PR DESCRIPTION
@bnasslahsen 

here is the PR for switching to 302 instead of 307 when using webflux-ui. This PR also contains some cleanups for affected test classes:
- remove never thrown Exceptions from throws list
- remove IntelliJ warning `Argument 'getResult.getResponseBody()' might be null` by asserting to not null
- switch from `org.junit.jupiter.api.Assertions.assertTrue` to `org.assertj.core.api.Assertions.assertThat` for better assertion error output