### PR TITLE
fix oauth redirection when used in spring-native

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/Constants.java
@@ -184,6 +184,11 @@ public final class Constants {
 	public static final String INDEX_PAGE = "/index.html";
 
 	/**
+	 * the constant OAUTH_REDIRECT_PAGE.
+	 */
+	public static final String OAUTH_REDIRECT_PAGE = "/oauth2-redirect.html";
+
+	/**
 	 * The constant SWAGGER_UI_URL.
 	 */
 	public static final String SWAGGER_UI_URL = SWAGGER_UI_PREFIX + INDEX_PAGE;
@@ -201,7 +206,7 @@ public final class Constants {
 	/**
 	 * The constant SWAGGER_UI_OAUTH_REDIRECT_URL.
 	 */
-	public static final String SWAGGER_UI_OAUTH_REDIRECT_URL = SWAGGER_UI_PREFIX + "/oauth2-redirect.html";
+	public static final String SWAGGER_UI_OAUTH_REDIRECT_URL = SWAGGER_UI_PREFIX + OAUTH_REDIRECT_PAGE;
 
 	/**
 	 * The constant APPLICATION_OPENAPI_YAML.

--- a/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
@@ -32,6 +32,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.springdoc.core.Constants.INDEX_PAGE;
+import static org.springdoc.core.Constants.OAUTH_REDIRECT_PAGE;
 import static org.springdoc.core.Constants.SWAGGER_UI_OAUTH_REDIRECT_URL;
 import static org.springdoc.core.Constants.SWAGGER_UI_PREFIX;
 import static org.springdoc.core.Constants.SWAGGER_UI_URL;
@@ -221,7 +222,12 @@ public abstract class AbstractSwaggerWelcome {
 	 * @return the oauth2 redirect url
 	 */
 	protected String getOauth2RedirectUrl() {
-		return StringUtils.defaultIfBlank(swaggerUiConfig.getOauth2RedirectUrl(), SWAGGER_UI_OAUTH_REDIRECT_URL);
+		if (StringUtils.isNotEmpty(swaggerUiConfig.getVersion())) {
+			return StringUtils.defaultIfBlank(swaggerUiConfig.getOauth2RedirectUrl(), SWAGGER_UI_PREFIX + DEFAULT_PATH_SEPARATOR + swaggerUiConfig.getVersion() + OAUTH_REDIRECT_PAGE);
+		}
+		else {
+			return StringUtils.defaultIfBlank(swaggerUiConfig.getOauth2RedirectUrl(), SWAGGER_UI_OAUTH_REDIRECT_URL);
+		}
 	}
 
 	/**


### PR DESCRIPTION
I realized, that the oauth redirect does not work when using swagger on top of an application build using spring-native. As mentioned in the docs, in this situation the version of the swagger-ui is used in the path. But this needs also being included in any redirect path i.e. when using oauth flow inside swagger-ui.