### PR TITLE
Optimize the group order problem

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigParameters.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigParameters.java
@@ -171,7 +171,7 @@ public class SwaggerUiConfigParameters extends AbstractSwaggerUiConfigProperties
 		this.showExtensions = swaggerUiConfig.getShowExtensions();
 		this.supportedSubmitMethods = swaggerUiConfig.getSupportedSubmitMethods();
 		this.url = swaggerUiConfig.getUrl();
-		this.urls = swaggerUiConfig.getUrls() == null ? new HashSet<>() : swaggerUiConfig.cloneUrls();
+		this.urls = swaggerUiConfig.getUrls() == null ? new LinkedHashSet<>() : swaggerUiConfig.cloneUrls();
 		this.urlsPrimaryName = swaggerUiConfig.getUrlsPrimaryName();
 		this.groupsOrder = swaggerUiConfig.getGroupsOrder();
 		this.tryItOutEnabled = swaggerUiConfig.getTryItOutEnabled();

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SwaggerUiConfigProperties.java
@@ -22,16 +22,16 @@
 
 package org.springdoc.core;
 
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.springdoc.core.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
 
@@ -431,7 +431,7 @@ public class SwaggerUiConfigProperties extends AbstractSwaggerUiConfigProperties
 	 * @return the set
 	 */
 	public Set<SwaggerUrl> cloneUrls(){
-		return this.urls.stream().map(swaggerUrl -> new SwaggerUrl(swaggerUrl.getName(), swaggerUrl.getUrl(), swaggerUrl.getDisplayName())).collect(Collectors.toSet());
+		return this.urls.stream().map(swaggerUrl -> new SwaggerUrl(swaggerUrl.getName(), swaggerUrl.getUrl(), swaggerUrl.getDisplayName())).collect(Collectors.toCollection(LinkedHashSet::new));
 	}
 
 }


### PR DESCRIPTION
for example，The display on springdoc is unordered
```
 @Bean
  public GroupedOpenApi userApi(){
      return GroupedOpenApi.builder()
          .group("user")
          .pathsToMatch(/user/**")
          .build();
  }

  @Bean
  public GroupedOpenApi orderApi(){
      return GroupedOpenApi.builder()
          .group("order")
          .pathsToMatch("/order/**")
          .build();
  }
```