### PR TITLE
making kotlin classes open via compilerplugin

### DIFF
--- a/springdoc-openapi-kotlin/pom.xml
+++ b/springdoc-openapi-kotlin/pom.xml
@@ -93,6 +93,18 @@
 						</configuration>
 					</execution>
 				</executions>
+				<configuration>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+				</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
adding the official jetbrains compiler plugin (https://kotlinlang.org/docs/all-open-plugin.html#spring-support) to the pom, which also gets added to spring boot projects by convention via the spring initializer.

this allows to write kotlin code in the same style as is common in spring projects.
