### PR TITLE
(fix): change ParameterId hashCode()

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterId.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/ParameterId.java
@@ -141,6 +141,6 @@ public class ParameterId {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(pName, paramType, $ref);
+		return Objects.hash(pName);
 	}
 }


### PR DESCRIPTION
Fixes #1901 

- Objects.hash(pName, paramType, $ref) -> Objects.hash(pName);

In version 1.6.11 `ParameterId` was simply `String name`.
There is a new `ParameterId` in version 1.6.12 and there is a bug.
So I changed `ParameterId.hashCode()` code to `String name`.