### PR TITLE
Update classgraph dependency to fix OpenJ9-specific issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 		<swagger-api.version>2.1.12</swagger-api.version>
 		<swagger-ui.version>4.1.3</swagger-ui.version>
 		<spring-security-oauth2.version>2.3.8.RELEASE</spring-security-oauth2.version>
-		<classgraph.version>4.8.117</classgraph.version>
+		<classgraph.version>4.8.138</classgraph.version>
 		<webjars-locator-core.version>0.45</webjars-locator-core.version>
 		<gmavenplus-plugin.version>1.8.1</gmavenplus-plugin.version>
 		<jaxb-impl.version>2.1</jaxb-impl.version>


### PR DESCRIPTION
I was running my Spring-Boot 2.6.2 application which uses Springdoc-OpenAPI version 1.6.3, with this relevant part of the dependency tree:
```
[INFO] |  +- org.springdoc:springdoc-openapi-common:jar:1.6.3:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-models:jar:2.1.12:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-annotations:jar:2.1.12:compile
[INFO] |  |  +- io.swagger.core.v3:swagger-integration:jar:2.1.12:compile
[INFO] |  |  |  \- io.swagger.core.v3:swagger-core:jar:2.1.12:compile
[INFO] |  |  \- io.github.classgraph:classgraph:jar:4.8.117:compile
[INFO] |  |     \- io.github.toolfactory:jvm-driver:jar:4.0.0:compile
[INFO] |  |        \- io.github.toolfactory:narcissus:jar:1.0.1:compile
```

and I hit the following exception on application startup:
```
2021-12-31T14:05:00.278773161Z 2021-12-31 14:05:00 ERROR [my-service-name,,,] 1  ---[           main]o.s.boot.SpringApplication               : Application run failed
2021-12-31T14:05:00.278803143Z org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'resourceHandlerMapping' defined in class path resource [org/springframework/boot/autoconfigure/web/servlet/WebMvcAutoConfiguration$EnableWebMvcConfiguration.class]: Bean instantiation via factory method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.web.servlet.HandlerMapping]: Factory method 'resourceHandlerMapping' threw exception; nested exception is java.lang.ExceptionInInitializerError
2021-12-31T14:05:00.278809820Z 	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:658)
2021-12-31T14:05:00.278814365Z 	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:638)
2021-12-31T14:05:00.278818851Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1352)
2021-12-31T14:05:00.278823111Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1195)
2021-12-31T14:05:00.278827296Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582)
2021-12-31T14:05:00.278831339Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542)
2021-12-31T14:05:00.278835496Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335)
2021-12-31T14:05:00.278839450Z 	at <unknown class>.getObject(Unknown Source)
2021-12-31T14:05:00.278843430Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234)
2021-12-31T14:05:00.278847406Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333)
2021-12-31T14:05:00.278851398Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208)
2021-12-31T14:05:00.278856145Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:953)
2021-12-31T14:05:00.278860163Z 	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:918)
2021-12-31T14:05:00.278877488Z 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
2021-12-31T14:05:00.278881572Z 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:145)
2021-12-31T14:05:00.278885643Z 	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:730)
2021-12-31T14:05:00.278889378Z 	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:412)
2021-12-31T14:05:00.278893203Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:302)
2021-12-31T14:05:00.278896927Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1301)
2021-12-31T14:05:00.278900882Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1290)
2021-12-31T14:05:00.278904625Z 	at com.oliverlockwood.MyApplication.main(Application.java:56)
2021-12-31T14:05:00.278908350Z 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2021-12-31T14:05:00.278912143Z 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2021-12-31T14:05:00.278915921Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2021-12-31T14:05:00.278919844Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2021-12-31T14:05:00.278923501Z 	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
2021-12-31T14:05:00.278927349Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
2021-12-31T14:05:00.278931018Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
2021-12-31T14:05:00.278934728Z 	at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:88)
2021-12-31T14:05:00.278938514Z Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.web.servlet.HandlerMapping]: Factory method 'resourceHandlerMapping' threw exception; nested exception is java.lang.ExceptionInInitializerError
2021-12-31T14:05:00.278942972Z 	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:185)
2021-12-31T14:05:00.278946977Z 	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:653)
2021-12-31T14:05:00.278951483Z 	... 28 common frames omitted
2021-12-31T14:05:00.278955137Z Caused by: java.lang.ExceptionInInitializerError: null
2021-12-31T14:05:00.278958783Z 	at java.lang.J9VMInternals.ensureError(J9VMInternals.java:145)
2021-12-31T14:05:00.278962471Z 	at java.lang.J9VMInternals.recordInitializationFailure(J9VMInternals.java:134)
2021-12-31T14:05:00.278966244Z 	at io.github.classgraph.ModulePathInfo.<init>(ModulePathInfo.java:136)
2021-12-31T14:05:00.278970133Z 	at nonapi.io.github.classgraph.scanspec.ScanSpec.<init>(ScanSpec.java:231)
2021-12-31T14:05:00.278982545Z 	at io.github.classgraph.ClassGraph.<init>(ClassGraph.java:67)
2021-12-31T14:05:00.278986533Z 	at org.webjars.WebJarAssetLocator.<init>(WebJarAssetLocator.java:150)
2021-12-31T14:05:00.278990285Z 	at org.springframework.web.servlet.resource.WebJarsResourceResolver.<init>(WebJarsResourceResolver.java:61)
2021-12-31T14:05:00.278993977Z 	at org.springframework.web.servlet.config.annotation.ResourceChainRegistration.getResourceResolvers(ResourceChainRegistration.java:114)
2021-12-31T14:05:00.278997916Z 	at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration.getRequestHandler(ResourceHandlerRegistration.java:215)
2021-12-31T14:05:00.279002053Z 	at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getRequestHandler(ResourceHandlerRegistry.java:178)
2021-12-31T14:05:00.279006947Z 	at org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry.getHandlerMapping(ResourceHandlerRegistry.java:168)
2021-12-31T14:05:00.279010956Z 	at org.springframework.web.servlet.config.annotation.WebMvcConfigurationSupport.resourceHandlerMapping(WebMvcConfigurationSupport.java:599)
2021-12-31T14:05:00.279014998Z 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2021-12-31T14:05:00.279018704Z 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
2021-12-31T14:05:00.279022538Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2021-12-31T14:05:00.279026460Z 	at java.lang.reflect.Method.invoke(Method.java:498)
2021-12-31T14:05:00.279030211Z 	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
2021-12-31T14:05:00.279034246Z 	... 29 common frames omitted
2021-12-31T14:05:00.279037899Z Caused by: io.github.toolfactory.jvm.Driver$InitializationException: Could not initiliaze DefaultDriver
2021-12-31T14:05:00.279041736Z 	at io.github.toolfactory.jvm.DefaultDriver.throwException(DefaultDriver.java:324)
2021-12-31T14:05:00.279045584Z 	at io.github.toolfactory.jvm.DefaultDriver.<init>(DefaultDriver.java:121)
2021-12-31T14:05:00.279049966Z 	at nonapi.io.github.classgraph.utils.ReflectionUtils.<clinit>(ReflectionUtils.java:48)
2021-12-31T14:05:00.279053953Z 	... 44 common frames omitted
2021-12-31T14:05:00.279057603Z Caused by: io.github.toolfactory.jvm.ObjectProvider$BuildingException: Unable to build the related object of io.github.toolfactory.jvm.function.catalog.DefineHookClassFunction
2021-12-31T14:05:00.279069549Z 	at io.github.toolfactory.jvm.ObjectProvider.getOrBuildObject(ObjectProvider.java:57)
2021-12-31T14:05:00.279073453Z 	at io.github.toolfactory.jvm.DefaultDriver.initHookClassDefiner(DefaultDriver.java:304)
2021-12-31T14:05:00.279077244Z 	at io.github.toolfactory.jvm.DefaultDriver.<init>(DefaultDriver.java:103)
2021-12-31T14:05:00.279081172Z 	... 45 common frames omitted
2021-12-31T14:05:00.279089099Z Caused by: java.lang.reflect.InvocationTargetException: null
2021-12-31T14:05:00.279092948Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2021-12-31T14:05:00.279096793Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2021-12-31T14:05:00.279100701Z 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2021-12-31T14:05:00.279104828Z 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
2021-12-31T14:05:00.279108535Z 	at io.github.toolfactory.jvm.ObjectProvider.getOrBuildObject(ObjectProvider.java:51)
2021-12-31T14:05:00.279112410Z 	... 47 common frames omitted
2021-12-31T14:05:00.279116029Z Caused by: io.github.toolfactory.jvm.ObjectProvider$BuildingException: Unable to build the related object of io.github.toolfactory.jvm.function.catalog.ConsulterSupplier
2021-12-31T14:05:00.279120051Z 	at io.github.toolfactory.jvm.ObjectProvider.getOrBuildObject(ObjectProvider.java:57)
2021-12-31T14:05:00.279123924Z 	at io.github.toolfactory.jvm.function.catalog.DefineHookClassFunction$ForJava7.<init>(DefineHookClassFunction.java:62)
2021-12-31T14:05:00.279127986Z 	... 52 common frames omitted
2021-12-31T14:05:00.279131804Z Caused by: java.lang.reflect.InvocationTargetException: null
2021-12-31T14:05:00.279135470Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
2021-12-31T14:05:00.279139277Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
2021-12-31T14:05:00.279143154Z 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
2021-12-31T14:05:00.279147050Z 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
2021-12-31T14:05:00.279150854Z 	at io.github.toolfactory.jvm.ObjectProvider.getOrBuildObject(ObjectProvider.java:51)
2021-12-31T14:05:00.279154958Z 	... 53 common frames omitted
2021-12-31T14:05:00.279158532Z Caused by: java.lang.NoSuchFieldException: allowedModes
2021-12-31T14:05:00.279162635Z 	at java.lang.Class.getDeclaredFieldImpl(Native Method)
2021-12-31T14:05:00.279166416Z 	at java.lang.Class.getDeclaredFieldInternal(Class.java:846)
2021-12-31T14:05:00.279170347Z 	at java.lang.Class.getDeclaredField(Class.java:821)
2021-12-31T14:05:00.279174182Z 	at io.github.toolfactory.jvm.function.catalog.ConsulterSupplier$ForJava7.<init>(ConsulterSupplier.java:53)
2021-12-31T14:05:00.279178468Z 	... 58 common frames omitted
```

Trying to figure out the cause of this, I came across this: https://github.com/classgraph/classgraph/issues/563
My application is running with the (latest) Java 8 OpenJ9 JRE (specifically https://github.com/ibmruntimes/semeru8-binaries/releases/download/jdk8u312-b07_openj9-0.29.0/ibm-semeru-open-jre_x64_linux_8u312b07_openj9-0.29.0.tar.gz)

In my project I tried overriding the version of the `classgraph` dependency (the ticket says version `4.8.120` required, but I chose the latest, which is `4.8.138` at the time of writing).  This change means my application starts up just fine.

I am raising this PR so that I can remove the override of the transitive dependency in my project - and hopefully so that other people don't get impacted by this problem!