### PR TITLE
more specific bean name for objectMapperProvider

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
@@ -606,7 +606,7 @@ public class SpringDocConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	@Lazy(false)
-	ObjectMapperProvider objectMapperProvider(SpringDocConfigProperties springDocConfigProperties){
+	ObjectMapperProvider springDocObjectMapperProvider(SpringDocConfigProperties springDocConfigProperties){
 		return new ObjectMapperProvider(springDocConfigProperties);
 	}
 }


### PR DESCRIPTION
The bean name is very generic. Application context failed to start up for me because in the graphql kickstart library there's a bean with the same name.

See https://github.com/graphql-java-kickstart/graphql-spring-boot/blob/13cd484f913fe7885ff5d5bc5883b1e9544d4ca6/graphql-spring-boot-autoconfigure/src/main/java/graphql/kickstart/spring/web/boot/GraphQLWebAutoConfiguration.java#L269

Therefore I propose a more specific bean name.