### PR TITLE
fix: Support PageableDefault#value()

### DIFF
--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app13/HelloController.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app13/HelloController.java
@@ -57,4 +57,10 @@ public class HelloController {
 	@ParameterObject Pageable pageable) {
 		return "bla";
 	}
+
+	@GetMapping("/test4")
+	public String getPatientList4(@PageableDefault(100)
+	@ParameterObject Pageable pageable) {
+		return "bla";
+	}
 }

--- a/springdoc-openapi-data-rest/src/test/resources/results/app13.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app13.json
@@ -11,6 +11,62 @@
     }
   ],
   "paths": {
+    "/test4": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "getPatientList4",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/hal+json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/test3": {
       "get": {
         "tags": [

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app176/HelloController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app176/HelloController.java
@@ -62,4 +62,10 @@ public class HelloController {
 	@ParameterObject Pageable pageable) {
 		return "bla";
 	}
+
+	@GetMapping("/test4")
+	public String getPatientList4(@PageableDefault(100)
+	@ParameterObject Pageable pageable) {
+		return "bla";
+	}
 }

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/3.0.1/app176.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/3.0.1/app176.json
@@ -11,6 +11,62 @@
     }
   ],
   "paths": {
+    "/test4": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "getPatientList4",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Zero-based page index (0..N)",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "minimum": 1,
+              "type": "integer",
+              "default": 100
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/test3": {
       "get": {
         "tags": [


### PR DESCRIPTION
[PageableDefault#value()](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/web/PageableDefault.html#value--) is an alias for [PageableDefault#size()](https://docs.spring.io/spring-data/commons/docs/current/api/org/springframework/data/web/PageableDefault.html#sort--), but currently, `springdoc-openapi` is only reading the default size from `size`, not `value`.

This change attempts to get the default size from `size` first. If it is the default value, then it will get the default size from `value`. I'm not sure if this is the correct precedence, anyone knows if Java annotation parsers normally give higher precedence to `value` or the aliased parameter?