### PR TITLE
Make springdoc-openapi-webmvc-core an optional dependency of springdo…

### DIFF
--- a/springdoc-openapi-data-rest/pom.xml
+++ b/springdoc-openapi-data-rest/pom.xml
@@ -32,6 +32,7 @@
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-webmvc-core</artifactId>
 			<version>${project.version}</version>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
…c-openapi-data-rest

springdoc-openapi-webmvc-core brings spring-webmvc in.
Making `ResponseEntityExceptionHandler` to exist and causing a linkage error on missing servlet classes.
https://github.com/springdoc/springdoc-openapi/blob/476b012cb23e93663ffdc87538a94690a5a557cc/springdoc-openapi-common/src/main/java/org/springdoc/core/GenericResponseService.java#L115

Closes https://github.com/springdoc/springdoc-openapi/issues/1357