### PR TITLE
Add-Support-For-Servlet-Paths

### DIFF
--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeCommon.java
@@ -12,7 +12,9 @@ import org.springdoc.ui.AbstractSwaggerWelcome;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.RequestPath;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.ServletRequestPathUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -77,6 +79,10 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 	void buildFromCurrentContextPath(HttpServletRequest request) {
 		super.init();
 		contextPath = request.getContextPath();
+		String servletPath = request.getServletPath();
+		if (StringUtils.isNotBlank(servletPath)) {
+			contextPath += servletPath;
+		}
 		buildConfigUrl(ServletUriComponentsBuilder.fromCurrentContextPath());
 	}
 }


### PR DESCRIPTION
In my project, the documentation exists inside of a servlet with its own separate context path.
This fix (and only this fix) is required for everything to work as expected in my project.

Would appreciate it if something similar to this could be added.