### PR TITLE
fix: check existence of superclass before accessing its name

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/MethodParameterPojoExtractor.java
@@ -174,9 +174,8 @@ class MethodParameterPojoExtractor {
 		try {
 			Parameter parameter = field.getAnnotation(Parameter.class);
 			boolean isNotRequired = parameter == null || !parameter.required();
-			Annotation[] finalFieldAnnotations = fieldAnnotations;
 
-			if ("java.lang.Record".equals(paramClass.getSuperclass().getName())) {
+			if (paramClass.getSuperclass() != null && "java.lang.Record".equals(paramClass.getSuperclass().getName())) {
 				Method classGetRecordComponents = Class.class.getMethod("getRecordComponents");
 				Object[] components = (Object[]) classGetRecordComponents.invoke(paramClass);
 
@@ -191,7 +190,7 @@ class MethodParameterPojoExtractor {
 						.filter(method -> method.getName().equals(field.getName()))
 						.map(method -> new MethodParameter(method, -1))
 						.map(methodParameter -> DelegatingMethodParameter.changeContainingClass(methodParameter, paramClass))
-						.map(param -> new DelegatingMethodParameter(param, fieldNamePrefix + field.getName(), finalFieldAnnotations, true, isNotRequired));
+						.map(param -> new DelegatingMethodParameter(param, fieldNamePrefix + field.getName(), fieldAnnotations, true, isNotRequired));
 
 			}
 			else
@@ -201,7 +200,7 @@ class MethodParameterPojoExtractor {
 						.filter(Objects::nonNull)
 						.map(method -> new MethodParameter(method, -1))
 						.map(methodParameter -> DelegatingMethodParameter.changeContainingClass(methodParameter, paramClass))
-						.map(param -> new DelegatingMethodParameter(param, fieldNamePrefix + field.getName(), finalFieldAnnotations, true, isNotRequired));
+						.map(param -> new DelegatingMethodParameter(param, fieldNamePrefix + field.getName(), fieldAnnotations, true, isNotRequired));
 		}
 		catch (IntrospectionException | NoSuchMethodException |
 			   InvocationTargetException | IllegalAccessException |


### PR DESCRIPTION
According to the JDK doc, getSuperClass() could return null.

> Returns the Class representing the direct superclass of the entity (class, interface, primitive type or void) represented by this Class. If this Class represents either the Object class, an interface, a primitive type, or void, then null is returned. If this object represents an array class then the Class object representing the Object class is returned.
Returns:
the direct superclass of the class represented by this object

In our env, without a null check first, this line caused scanning of parameter types that are interfaces to throw NPE.