### PR TITLE
Support for Webflux springdoc behind a proxy v2.x

### DIFF
--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
@@ -1,0 +1,83 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework"
+})
+public class SpringDocBehindProxyTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldServeSwaggerUIAtDefaultPath() {
+		webTestClient.get().uri("/webjars/swagger-ui/index.html").exchange()
+				.expectStatus().isOk();
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() throws Exception {
+		webTestClient
+				.get().uri("/webjars/swagger-ui/swagger-initializer.js")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(String.class)
+				.consumeWith(response ->
+						assertThat(response.getResponseBody())
+								.contains("\"configUrl\" : \"/path/prefix/v3/api-docs/swagger-config\",")
+				);
+	}
+
+	@Test
+	public void shouldCalculateOauthRedirectBehindProxy() throws Exception {
+		webTestClient
+				.get().uri("/v3/api-docs/swagger-config")
+				.header("X-Forwarded-Proto", "https")
+				.header("X-Forwarded-Host", "proxy-host")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk().expectBody()
+				.jsonPath("$.oauth2RedirectUrl").isEqualTo("https://proxy-host/path/prefix/swagger-ui/oauth2-redirect.html");
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() throws Exception {
+		webTestClient
+				.get().uri("/v3/api-docs/swagger-config")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk().expectBody()
+				.jsonPath("$.url")
+				.isEqualTo("/path/prefix/v3/api-docs")
+				.jsonPath("$.configUrl")
+				.isEqualTo("/path/prefix/v3/api-docs/swagger-config");
+	}
+}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework",
+		"springdoc.swagger-ui.path=/foo/documentation/swagger.html"
+})
+public class SpringDocBehindProxyWithCustomUIPathTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldRedirectSwaggerUIFromCustomPath() {
+		webTestClient
+				.get().uri("/foo/documentation/swagger.html")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isFound()
+				.expectHeader().location("/path/prefix/foo/documentation/swagger-ui/index.html");
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() {
+		webTestClient
+				.get().uri("/foo/documentation/swagger-ui/swagger-initializer.js")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(String.class)
+				.consumeWith(response ->
+						assertThat(response.getResponseBody())
+								.contains("\"configUrl\" : \\\"/path/prefix/v3/api-docs/swagger-config\\\",")
+				);
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() throws Exception {
+		webTestClient
+				.get().uri("/v3/api-docs/swagger-config")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody()
+				.jsonPath("$.url")
+				.isEqualTo("/path/prefix/v3/api-docs")
+				.jsonPath("$.configUrl")
+				.isEqualTo("/path/prefix/v3/api-docs/swagger-config");
+	}
+}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
@@ -1,0 +1,78 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework",
+		"springdoc.swagger-ui.path=/foo/documentation/swagger.html",
+		"springdoc.api-docs.path=/bar/openapi/v3"
+})
+public class SpringDocBehindProxyWithCustomUIPathWithApiDocsTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldRedirectSwaggerUIFromCustomPath() {
+		webTestClient
+				.get().uri("/foo/documentation/swagger.html")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isFound()
+				.expectHeader().location("/path/prefix/foo/documentation/swagger-ui/index.html");
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() {
+		webTestClient
+				.get().uri("/foo/documentation/swagger-ui/swagger-initializer.js")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(String.class)
+				.consumeWith(response ->
+						assertThat(response.getResponseBody())
+								.contains("\"configUrl\" : \\\"/path/prefix/v3/api-docs/swagger-config\\\",")
+				);
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() {
+		webTestClient
+				.get().uri("/bar/openapi/v3/swagger-config")
+				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody()
+				.jsonPath("$.url")
+				.isEqualTo("/path/prefix/bar/openapi/v3")
+				.jsonPath("$.configUrl")
+				.isEqualTo("/path/prefix/bar/openapi/v3/swagger-config");
+	}
+}

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
@@ -1,0 +1,84 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework"
+})
+public class SpringDocBehindProxyTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldServeSwaggerUIAtDefaultPath() throws Exception {
+		mockMvc.perform(get("/swagger-ui/index.html"))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() throws Exception {
+		mockMvc.perform(get("/swagger-ui/swagger-initializer.js")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(content().string(
+						containsString("\"configUrl\" : \"/path/prefix/v3/api-docs/swagger-config\",")
+				));
+	}
+
+	@Test
+	public void shouldCalculateOauthRedirectBehindProxy() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/swagger-config")
+						.header("X-Forwarded-Proto", "https")
+						.header("X-Forwarded-Host", "proxy-host")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("oauth2RedirectUrl",
+						equalTo("https://proxy-host/path/prefix/swagger-ui/oauth2-redirect.html")
+				));
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/swagger-config")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("url",
+						equalTo("/path/prefix/v3/api-docs")
+				))
+				.andExpect(jsonPath("configUrl",
+						equalTo("/path/prefix/v3/api-docs/swagger-config")
+				));
+	}
+}

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework",
+		"springdoc.swagger-ui.path=/foo/documentation/swagger.html"
+})
+public class SpringDocBehindProxyWithCustomUIPathTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldRedirectSwaggerUIFromCustomPath() throws Exception {
+		mockMvc.perform(get("/foo/documentation/swagger.html")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isFound())
+				.andExpect(header().string("Location", "/path/prefix/foo/documentation/swagger-ui/index.html"));
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() throws Exception {
+		mockMvc.perform(get("/foo/documentation/swagger-ui/swagger-initializer.js")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(content().string(
+						containsString("\"configUrl\" : \"/path/prefix/v3/api-docs/swagger-config\",")
+				));
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/swagger-config")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("url",
+						equalTo("/path/prefix/v3/api-docs")
+				))
+				.andExpect(jsonPath("configUrl",
+						equalTo("/path/prefix/v3/api-docs/swagger-config")
+				));
+	}
+
+}

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
@@ -1,0 +1,75 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app32;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+		"server.forward-headers-strategy=framework",
+		"springdoc.swagger-ui.path=/foo/documentation/swagger.html",
+		"springdoc.api-docs.path=/bar/openapi/v3"
+})
+public class SpringDocBehindProxyWithCustomUIPathWithApiDocsTest extends AbstractSpringDocTest {
+
+	private static final String X_FORWARD_PREFIX = "/path/prefix";
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+	@Test
+	public void shouldServeOpenapiJsonUnderCustomPath() throws Exception {
+		mockMvc.perform(get("/bar/openapi/v3")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk());
+	}
+
+	@Test
+	public void shouldReturnCorrectInitializerJS() throws Exception {
+		mockMvc.perform(get("/foo/documentation/swagger-ui/swagger-initializer.js")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(content().string(
+						containsString("\"configUrl\" : \"/path/prefix/bar/openapi/v3/swagger-config\",")
+				));
+	}
+
+	@Test
+	public void shouldCalculateUrlsBehindProxy() throws Exception {
+		mockMvc.perform(get("/bar/openapi/v3/swagger-config")
+						.header("X-Forwarded-Prefix", X_FORWARD_PREFIX))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("url",
+						equalTo("/path/prefix/bar/openapi/v3")
+				))
+				.andExpect(jsonPath("configUrl",
+						equalTo("/path/prefix/bar/openapi/v3/swagger-config")
+				));
+	}
+}


### PR DESCRIPTION
Automated tests to fix springdoc/springdoc-openapi#1645 for Springdoc version 2.x