### PR TITLE
bug: incorrect generic param for multi interfaces

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ReturnTypeParser.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ReturnTypeParser.java
@@ -166,6 +166,9 @@ public interface ReturnTypeParser {
 			}
 		}
 		for (ResolvableType ifc : contextType.getInterfaces()) {
+			if(!ifc.getType().equals(typeVariable.getGenericDeclaration())){
+				continue;
+			}
 			resolvedType = resolveVariable(typeVariable, ifc);
 			if (resolvedType.resolve() != null) {
 				return resolvedType;

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ReturnTypeParser.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ReturnTypeParser.java
@@ -151,7 +151,7 @@ public interface ReturnTypeParser {
 	 */
 	static ResolvableType resolveVariable(TypeVariable<?> typeVariable, ResolvableType contextType) {
 		ResolvableType resolvedType;
-		if (contextType.hasGenerics()) {
+		if (contextType.hasGenerics() && contextType.getRawClass().equals(typeVariable.getGenericDeclaration())){
 			resolvedType = ResolvableType.forType(typeVariable, contextType);
 			if (resolvedType.resolve() != null) {
 				return resolvedType;
@@ -166,9 +166,6 @@ public interface ReturnTypeParser {
 			}
 		}
 		for (ResolvableType ifc : contextType.getInterfaces()) {
-			if(!ifc.getType().equals(typeVariable.getGenericDeclaration())){
-				continue;
-			}
 			resolvedType = resolveVariable(typeVariable, ifc);
 			if (resolvedType.resolve() != null) {
 				return resolvedType;


### PR DESCRIPTION
public interface CrudControllerBase<S extends Service<?, ?>,  SRC extends CustomQuery> {
    // some code
}

public interface ExistsControllerBase<S extends Service<?, ?>, EQUERY extends CustomQuery> {

@PostMapping("exist")
default Response<Boolean> exist(@RequestBody PostBody<EQUERY> req) {
    // some code
}

}

@RestController
@RequestMapping("/v1/{tenant_id:[0-9A-Z]+}/user")
public class UserAdminController implements 
    CrudControllerBase<AdminUserService, AdminUserSearch>,
    ExistsControllerBase<AdminUserService, UserExistsQuery> {
    // some code
}

the "requestBody" in "/v1/{tenant_id}/user/exist" path get incorrect schema: 
    "schema": {
         "$ref": "#/components/schemas/PostBodyCustomQuery"
      }
the correct schema should be:
    "schema": {
         "$ref": "#/components/schemas/PostBodyUserExistsQuery"
      }