### PR TITLE
fix: to adjust default value and description of the page parameter when enabled `spring.data.web.pageable.one-indexed-parameters` property.

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
@@ -141,7 +141,7 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 
 				@Override
 				public String description() {
-					return parameter.description();
+					return getDescription(parameterName, parameter.description());
 				}
 
 				@Override
@@ -706,6 +706,20 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 	}
 
 	/**
+	 * Gets description.
+	 *
+	 * @param parameterName the parameter name
+	 * @param originalDescription the original description
+	 * @return the description
+	 */
+	private String getDescription(String parameterName, String originalDescription) {
+		if ("page".equals(parameterName) && isSpringDataWebPropertiesPresent() &&
+				optionalSpringDataWebPropertiesProvider.get().getSpringDataWebProperties().getPageable().isOneIndexedParameters())
+			return "One-based page index (1..N)";
+		return originalDescription;
+	}
+
+	/**
 	 * Gets default value.
 	 *
 	 * @param parameterName the parameter name
@@ -742,6 +756,8 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 			case "page":
 				if (pageableDefault != null)
 					defaultValue = String.valueOf(pageableDefault.page());
+				else if (isSpringDataWebPropertiesPresent() && optionalSpringDataWebPropertiesProvider.get().getSpringDataWebProperties().getPageable().isOneIndexedParameters())
+					defaultValue = "1";
 				else
 					defaultValue = defaultSchemaVal;
 				break;

--- a/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app14/SpringDocApp14Test.java
+++ b/springdoc-openapi-data-rest/src/test/java/test/org/springdoc/api/app14/SpringDocApp14Test.java
@@ -43,6 +43,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = { "spring.data.web.pageable.default-page-size=25",
 		"spring.data.web.pageable.page-parameter=pages",
 		"spring.data.web.pageable.size-parameter=sizes",
+		"spring.data.web.pageable.one-indexed-parameters=true",
 		"spring.data.web.sort.sort-parameter=sorts" })
 @EnableAutoConfiguration(exclude = {
 		RepositoryRestMvcAutoConfiguration.class, SpringDocDataRestConfiguration.class

--- a/springdoc-openapi-data-rest/src/test/resources/results/app14.json
+++ b/springdoc-openapi-data-rest/src/test/resources/results/app14.json
@@ -21,12 +21,12 @@
           {
             "name": "pages",
             "in": "query",
-            "description": "Zero-based page index (0..N)",
+            "description": "One-based page index (1..N)",
             "required": false,
             "schema": {
               "minimum": 0,
               "type": "integer",
-              "default": 0
+              "default": 1
             }
           },
           {


### PR DESCRIPTION
When the property `spring.data.web.pageable.one-indexed-parameters` is enabled, the page starts at 1 and not at 0, so the description and the default value are incoherent.

To simulate the behavior this project can be used: https://github.com/marcospds/springdoc-one-indexed-parameters