### PR TITLE
Modify ResponseSupportConverter to resolve inner type

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ResponseSupportConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ResponseSupportConverter.java
@@ -49,12 +49,10 @@ public class ResponseSupportConverter implements ModelConverter {
 				JavaType innerType = javaType.getBindings().getBoundType(0);
 				if (innerType == null)
 					return new StringSchema();
-				else if (innerType.getBindings() != null && isResponseTypeWrapper(innerType.getRawClass())) {
-					type = new AnnotatedType(innerType).jsonViewAnnotation(type.getJsonViewAnnotation()).ctxAnnotations(type.getCtxAnnotations()).resolveAsRef(true);
-					return this.resolve(type, context, chain);
-				}
-				else
-					type = new AnnotatedType(innerType).jsonViewAnnotation(type.getJsonViewAnnotation()).ctxAnnotations((type.getCtxAnnotations())).resolveAsRef(true);
+				return context.resolve(new AnnotatedType(innerType)
+						.jsonViewAnnotation(type.getJsonViewAnnotation())
+						.ctxAnnotations((type.getCtxAnnotations()))
+						.resolveAsRef(true));
 			}
 			else if (isResponseTypeToIgnore(cls))
 				return null;

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/Bar.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/Bar.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app157;
+
+/**
+ * A class without a String in it
+ */
+public class Bar {
+  private Object child;
+
+  public Object getChild() {
+    return this.child;
+  }
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/Foo.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/Foo.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app157;
+
+/**
+ * A class with a String in it
+ */
+public class Foo {
+  private String child;
+
+  public String getChild() {
+    return this.child;
+  }
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/HelloController.java
@@ -1,0 +1,44 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app157;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Put Foo and Bar in the schema's components, make sure there is an ignored wrapper
+ * ({@code ResponseEntity}).
+ */
+@RestController
+public class HelloController {
+
+	@GetMapping( "/foo")
+	public ResponseEntity<Foo> getFoo() {
+		return new ResponseEntity<Foo>(HttpStatus.OK);
+	}
+
+	@GetMapping( "/bar")
+	public ResponseEntity<Bar> getBar() {
+		return new ResponseEntity<Bar>(HttpStatus.OK);
+	}
+
+
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/SpringDocApp157Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/SpringDocApp157Test.java
@@ -1,0 +1,39 @@
+package test.org.springdoc.api.app157;
+
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.util.Json;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import org.springdoc.core.converters.ModelConverterRegistrar;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * This test is to make sure that a new model converter can access the parent of a type, even if
+ * the type is enclosed in an ignored wrapper.  We test this by setting up a model converter which
+ * adds "stringy" to the "required" property of a schema's parent, when the sub schema is a String.
+ */
+public class SpringDocApp157Test extends AbstractSpringDocTest {
+
+  @SpringBootApplication
+  static class SpringBootApp {}
+
+  @Test
+  public void testApp() throws Exception {
+    // Not sure why the converter isn't registered automatically. Register it here.
+    new ModelConverterRegistrar(List.of(new StringyConverter()));
+    mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.openapi", is("3.0.1")))
+        .andExpect(jsonPath("$.components.schemas.Foo.required", is(List.of("stringy"))))
+        .andExpect(jsonPath("$.components.schemas.Bar", not(hasProperty("required"))));
+  }
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/SpringDocApp157Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/SpringDocApp157Test.java
@@ -2,6 +2,10 @@ package test.org.springdoc.api.app157;
 
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.core.util.Json;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.Constants;
 import org.springdoc.core.converters.ModelConverterRegistrar;
@@ -26,10 +30,21 @@ public class SpringDocApp157Test extends AbstractSpringDocTest {
   @SpringBootApplication
   static class SpringBootApp {}
 
+  private StringyConverter myConverter = new StringyConverter();
+  private ModelConverters converters = ModelConverters.getInstance();
+
+  @BeforeEach
+  public void registerConverter() {
+    converters.addConverter(myConverter);
+  }
+
+  @AfterEach
+  public void unregisterConverter() {
+    converters.removeConverter(myConverter);
+  }
+
   @Test
   public void testApp() throws Exception {
-    // Not sure why the converter isn't registered automatically. Register it here.
-    new ModelConverterRegistrar(List.of(new StringyConverter()));
     mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.openapi", is("3.0.1")))

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/StringyConverter.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app157/StringyConverter.java
@@ -1,0 +1,25 @@
+package test.org.springdoc.api.app157;
+
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.Iterator;
+
+public class StringyConverter implements ModelConverter {
+
+  @Override
+  public Schema resolve(AnnotatedType type, ModelConverterContext context,
+    Iterator<ModelConverter> chain) {
+
+    JavaType javaType = Json.mapper().constructType(type.getType());
+
+    if (javaType.getRawClass().equals(String.class)) {
+      type.getParent().addRequiredItem("stringy");
+    }
+    return chain.next().resolve(type, context, chain);
+  }
+}


### PR DESCRIPTION
This makes it so, given a type `IgnoredWrapper<C>` that you're trying to resolve, the fields of `C` will be resolved with `AnnotatedType`s pointing to `C` as the parent, which wasn't happening before.

We are trying to apply properties to the parent schema of some fields, that's the use case for the change.  When the parent is wrapped in some ignored wrapper, this fails due to the current behavior.