### PR TITLE
springdoc-openapi-security: support custom login processing endpoints

### DIFF
--- a/springdoc-openapi-security/src/main/java/org/springdoc/security/SpringDocSecurityConfiguration.java
+++ b/springdoc-openapi-security/src/main/java/org/springdoc/security/SpringDocSecurityConfiguration.java
@@ -49,6 +49,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpointHandlerMapping;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
@@ -133,16 +134,15 @@ public class SpringDocSecurityConfiguration {
 						operation.responses(apiResponses);
 						operation.addTagsItem("login-endpoint");
 						PathItem pathItem = new PathItem().post(operation);
-						String loginPath = "/login";
 						try {
-							Field requestMatcherField = usernamePasswordAuthenticationFilter.getClass().getSuperclass().getDeclaredField("requiresAuthenticationRequestMatcher");
+							Field requestMatcherField = AbstractAuthenticationProcessingFilter.class.getDeclaredField("requiresAuthenticationRequestMatcher");
 							requestMatcherField.setAccessible(true);
 							AntPathRequestMatcher requestMatcher = (AntPathRequestMatcher) requestMatcherField.get(usernamePasswordAuthenticationFilter);
-							loginPath = requestMatcher.getPattern();
+							String loginPath = requestMatcher.getPattern();
 							requestMatcherField.setAccessible(false);
-						} catch (NoSuchFieldException | IllegalAccessException ignored) {
+							openAPI.getPaths().addPathItem(loginPath, pathItem);
+						} catch (NoSuchFieldException | IllegalAccessException | ClassCastException ignored) {
 						}
-						openAPI.getPaths().addPathItem(loginPath, pathItem);
 					}
 				}
 			};

--- a/springdoc-openapi-security/src/test/java/test/org/springdoc/api/app8/SpringDocApp8Test.java
+++ b/springdoc-openapi-security/src/test/java/test/org/springdoc/api/app8/SpringDocApp8Test.java
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.app8;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+@TestPropertySource(properties = "springdoc.show-login-endpoint=true")
+public class SpringDocApp8Test extends AbstractSpringDocTest {
+
+    @SpringBootApplication(scanBasePackages = { "test.org.springdoc.api.configuration,test.org.springdoc.api.app8" })
+    static class SpringDocTestApp {
+        @Bean
+        public OpenAPI customOpenAPI() {
+            return new OpenAPI()
+                    .info(new Info().title("Security API").version("v1")
+                            .license(new License().name("Apache 2.0").url("http://springdoc.org")));
+        }
+    }
+}

--- a/springdoc-openapi-security/src/test/java/test/org/springdoc/api/app8/security/WebConfig.java
+++ b/springdoc-openapi-security/src/test/java/test/org/springdoc/api/app8/security/WebConfig.java
@@ -1,0 +1,17 @@
+package test.org.springdoc.api.app8.security;
+
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@EnableWebSecurity
+@Order(200)
+public class WebConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.formLogin()
+                .loginProcessingUrl("/api/login");
+    }
+}

--- a/springdoc-openapi-security/src/test/resources/results/app8.json
+++ b/springdoc-openapi-security/src/test/resources/results/app8.json
@@ -1,0 +1,53 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Security API",
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://springdoc.org"
+    },
+    "version": "v1"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/login": {
+      "post": {
+        "tags": [
+          "login-endpoint"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "Forbidden"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+  }
+}


### PR DESCRIPTION
My application uses a reverse proxy with only `/api/**` routes being available to the Spring server. Unfortunately, the login processing endpoint path in springdoc-openapi-security currently is fixed to `/login` so I had to make some changes in the code.
The new code uses the `requiresAuthenticationRequestMatcher` field of `usernamePasswordAuthenticationFilter` (it's private on `AbstractAuthenticationProcessingFilter` with no getter so we need to use the Reflection API) to find the login processing endpoint path.
I supported only `AntPathRequestMatcher` matchers because it is used by all default Spring Security filters when configuring with `HttpSecurity`. This should cover most use cases. 
I also have added a test `app8` that verifies if a login processing URL set as `/api/login` is properly reflected in API schema.  