### PR TITLE
fix(sec): upgrade org.springframework.security.oauth:spring-security-oauth2 to 2.5.2.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 		<nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
 		<swagger-api.version>2.2.4</swagger-api.version>
 		<swagger-ui.version>4.15.0</swagger-ui.version>
-		<spring-security-oauth2.version>2.3.8.RELEASE</spring-security-oauth2.version>
+		<spring-security-oauth2.version>2.5.2.RELEASE</spring-security-oauth2.version>
 		<classgraph.version>4.8.149</classgraph.version>
 		<webjars-locator-core.version>0.52</webjars-locator-core.version>
 		<gmavenplus-plugin.version>1.8.1</gmavenplus-plugin.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.springframework.security.oauth:spring-security-oauth2 2.3.8.RELEASE
- [CVE-2022-22969](https://www.oscs1024.com/hd/CVE-2022-22969)


### What did I do？
Upgrade org.springframework.security.oauth:spring-security-oauth2 from 2.3.8.RELEASE to 2.5.2.RELEASE for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS