### PR TITLE
Fixes NPE in springdoc-openapi-javadoc for nested parameters with a depth > 1

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestService.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/AbstractRequestService.java
@@ -729,7 +729,7 @@ public abstract class AbstractRequestService {
 		if (delegatingMethodParameter.isParameterObject()) {
 			String fieldName;
 			if (StringUtils.isNotEmpty(pName) && pName.contains(DOT))
-				fieldName = StringUtils.substringAfter(pName, DOT);
+				fieldName = StringUtils.substringAfterLast(pName, DOT);
 			else
 				fieldName = pName;
 			Field field = FieldUtils.getDeclaredField(((DelegatingMethodParameter) methodParameter).getExecutable().getDeclaringClass(), fieldName, true);

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/ConcreteSubclassFromGeneric.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/ConcreteSubclassFromGeneric.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.app166;
+
+public class ConcreteSubclassFromGeneric extends SimpleGeneric<MyData> {
+
+    /**
+     * Return the top name
+     */
+    private String topName;
+
+    public String getTopName() {
+        return topName;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/HelloController.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/HelloController.java
@@ -1,0 +1,48 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  * Copyright 2019-2022 the original author or authors.
+ *  *  *  *
+ *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  * You may obtain a copy of the License at
+ *  *  *  *
+ *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *
+ *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.app166;
+
+
+import org.springdoc.api.annotations.ParameterObject;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+	@GetMapping("/nested")
+	public ResponseEntity<String> nested(@ParameterObject final SimpleOuterClass filter) {
+		return new ResponseEntity<>("{\"Say\": \"Hello\"}", HttpStatus.OK);
+	}
+
+	@GetMapping( "/nestedTypeErasureGeneric")
+	public ResponseEntity<String> nestedTypeErasureGeneric( @ParameterObject final SimpleGeneric<MyData> filter) {
+		return new ResponseEntity<>("{\"Say\": \"Hello\"}", HttpStatus.OK);
+	}
+
+	@GetMapping( "/nestedReifiableGeneric")
+	public ResponseEntity<String> nestedReifiableGeneric( @ParameterObject final ConcreteSubclassFromGeneric filter) {
+		return new ResponseEntity<>("{\"Say\": \"Hello\"}", HttpStatus.OK);
+	}
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/MyData.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/MyData.java
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.app166;
+
+public class MyData {
+
+    /**
+     * Returns the first name
+     */
+    private String firstName;
+
+    /**
+     * Returns the max number
+     */
+    private Integer maxNumber;
+
+    public Integer getMaxNumber() {
+        return maxNumber;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleGeneric.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleGeneric.java
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.app166;
+
+public class SimpleGeneric<T> {
+
+    /**
+     * Returns name
+     */
+    private String name;
+
+    /**
+     * Returns the generic child
+     */
+    private T child;
+
+    public T getChild() {
+        return child;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleInnerClass.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleInnerClass.java
@@ -1,0 +1,31 @@
+package test.org.springdoc.api.app166;
+
+public class SimpleInnerClass {
+
+    /**
+     * Returns the inner inner class
+     */
+    private SimpleInnerInnerClass innerInnerClass;
+
+    /**
+     * Returns the boolean name
+     */
+    private Boolean name;
+
+    /**
+     * Returns the max number
+     */
+    private Integer maxNumber;
+
+    public Integer getMaxNumber() {
+        return maxNumber;
+    }
+
+    public Boolean getName() {
+        return name;
+    }
+
+    public SimpleInnerInnerClass getInnerInnerClass() {
+        return innerInnerClass;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleInnerInnerClass.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleInnerInnerClass.java
@@ -1,0 +1,21 @@
+package test.org.springdoc.api.app166;
+
+public class SimpleInnerInnerClass {
+    /**
+     * Returns the name of the inner inner class
+     */
+    Boolean name;
+
+    /**
+     * Returns the maxNumber of the inner inner class
+     */
+    private Integer maxNumber;
+
+    public Integer getMaxNumber() {
+        return maxNumber;
+    }
+
+    public Boolean getName() {
+        return name;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleOuterClass.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SimpleOuterClass.java
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.app166;
+
+public class SimpleOuterClass {
+
+    /**
+     * Returns the name of the outer class
+     */
+    private String name;
+
+    /**
+     * Returns the inner class
+     */
+    private SimpleInnerClass innerClass;
+
+    public String getName() {
+        return name;
+    }
+
+    public SimpleInnerClass getInnerClass() {
+        return innerClass;
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SpringDocApp166Test.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app166/SpringDocApp166Test.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app166;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+/**
+ * The type Spring doc app 165 test.
+ */
+public class SpringDocApp166Test extends AbstractSpringDocTest {
+
+    /**
+     * The type Spring doc test app.
+     */
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/resources/results/app166.json
+++ b/springdoc-openapi-javadoc/src/test/resources/results/app166.json
@@ -1,0 +1,122 @@
+{
+  "openapi": "3.0.1",
+  "info": { "title": "OpenAPI definition", "version": "v0" },
+  "servers": [
+    { "url": "http://localhost", "description": "Generated server url" }
+  ],
+  "paths": {
+    "/nested": {
+      "get": {
+        "tags": ["hello-controller"],
+        "operationId": "nested",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Returns the name of the outer class",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "innerClass.innerInnerClass.name",
+            "in": "query",
+            "description": "Returns the name of the inner inner class",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "innerClass.innerInnerClass.maxNumber",
+            "in": "query",
+            "description": "Returns the maxNumber of the inner inner class",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          },
+          {
+            "name": "innerClass.name",
+            "in": "query",
+            "description": "Returns the boolean name",
+            "required": false,
+            "schema": { "type": "boolean" }
+          },
+          {
+            "name": "innerClass.maxNumber",
+            "in": "query",
+            "description": "Returns the max number",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/nestedTypeErasureGeneric": {
+      "get": {
+        "tags": ["hello-controller"],
+        "operationId": "nestedTypeErasureGeneric",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Returns name",
+            "required": false,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    },
+    "/nestedReifiableGeneric": {
+      "get": {
+        "tags": ["hello-controller"],
+        "operationId": "nestedReifiableGeneric",
+        "parameters": [
+          {
+            "name": "topName",
+            "in": "query",
+            "description": "Return the top name",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Returns name",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "child.firstName",
+            "in": "query",
+            "description": "Returns the first name",
+            "required": false,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "child.maxNumber",
+            "in": "query",
+            "description": "Returns the max number",
+            "required": false,
+            "schema": { "type": "integer", "format": "int32" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": { "*/*": { "schema": { "type": "string" } } }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
# Describe the bug
You get the following NPE when you have an nested pojo as parameter with a depth > 1 

# To Reproduce

## What version of spring-boot you are using?
1.6.9

## What modules and versions of springdoc-openapi are you using?
springdoc-openapi-javadoc

## What is the actual and the expected result using OpenAPI Description (yml or json)?

actual
```java
org.springframework.web.util.NestedServletException: Request processing failed; nested exception is java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Field.getDeclaringClass()" because "field" is null

	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:497)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at org.springframework.test.web.servlet.TestDispatcherServlet.service(TestDispatcherServlet.java:72)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:584)
	at org.springframework.mock.web.MockFilterChain$ServletFilterProxy.doFilter(MockFilterChain.java:167)
	at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:134)
	at org.springframework.web.filter.RequestContextFilter.doFilterInternal(RequestContextFilter.java:100)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:134)
	at org.springframework.web.filter.FormContentFilter.doFilterInternal(FormContentFilter.java:93)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:134)
	at org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
	at org.springframework.mock.web.MockFilterChain.doFilter(MockFilterChain.java:134)
	at org.springframework.test.web.servlet.MockMvc.perform(MockMvc.java:199)
	at test.org.springdoc.api.AbstractSpringDocTest.testApp(AbstractSpringDocTest.java:95)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
	at org.junit.platform.launcher.core.SessionPerRequestLauncher.execute(SessionPerRequestLauncher.java:53)
	at com.intellij.junit5.JUnit5IdeaTestRunner.startRunnerWithArgs(JUnit5IdeaTestRunner.java:71)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.reflect.Field.getDeclaringClass()" because "field" is null
	at com.github.therapi.runtimejavadoc.RuntimeJavadoc.getJavadoc(RuntimeJavadoc.java:222)
	at org.springdoc.openapi.javadoc.SpringDocJavadocProvider.getFieldJavadoc(SpringDocJavadocProvider.java:127)
	at org.springdoc.core.AbstractRequestService.getParamJavadoc(AbstractRequestService.java:737)
	at org.springdoc.core.AbstractRequestService.build(AbstractRequestService.java:288)
	at org.springdoc.api.AbstractOpenApiResource.calculatePath(AbstractOpenApiResource.java:453)
	at org.springdoc.api.AbstractOpenApiResource.calculatePath(AbstractOpenApiResource.java:615)
	at org.springdoc.webmvc.api.OpenApiResource.lambda$calculatePath$11(OpenApiResource.java:234)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.springdoc.webmvc.api.OpenApiResource.calculatePath(OpenApiResource.java:215)
	at org.springdoc.webmvc.api.OpenApiResource.lambda$getPaths$2(OpenApiResource.java:185)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at org.springdoc.webmvc.api.OpenApiResource.getPaths(OpenApiResource.java:164)
	at org.springdoc.api.AbstractOpenApiResource.getOpenApi(AbstractOpenApiResource.java:329)
	at org.springdoc.webmvc.api.OpenApiResource.openapiJson(OpenApiResource.java:139)
	at org.springdoc.webmvc.api.OpenApiWebMvcResource.openapiJson(OpenApiWebMvcResource.java:116)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1070)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	... 87 more
```

```json
{
  "openapi": "3.0.1",
  "info": { "title": "OpenAPI definition", "version": "v0" },
  "servers": [
    { "url": "http://localhost", "description": "Generated server url" }
  ],
  "paths": {
    "/nested": {
      "get": {
        "tags": ["hello-controller"],
        "operationId": "nested",
        "parameters": [
          {
            "name": "name",
            "in": "query",
            "description": "Returns the name of the outer class",
            "required": false,
            "schema": { "type": "string" }
          },
          {
            "name": "innerClass.innerInnerClass.name",
            "in": "query",
            "description": "Returns the name of the inner inner class",
            "required": false,
            "schema": { "type": "boolean" }
          },
          {
            "name": "innerClass.innerInnerClass.maxNumber",
            "in": "query",
            "description": "Returns the maxNumber of the inner inner class",
            "required": false,
            "schema": { "type": "integer", "format": "int32" }
          },
          {
            "name": "innerClass.name",
            "in": "query",
            "description": "Returns the boolean name",
            "required": false,
            "schema": { "type": "boolean" }
          },
          {
            "name": "innerClass.maxNumber",
            "in": "query",
            "description": "Returns the max number",
            "required": false,
            "schema": { "type": "integer", "format": "int32" }
          }
        ],
        "responses": {
          "200": {
            "description": "OK",
            "content": { "*/*": { "schema": { "type": "string" } } }
          }
        }
      }
    },
  "components": {}
}
```

## Provide with a sample code (HelloController) or Test that reproduces the problem

**All classes have a  public getter method for each member. I have left this out in the example for easier reading**

```java
public class SimpleInnerInnerClass {
    /**
     * Returns the name of the inner inner class
     */
    Boolean name;

    /**
     * Returns the maxNumber of the inner inner class
     */
    private Integer maxNumber;
}

public class SimpleInnerClass {

    /**
     * Returns the inner inner class
     */
    private SimpleInnerInnerClass innerInnerClass;

    /**
     * Returns the boolean name
     */
    private Boolean name;

    /**
     * Returns the max number
     */
    private Integer maxNumber;
}

public class SimpleOuterClass {

    /**
     * Returns the name of the outer class
     */
    private String name;

    /**
     * Returns the inner class
     */
    private SimpleInnerClass innerClass;
}
```

```java
@RestController
public class HelloController {
	@GetMapping("/nested")
	public ResponseEntity<String> nested(@ParameterObject final SimpleOuterClass filter) {
		return new ResponseEntity<>("{\"Say\": \"Hello\"}", HttpStatus.OK);
	}
}
```

# Expected behavior
If nested objects with a depth > 1 are possible as parameters, then the javadoc should also be able to query the documentation of these fields