### PR TITLE
not cache swagger-initializer.js. #1929

### DIFF
--- a/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
+++ b/springdoc-openapi-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
@@ -49,6 +49,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import static org.springdoc.core.Constants.CLASSPATH_RESOURCE_LOCATION;
 import static org.springdoc.core.Constants.DEFAULT_WEB_JARS_PREFIX_URL;
+import static org.springdoc.core.Constants.SWAGGER_INITIALIZER_JS;
 import static org.springdoc.core.Constants.SWAGGER_UI_PREFIX;
 import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
@@ -95,6 +96,12 @@ public class SwaggerWebMvcConfigurer implements WebMvcConfigurer {
 			uiRootPath.append(swaggerPath, 0, swaggerPath.lastIndexOf(DEFAULT_PATH_SEPARATOR));
 		if (actuatorProvider.isPresent() && actuatorProvider.get().isUseManagementPort())
 			uiRootPath.append(actuatorProvider.get().getBasePath());
+
+		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + "*/*" + SWAGGER_INITIALIZER_JS)
+				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR)
+				.setCachePeriod(0)
+				.resourceChain(false)
+				.addTransformer(swaggerIndexTransformer);
 
 		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + "*/**")
 				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR)

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
@@ -37,6 +37,7 @@ public abstract class AbstractSpringDocTest extends AbstractCommonTest {
 		MvcResult mvcResult = mockMvc.perform(get(uri)).andExpect(status().isOk()).andReturn();
 		String transformedIndex = mvcResult.getResponse().getContentAsString();
 		assertTrue(transformedIndex.contains("window.ui"));
+		assertEquals("no-store", mvcResult.getResponse().getHeader("Cache-Control"));
 		assertEquals(this.getContent(fileName), transformedIndex.replace("\r", ""));
 	}
 


### PR DESCRIPTION
Thank you.
This pull request is for #1929.
Set `Cache-Control: no-store` in swagger-initializer.js.

<img width="727" alt="スクリーンショット 2022-11-06 2 26 19" src="https://user-images.githubusercontent.com/36355491/200133175-ea7f0ccd-ccc8-4a95-bf3b-a5f4bcd73993.png">

Please let me know if you have any problems with this feature.
