### PR TITLE
Use Publisher as response wrapper to ignore instead of Mono

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ResponseSupportConverter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/converters/ResponseSupportConverter.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.models.media.StringSchema;
 
 import static org.springdoc.core.converters.ConverterUtils.isResponseTypeToIgnore;
 import static org.springdoc.core.converters.ConverterUtils.isResponseTypeWrapper;
+import static org.springdoc.core.converters.ConverterUtils.isFluxTypeWrapper;
 
 /**
  * The type Response support converter.
@@ -45,7 +46,7 @@ public class ResponseSupportConverter implements ModelConverter {
 		JavaType javaType = Json.mapper().constructType(type.getType());
 		if (javaType != null) {
 			Class<?> cls = javaType.getRawClass();
-			if (isResponseTypeWrapper(cls)) {
+			if (isResponseTypeWrapper(cls) && !isFluxTypeWrapper(cls)) {
 				JavaType innerType = javaType.getBindings().getBoundType(0);
 				if (innerType == null)
 					return new StringSchema();

--- a/springdoc-openapi-webflux-core/src/main/java/org/springdoc/webflux/core/converters/WebFluxSupportConverter.java
+++ b/springdoc-openapi-webflux-core/src/main/java/org/springdoc/webflux/core/converters/WebFluxSupportConverter.java
@@ -30,8 +30,8 @@ import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 import static org.springdoc.core.SpringDocUtils.getConfig;
 import static org.springdoc.core.converters.ConverterUtils.isFluxTypeWrapper;
@@ -45,7 +45,7 @@ import static org.springdoc.core.converters.ConverterUtils.isResponseTypeWrapper
 public class WebFluxSupportConverter implements ModelConverter {
 
 	static {
-		getConfig().addResponseWrapperToIgnore(Mono.class)
+		getConfig().addResponseWrapperToIgnore(Publisher.class)
 				.addFluxWrapperToIgnore(Flux.class);
 	}
 

--- a/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app152/HelloController.java
+++ b/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app152/HelloController.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  * Copyright 2019-2021 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app152;
+
+import org.reactivestreams.Publisher;
+import org.springdoc.core.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+public class HelloController {
+
+	@GetMapping("/persons")
+	public Publisher<String> persons() {
+		return Mono.just("OK");
+	}
+
+	@Bean
+	public GroupedOpenApi userOpenApi() {
+		return GroupedOpenApi.builder()
+				.group("users")
+				.packagesToScan("test.org.springdoc.api.app152")
+				.build();
+	}
+}

--- a/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app152/SpringDocApp152Test.java
+++ b/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app152/SpringDocApp152Test.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  *
+ *  *  * Copyright 2019-2021 the original author or authors.
+ *  *  *
+ *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  * you may not use this file except in compliance with the License.
+ *  *  * You may obtain a copy of the License at
+ *  *  *
+ *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *
+ *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  * See the License for the specific language governing permissions and
+ *  *  * limitations under the License.
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.app152;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+public class SpringDocApp152Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	@ComponentScan(basePackages = { "org.springdoc", "test.org.springdoc.api.app152" })
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app146-1.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app146-1.json
@@ -43,7 +43,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -71,7 +71,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -91,7 +91,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -111,7 +111,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -141,7 +141,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -161,7 +161,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -181,7 +181,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -201,7 +201,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -221,7 +221,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -241,7 +241,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -261,7 +261,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -291,7 +291,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -311,7 +311,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -341,7 +341,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -361,7 +361,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -381,7 +381,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -411,7 +411,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -439,7 +439,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -459,7 +459,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -477,7 +477,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -497,7 +497,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -535,9 +535,6 @@
   },
   "components": {
     "schemas": {
-      "PublisherResponseEntityObject": {
-        "type": "object"
-      },
       "Link": {
         "type": "object",
         "properties": {

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app147-1.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app147-1.json
@@ -43,7 +43,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -71,7 +71,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -91,7 +91,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -111,7 +111,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -141,7 +141,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -161,7 +161,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -181,7 +181,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -201,7 +201,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -221,7 +221,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -241,7 +241,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -261,7 +261,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -291,7 +291,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -311,7 +311,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -341,7 +341,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -361,7 +361,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -381,7 +381,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -411,7 +411,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -439,7 +439,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -459,7 +459,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -477,7 +477,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -497,7 +497,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -535,9 +535,6 @@
   },
   "components": {
     "schemas": {
-      "PublisherResponseEntityObject": {
-        "type": "object"
-      },
       "Link": {
         "type": "object",
         "properties": {

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app148-2.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app148-2.json
@@ -43,7 +43,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -71,7 +71,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -91,7 +91,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -111,7 +111,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -141,7 +141,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -161,7 +161,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -181,7 +181,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -201,7 +201,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -221,7 +221,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -241,7 +241,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -261,7 +261,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -291,7 +291,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -311,7 +311,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -341,7 +341,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -361,7 +361,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -381,7 +381,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -411,7 +411,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -439,7 +439,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -459,7 +459,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -477,7 +477,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -497,7 +497,7 @@
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/PublisherResponseEntityObject"
+                  "type": "object"
                 }
               }
             }
@@ -535,9 +535,6 @@
   },
   "components": {
     "schemas": {
-      "PublisherResponseEntityObject": {
-        "type": "object"
-      },
       "Link": {
         "type": "object",
         "properties": {

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app152.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app152.json
@@ -1,0 +1,36 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/persons": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "persons",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}

--- a/springdoc-openapi-webflux-core/src/test/resources/results/app78.json
+++ b/springdoc-openapi-webflux-core/src/test/resources/results/app78.json
@@ -42,17 +42,7 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
-                  }
-                }
-              }
-            }
+            "description": "OK"
           }
         }
       }


### PR DESCRIPTION
More abstract way to cover wrappers since spring supports any Publisher implementation.
My main concern is that Flux is also Publisher implementation and if it could break something.