### PR TITLE
configure openapi ObjectMapper using spring builder settings

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfiguration.java
@@ -99,6 +99,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.rest.core.config.RepositoryRestConfiguration;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -608,13 +609,14 @@ public class SpringDocConfiguration {
 	 * Object mapper provider object mapper provider.
 	 *
 	 * @param springDocConfigProperties the spring doc config properties
+	 * @param objectMapperBuilder the object mapper builder
 	 * @return the object mapper provider
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@Lazy(false)
-	ObjectMapperProvider springDocObjectMapperProvider(SpringDocConfigProperties springDocConfigProperties){
-		return new ObjectMapperProvider(springDocConfigProperties);
+	ObjectMapperProvider springDocObjectMapperProvider(SpringDocConfigProperties springDocConfigProperties, Jackson2ObjectMapperBuilder objectMapperBuilder) {
+		return new ObjectMapperProvider(springDocConfigProperties, objectMapperBuilder);
 	}
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
@@ -38,6 +38,7 @@ import org.springdoc.api.mixins.SortedSchemaMixin;
 import org.springdoc.api.mixins.SortedSchemaMixin31;
 import org.springdoc.core.SpringDocConfigProperties;
 import org.springdoc.core.SpringDocConfigProperties.ApiDocs.OpenApiVersion;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 /**
  * The type Spring doc object mapper provider.
@@ -58,8 +59,9 @@ public class ObjectMapperProvider extends ObjectMapperFactory {
 	 * Instantiates a new Spring doc object mapper.
 	 *
 	 * @param springDocConfigProperties the spring doc config properties
+	 * @param objectMapperBuilder the object mapper builder
 	 */
-	public ObjectMapperProvider(SpringDocConfigProperties springDocConfigProperties) {
+	public ObjectMapperProvider(SpringDocConfigProperties springDocConfigProperties, Jackson2ObjectMapperBuilder objectMapperBuilder) {
 		OpenApiVersion openApiVersion = springDocConfigProperties.getApiDocs().getVersion();
 		if (openApiVersion == OpenApiVersion.OPENAPI_3_1) {
 			jsonMapper = Json31.mapper();
@@ -69,6 +71,7 @@ public class ObjectMapperProvider extends ObjectMapperFactory {
 			jsonMapper = Json.mapper();
 			yamlMapper = Yaml.mapper();
 		}
+		objectMapperBuilder.configure(jsonMapper);
 	}
 
 	/**


### PR DESCRIPTION
allows to swagger-core to detect enabled features like DEFAULT_VIEW_INCLUSION (see swagger-api/swagger-core#4127)