### PR TITLE
Sort request methods

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -397,7 +398,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		routerOperation = customizeRouterOperation(routerOperation, handlerMethod);
 
 		String operationPath = routerOperation.getPath();
-		Set<RequestMethod> requestMethods = new HashSet<>(Arrays.asList(routerOperation.getMethods()));
+		Set<RequestMethod> requestMethods = new TreeSet<>(Arrays.asList(routerOperation.getMethods()));
 		io.swagger.v3.oas.annotations.Operation apiOperation = routerOperation.getOperation();
 		String[] methodConsumes = routerOperation.getConsumes();
 		String[] methodProduces = routerOperation.getProduces();

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app167/HelloController.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app167/HelloController.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app167;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The type Hello controller.
+ */
+@RestController("/api")
+public class HelloController {
+
+    @RequestMapping("/process")
+    public void process() {
+
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app167/SpringDocApp167Test.java
+++ b/springdoc-openapi-javadoc/src/test/java/test/org/springdoc/api/app167/SpringDocApp167Test.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app167;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+/**
+ * The type Spring doc app 167 test.
+ */
+public class SpringDocApp167Test extends AbstractSpringDocTest {
+
+    /**
+     * The type Spring doc test app.
+     */
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
+}

--- a/springdoc-openapi-javadoc/src/test/resources/results/app167.json
+++ b/springdoc-openapi-javadoc/src/test/resources/results/app167.json
@@ -1,0 +1,101 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "OpenAPI definition",
+        "version": "v0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost",
+            "description": "Generated server url"
+        }
+    ],
+    "tags": [
+        {
+            "name": "hello-controller",
+            "description": "The type Hello controller."
+        }
+    ],
+    "paths": {
+        "/process": {
+            "get": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "put": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_3",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "post": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_2",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_5",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "options": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_6",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "head": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_1",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            },
+            "patch": {
+                "tags": [
+                    "hello-controller"
+                ],
+                "operationId": "process_4",
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    },
+    "components": {}
+}


### PR DESCRIPTION
There is a bug with a random integer suffix for generated operation id when there is `@RequestMapping` without a specific method.

Similar to another issue that was solved already: https://github.com/springdoc/springdoc-openapi/issues/96

But the solution introduced for the closed issue didn't help in this case.

Added a test to show it is solved. You can reproduce the issue by reverting from TreeSet to HashSet and running the test multiple times (you will see you get different operation IDs randomly).

The reason is, HashSet does not guarantee the same order, so in different runs, it may produce different orders and therefor different operation ids.

It is my first open-source contribution so please let me know if I missed anything in the process.