### PR TITLE
Fixed exception handler order

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIService.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/OpenAPIService.java
@@ -705,7 +705,7 @@ public class OpenAPIService {
 		Map<String, Object> controllerAdviceMap = context.getBeansWithAnnotation(ControllerAdvice.class);
 		return Stream.of(controllerAdviceMap).flatMap(mapEl -> mapEl.entrySet().stream()).filter(
 				controller -> (AnnotationUtils.findAnnotation(controller.getValue().getClass(), Hidden.class) == null))
-				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a1, a2) -> a1));
+				.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a1, a2) -> a1, LinkedHashMap::new));
 	}
 
 	/**

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/GlobalErrorResponseDto.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/GlobalErrorResponseDto.java
@@ -1,0 +1,18 @@
+package test.org.springdoc.api.app166;
+
+public class GlobalErrorResponseDto {
+
+	private String globalMessage;
+
+	public GlobalErrorResponseDto(String globalMessage) {
+		this.globalMessage = globalMessage;
+	}
+
+	public String getGlobalMessage() {
+		return globalMessage;
+	}
+
+	public void setGlobalMessage(String globalMessage) {
+		this.globalMessage = globalMessage;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/GlobalExceptionHandler.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package test.org.springdoc.api.app166;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Component("1") // bean name override to simulate order in HashMap
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus
+	public GlobalErrorResponseDto processException() {
+		return new GlobalErrorResponseDto("global");
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/LocalErrorResponseDto.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/LocalErrorResponseDto.java
@@ -1,0 +1,18 @@
+package test.org.springdoc.api.app166;
+
+public class LocalErrorResponseDto {
+
+	private String localMessage;
+
+	public LocalErrorResponseDto(String localMessage) {
+		this.localMessage = localMessage;
+	}
+
+	public String getLocalMessage() {
+		return localMessage;
+	}
+
+	public void setLocalMessage(String localMessage) {
+		this.localMessage = localMessage;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/SpringDocApp166Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/SpringDocApp166Test.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  * Copyright 2019-2021 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app166;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * In this test, it is checked that the error handler is displayed correctly in the documentation.
+ * Exactly, that the local handler takes precedence over the global one
+ * */
+@TestPropertySource(properties = "springdoc.api-docs.resolve-schema-properties=true")
+public class SpringDocApp166Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {
+	}
+
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/TestApiController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app166/TestApiController.java
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.app166;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Component("0") // bean name override to simulate order in HashMap
+public class TestApiController {
+
+	@GetMapping(value = "/test")
+	public String throwError() {
+		throw new IllegalArgumentException();
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus
+	public LocalErrorResponseDto processException() {
+		return new LocalErrorResponseDto("local");
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app166.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app166.json
@@ -1,0 +1,57 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "tags": [
+          "test-api-controller"
+        ],
+        "operationId": "throwError",
+        "responses": {
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalErrorResponseDto"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "LocalErrorResponseDto": {
+        "type": "object",
+        "properties": {
+          "localMessage": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Hi, I fixed a bug due to which the documentation incorrectly displayed information obtained from the `ExceptionHandler`.
The problem was when there were 2 exception handlers (controller - local and global).

The documentation displayed information from the global, but in the `Spring`, the priority is higher for the local.

The problem was in the method `AbstractOpenApiResource#getOpenApi`. It him combined information about the 'Exception Handler' from the ControllerAdvice and from the controller. But `HashMap` was used as a container for which the order is not guaranteed.

I changed the container type to `LinkedHashMap`.

An [example](https://github.com/bespaltovyj/springdoc-exception-handler-order-bug)of a simple application in which you can check the issue
