### PR TITLE
Fix the problem that the inconsistent newline characters of different platforms

### DIFF
--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractCommonTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractCommonTest.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +26,12 @@ public abstract class AbstractCommonTest {
 	protected String getContent(String fileName) {
 		try {
 			Path path = Paths.get(AbstractCommonTest.class.getClassLoader().getResource(fileName).toURI());
-			byte[] fileBytes = Files.readAllBytes(path);
-			return new String(fileBytes, StandardCharsets.UTF_8);
+			List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+			StringBuilder sb = new StringBuilder();
+			for (String line : lines) {
+				sb.append(line).append("\n");
+			}
+			return sb.toString();
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to read file: " + fileName, e);

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
@@ -39,8 +39,9 @@ public abstract class AbstractSpringDocTest extends AbstractCommonTest {
 		MvcResult mvcResult = mockMvc.perform(get(uri)).andExpect(status().isOk()).andReturn();
 		String transformedIndex = mvcResult.getResponse().getContentAsString();
 		assertTrue(transformedIndex.contains("Swagger UI"));
-		assertEquals(this.getContent(fileName), transformedIndex);
+		assertEquals(this.getContent(fileName), transformedIndex.replace("\r", ""));
 	}
+
 	protected void chekHTML(String fileName) throws Exception {
 		checkHTML( fileName, DEFAULT_SWAGGER_UI_URL);
 	}
@@ -49,5 +50,10 @@ public abstract class AbstractSpringDocTest extends AbstractCommonTest {
 		className = getClass().getSimpleName();
 		String testNumber = className.replaceAll("[^0-9]", "");
 		checkHTML( "results/app" + testNumber, DEFAULT_SWAGGER_UI_URL);
+	}
+
+	protected void checkHTMLResult(String fileName, String htmlResult)throws Exception {
+		assertTrue(htmlResult.contains("Swagger UI"));
+		assertEquals(this.getContent(fileName), htmlResult.replace("\r", ""));
 	}
 }

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocConfigPathsTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocConfigPathsTest.java
@@ -50,8 +50,7 @@ public class SpringDocConfigPathsTest extends AbstractSpringDocTest {
 
 		MvcResult mvcResult = mockMvc.perform(get("/context-path/servlet-path/test/swagger-ui/index.html").contextPath("/context-path").servletPath("/servlet-path")).andExpect(status().isOk()).andReturn();
 		String transformedIndex = mvcResult.getResponse().getContentAsString();
-		assertTrue(transformedIndex.contains("Swagger UI"));
-		assertEquals(this.getContent("results/app1-contextpath"), transformedIndex);
+        checkHTMLResult("results/app1-contextpath", transformedIndex);
     }
 
     @SpringBootApplication

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocOauthServletPathsTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app5/SpringDocOauthServletPathsTest.java
@@ -47,8 +47,7 @@ public class SpringDocOauthServletPathsTest extends AbstractSpringDocTest {
 
 		MvcResult mvcResult = mockMvc.perform(get("/context-path/servlet-path/test/swagger-ui/index.html").servletPath("/servlet-path").contextPath("/context-path")).andExpect(status().isOk()).andReturn();
 		String transformedIndex = mvcResult.getResponse().getContentAsString();
-		assertTrue(transformedIndex.contains("Swagger UI"));
-		assertEquals(this.getContent("results/app5-contextpath"), transformedIndex);
+		checkHTMLResult("results/app5-contextpath", transformedIndex);
 	}
 
 	@Test

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractCommonTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractCommonTest.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +26,12 @@ public abstract class AbstractCommonTest {
 	protected String getContent(String fileName) {
 		try {
 			Path path = Paths.get(AbstractCommonTest.class.getClassLoader().getResource(fileName).toURI());
-			byte[] fileBytes = Files.readAllBytes(path);
-			return new String(fileBytes, StandardCharsets.UTF_8);
+			List<String> lines = Files.readAllLines(path, StandardCharsets.UTF_8);
+			StringBuilder sb = new StringBuilder();
+			for (String line : lines) {
+				sb.append(line).append("\n");
+			}
+			return sb.toString();
 		}
 		catch (Exception e) {
 			throw new RuntimeException("Failed to read file: " + fileName, e);

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
@@ -51,26 +51,18 @@ public abstract class AbstractSpringDocTest extends AbstractCommonTest {
 
 	private static final String DEFAULT_SWAGGER_UI_URL= Constants.DEFAULT_WEB_JARS_PREFIX_URL  + Constants.SWAGGER_UI_URL;
 
-	protected String getContent(String fileName) {
-		try {
-			Path path = Paths.get(AbstractSpringDocTest.class.getClassLoader().getResource(fileName).toURI());
-			byte[] fileBytes = Files.readAllBytes(path);
-			return new String(fileBytes, StandardCharsets.UTF_8);
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to read file: " + fileName, e);
-		}
-	}
-
 	protected void checkHTML(String fileName, String uri) {
 		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri(uri)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
-		String result = new String(getResult.getResponseBody());
+		checkHTMLResult(fileName, new String(getResult.getResponseBody()));
+	}
+
+	protected void checkHTMLResult(String fileName, String result) {
 		assertTrue(result.contains("Swagger UI"));
 		String expected = getContent("results/" + fileName);
-		assertEquals(expected, result);
+		assertEquals(expected, result.replace("\r", ""));
 	}
 
 	protected void checkHTML(String fileName) {

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app6/SpringDocApp6Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app6/SpringDocApp6Test.java
@@ -42,10 +42,7 @@ public class SpringDocApp6Test extends AbstractSpringDocTest {
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
-		String result = new String(getResult.getResponseBody());
-		assertTrue(result.contains("Swagger UI"));
-		String expected = getContent("results/index6");
-		assertEquals(expected, result);
+		checkHTMLResult("index6", new String(getResult.getResponseBody()));
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
+++ b/springdoc-openapi-webflux-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
@@ -42,10 +42,7 @@ public class SpringDocApp7Test extends AbstractSpringDocTest {
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();
-		String result = new String(getResult.getResponseBody());
-		assertTrue(result.contains("Swagger UI"));
-		String expected = getContent("results/index7");
-		assertEquals(expected, result);
+		checkHTMLResult("index7", new String(getResult.getResponseBody()));
 	}
 
 	@SpringBootApplication


### PR DESCRIPTION
The newline character of linux system is LF,
The default newline character in Windows system files is CRLF.

When git clones the code, it will automatically do a newline conversion for different platforms, which causes the newline of the tested file to be CRLF in the windows system, which does not match the expected return value.

In addition, because the CR character is used in three places in swagger-ui/index.html, and it is just before the carriage return character LF, which will cause the original CR character representation to be lost when git clone converts the newline character, so in order to cross The unification of the platform needs to ignore the comparison of CR characters when judging