### PR TITLE
WIP: Upgrade Spring Cloud Function to 4.0.0-M3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
 		<jjwt.version>0.9.1</jjwt.version>
 		<spring-native.version>0.11.5</spring-native.version>
 		<therapi-runtime-javadoc.version>0.13.0</therapi-runtime-javadoc.version>
-		<spring-cloud-function.version>4.0.0-M2</spring-cloud-function.version>
+		<spring-cloud-function.version>4.0.0-M3</spring-cloud-function.version>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

I just upgrade the Spring Cloud Function to 4.0.0-M3, and it works very well. Please refer to <https://github.com/spring-cloud/spring-cloud-function/releases/tag/v4.0.0-M3>.

We cannot find `io.micrometer:micrometer-bom:2.0.0-M3` in `Spring Milestones` repository. See <https://mvnrepository.com/artifact/io.micrometer/micrometer-bom?repo=springio-milestone> for more.

#### Which issue(s) this PR fixes:

Fixes #1752

#### Special notes for your reviewer:

Please wait for https://github.com/springdoc/springdoc-openapi/pull/1751 got merged before merging this PR. Because that PR will fix the build error.
