### PR TITLE
Fix concurrent problems when initializing multiple GroupedOpenApi parallelly

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
@@ -130,12 +131,12 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	/**
 	 * The constant ADDITIONAL_REST_CONTROLLERS.
 	 */
-	private static final List<Class<?>> ADDITIONAL_REST_CONTROLLERS = Collections.synchronizedList(new ArrayList<>());
+	private static final Set<Class<?>> ADDITIONAL_REST_CONTROLLERS = new CopyOnWriteArraySet<>();
 
 	/**
 	 * The constant HIDDEN_REST_CONTROLLERS.
 	 */
-	private static final List<Class<?>> HIDDEN_REST_CONTROLLERS = Collections.synchronizedList(new ArrayList<>());
+	private static final Set<Class<?>> HIDDEN_REST_CONTROLLERS = new CopyOnWriteArraySet<>();
 
 	/**
 	 * The Open api builder.


### PR DESCRIPTION
## Problem

Continuation of #1641

If a project has multiple `GroupedOpenApi` bean, they will be initialized parallelly. This lead to concurrent read and write of `AbstractOpenApiResource#HIDDEN_REST_CONTROLLERS`.

Since the list is not correctly synchronized, concurrent read and write might cause `ConcurrentModificationException` ([`Collections#synchronizedList` isn't thread-safe on iteration](https://stackoverflow.com/questions/25113987/why-is-there-a-concurrentmodificationexception-even-when-list-is-synchronized)):

> Exception in thread "pool-3-thread-1" java.util.ConcurrentModificationException  
> &nbsp;&nbsp;at java.util.ArrayList$ArrayListSpliterator.tryAdvance(ArrayList.java:1363)  
> &nbsp;&nbsp;at java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:126)  
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:499)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:486)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
> &nbsp;&nbsp;at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:230)
> &nbsp;&nbsp;at java.util.stream.MatchOps$MatchOp.evaluateSequential(MatchOps.java:196)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
> &nbsp;&nbsp;at java.util.stream.ReferencePipeline.anyMatch(ReferencePipeline.java:516)
> &nbsp;&nbsp;at org.springdoc.api.AbstractOpenApiResource.isHiddenRestControllers(AbstractOpenApiResource.java:822)
> &nbsp;&nbsp;at org.springdoc.api.AbstractOpenApiResource.lambda$getOpenApi$3(AbstractOpenApiResource.java:309)
> &nbsp;&nbsp;at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174)
> &nbsp;&nbsp;at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:175)
> &nbsp;&nbsp;at java.util.HashMap$EntrySpliterator.forEachRemaining(HashMap.java:1723)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
> &nbsp;&nbsp;at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
> &nbsp;&nbsp;at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
> &nbsp;&nbsp;at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:566)
> &nbsp;&nbsp;at org.springdoc.api.AbstractOpenApiResource.getOpenApi(AbstractOpenApiResource.java:310)
> &nbsp;&nbsp;at org.springdoc.api.AbstractOpenApiResource.getOpenApi(AbstractOpenApiResource.java:256)
> &nbsp;&nbsp;at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
> &nbsp;&nbsp;at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
> &nbsp;&nbsp;at java.lang.Thread.run(Thread.java:750)

## Solution

There are 3 possible solutions:

1. Synchronize on the list before every read and write:
    ```java
    synchronized (HIDDEN_REST_CONTROLLERS) {
        return HIDDEN_REST_CONTROLLERS.stream().anyMatch(clazz -> clazz.isAssignableFrom(rawClass));
    }
    ```
    * Cons: The list is much more often used for read than write (in my project it's 1698 to 12), so synchronize on every read might hurt performance.

2. Use an fully thread-safe implementation for list, such as `CopyOnWriteArrayList`
    * Pros: Read operations don't need synchronization
    * Cons: Write operations are very expensive since they usually entail copying the entire underlying array. However, each `GroupedOpenApi` only triggers two write operations for `HIDDEN_REST_CONTROLLERS`, and the list is generally small, so the trade-off is acceptable.

3. Reactor the initialization to eliminate concurrent write
    Each `GroupedOpenApi` will try to add the same controllers to `HIDDEN_REST_CONTROLLERS` in `OpenAPIService#initializeHiddenRestController`, since the controllers are obtained from the same `ApplicationContext`.
    It's better to write to `HIDDEN_REST_CONTROLLERS` only once before parallel initialization. This can not only eliminate concurrent write but also avoid duplication.
    However, this refactoring requires more familiarity of Springdoc's code base, and it's beyond my powers at present.

This PR implements solution 2.

I also replaced `ADDITIONAL_REST_CONTROLLERS`, `HIDDEN_REST_CONTROLLERS` with set to avoid duplication. This will reduce the number of elements to iterate thus improving performance.