### PR TITLE
Allow ComposedSchemas to replace non-composed so we can respect polymorphic links discovered in later methods

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
@@ -129,9 +129,16 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 					componentSchemas.putAll(schemaMap);
 				}
 				else
-					for (Map.Entry<String, Schema> entry : schemaMap.entrySet())
-						if (!componentSchemas.containsKey(entry.getKey()))
-							componentSchemas.put(entry.getKey(), entry.getValue());
+					for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
+                        if (!componentSchemas.containsKey(entry.getKey())) {
+                            componentSchemas.put(entry.getKey(), entry.getValue());
+                            // If we've seen this schema before but find later it should be polymorphic,
+                            // replace the existing schema with this richer version.
+                        } else if (entry.getValue() instanceof ComposedSchema &&
+                                !(componentSchemas.get(entry.getKey()) instanceof ComposedSchema)) {
+                            componentSchemas.put(entry.getKey(), entry.getValue());
+                        }
+                    }
 				components.setSchemas(componentSchemas);
 			}
 			if (resolvedSchema.schema != null) {

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocAnnotationsUtils.java
@@ -130,15 +130,15 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 				}
 				else
 					for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
-                        if (!componentSchemas.containsKey(entry.getKey())) {
-                            componentSchemas.put(entry.getKey(), entry.getValue());
-                            // If we've seen this schema before but find later it should be polymorphic,
-                            // replace the existing schema with this richer version.
-                        } else if (entry.getValue() instanceof ComposedSchema &&
-                                !(componentSchemas.get(entry.getKey()) instanceof ComposedSchema)) {
-                            componentSchemas.put(entry.getKey(), entry.getValue());
-                        }
-                    }
+						if (!componentSchemas.containsKey(entry.getKey())) {
+							componentSchemas.put(entry.getKey(), entry.getValue());
+							// If we've seen this schema before but find later it should be polymorphic,
+							// replace the existing schema with this richer version.
+						} else if (entry.getValue() instanceof ComposedSchema &&
+							!(componentSchemas.get(entry.getKey()) instanceof ComposedSchema)) {
+							componentSchemas.put(entry.getKey(), entry.getValue());
+						}
+					}
 				components.setSchemas(componentSchemas);
 			}
 			if (resolvedSchema.schema != null) {

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Cat.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Cat.java
@@ -1,0 +1,24 @@
+package test.org.springdoc.api.app31;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema
+public class Cat extends Pet {
+
+    private final boolean meows;
+
+    public Cat() {
+        super();
+        this.meows = false;
+    }
+
+    public Cat(boolean meows, String name) {
+        super(name);
+        this.meows = meows;
+    }
+
+    public boolean getMeows() {
+        return meows;
+    }
+
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Dog.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Dog.java
@@ -1,0 +1,24 @@
+package test.org.springdoc.api.app31;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema
+public class Dog extends Pet {
+
+    private final boolean barks;
+
+    public Dog() {
+        super();
+        this.barks = false;
+    }
+
+    public Dog(boolean barks, String name) {
+        super(name);
+        this.barks = barks;
+    }
+
+    public boolean getBarks() {
+        return barks;
+    }
+
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Pet.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/Pet.java
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.app31;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(Dog.class),
+        @JsonSubTypes.Type(Cat.class)
+})
+public class Pet {
+
+    public final String name;
+
+    public Pet() {
+        this.name = null;
+    }
+
+    public Pet(String name) {
+        this.name = name;
+    }
+
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/PetController.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/PetController.java
@@ -1,0 +1,18 @@
+package test.org.springdoc.api.app31;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PetController {
+
+    @GetMapping("/any")
+    public Pet getAnyPet() {
+        return new Cat(true, "cat");
+    }
+
+    @GetMapping("/dog")
+    public Dog getDog() {
+        return new Dog(true, "dog");
+    }
+}

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/SpringDocApp31Test.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app31/SpringDocApp31Test.java
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.app31;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+public class SpringDocApp31Test extends AbstractSpringDocTest {
+
+    @SpringBootApplication
+    static class SpringDocTestApp {}
+
+}

--- a/springdoc-openapi-data-rest/src/test/resources/results/app31.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app31.json
@@ -1,0 +1,100 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [{
+    "url": "http://localhost",
+    "description": "Generated server url"
+  }],
+  "paths": {
+    "/dog": {
+      "get": {
+        "tags": ["pet-controller"],
+        "operationId": "getDog",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Dog"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/any": {
+      "get": {
+        "tags": ["pet-controller"],
+        "operationId": "getAnyPet",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "oneOf": [{
+                    "$ref": "#/components/schemas/Pet"
+                  }, {
+                    "$ref": "#/components/schemas/Cat"
+                  }, {
+                    "$ref": "#/components/schemas/Dog"
+                  }]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Dog": {
+        "type": "object",
+        "allOf": [{
+          "$ref": "#/components/schemas/Pet"
+        }, {
+          "type": "object",
+          "properties": {
+            "barks": {
+              "type": "boolean"
+            }
+          }
+        }]
+      },
+      "Cat": {
+        "type": "object",
+        "allOf": [{
+          "$ref": "#/components/schemas/Pet"
+        }, {
+          "type": "object",
+          "properties": {
+            "meows": {
+              "type": "boolean"
+            }
+          }
+        }]
+      },
+      "Pet": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Paths are inspected in reverse alphabetical order, with the first schema generated any inserted into components taking precedence.

Therefore if you have paths e.g.
```
    @GetMapping("/any")
    public Pet aaaagetAnyPet() {
        return new Cat(true, "cat");
    }

    @GetMapping("/zzzzzdog")
    public Dog zzzzgetDog() {
        return new Dog(true, "dog");
    }

...
class Dog extends Pet
class Cat extends Pet
class Pet
```

We'll generate Dog first by inspecting zzzGetDog, which isn't composed because we are returning Dog directly.
We then generate Pet and subtypes when we find the other method. At this point we should replace the existing Dog component with the new composed one, as we're now aware that we care about the polymorphism, but the existing code skips the existing key for Dog, meaning the spec incorrectly presents Dog as unrelated to Pet.

Meanwhile, as Pet and Cat were not previously generated, Cat is correctly emitted as a subtype of Pet with an allOf Pet reference.

As far as I can tell, this issue hasn't cropped up before in examples or existing tests because the path naming has always been such that Pet generated first by conincidence, which meant a ComposedSchema for Dog would already be present in the components.

