### PR TITLE
Pick up exception handler in case there is no controller advice at alll, fixes 1498

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -324,7 +324,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			Map<String, Object> findControllerAdvice = openAPIService.getControllerAdviceMap();
 			// calculate generic responses
 			openApi = openAPIService.getCalculatedOpenAPI();
-			if (springDocConfigProperties.isOverrideWithGenericResponse() && !CollectionUtils.isEmpty(findControllerAdvice)) {
+			if (springDocConfigProperties.isOverrideWithGenericResponse()) {
 				if (!CollectionUtils.isEmpty(mappingsMap))
 					findControllerAdvice.putAll(mappingsMap);
 				responseBuilder.buildGenericResponse(openApi.getComponents(), findControllerAdvice, finalLocale);

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app182/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app182/HelloController.java
@@ -1,0 +1,56 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app182;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import test.org.springdoc.api.app181.ConcreteParameterObject;
+
+@RestController
+public class HelloController<T> {
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	@ApiResponse(responseCode = "404", description = "Not here", content = @Content)
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	public void bad(IllegalArgumentException e) {
+
+	}
+
+	@ExceptionHandler(RuntimeException.class)
+	@ResponseStatus(HttpStatus.BAD_GATEWAY)
+	public Object gateway(RuntimeException e) {
+		return null;
+	}
+
+	@GetMapping(value = "/hello/{numTelco}")
+	@Operation(summary = "GET Persons", responses = @ApiResponse(responseCode = "418"))
+	public T index(@PathVariable("numTelco") String numTel, String adresse) {
+		throw new IllegalArgumentException();
+
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app182/SpringDocApp182Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/app182/SpringDocApp182Test.java
@@ -1,0 +1,32 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app182;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+
+/**
+ * Copy of 124 without RestControllerAdvice class
+ */
+public class SpringDocApp182Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/app182.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/app182.json
@@ -1,0 +1,68 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/hello/{numTelco}": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "GET Persons",
+        "operationId": "index",
+        "parameters": [
+          {
+            "name": "numTelco",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "adresse",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not here"
+          },
+          "418": {
+            "description": "I'm a teapot",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
This PR fixes #1498 issue. 
Exception handlers can be resolved even if no @ControllerAdvice is registered