### PR TITLE
Fixed a few documentation typos/broken URLs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,5 +35,5 @@ individual is representing the project or its community.
 
 This Code of Conduct is adapted from the
 [Contributor Covenant](https://contributor-covenant.org), version 1.3.0, available at
-contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/[) and [spring-boot
+[contributor-covenant.org/version/1/3/0/](https://contributor-covenant.org/version/1/3/0/) and [spring-boot
 Contributor Code of Conduct](https://github.com/spring-projects/spring-boot/blob/master/CODE_OF_CONDUCT.adoc)

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Pivotal)
 * Automatically deploys swagger-ui to a Spring Boot 2.x application
 * Documentation will be available in HTML format, using the
   official [swagger-ui jars](https://github.com/swagger-api/swagger-ui.git).
-* The Swagger UI page should then be available at http://server:
-  port/context-path/swagger-ui.html and the OpenAPI description will be available at the
+* The Swagger UI page should then be available at 
+http://server:port/context-path/swagger-ui.html and the OpenAPI description will be available at the
   following url for json format: http://server:port/context-path/v3/api-docs
     * `server`: The server name or IP
     * `port`: The server port
@@ -125,8 +125,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 
 ## Integration of the library in a Spring Boot 2.x.x project without the swagger-ui:
 
-* Documentation will be available at the following url for json format: http://server:
-  port/context-path/v3/api-docs
+* Documentation will be available at the following url for json format: http://server:port/context-path/v3/api-docs
     * `server`: The server name or IP
     * `port`: The server port
     * `context-path`: The context path of the application
@@ -220,7 +219,7 @@ its [contributors](https://github.com/springdoc/springdoc-openapi/graphs/contrib
   <img src="https://contrib.rocks/image?repo=springdoc/springdoc-openapi" width="50%"/>
 </a>
 
-Thanks you all for your support!
+Thank you all for your support!
 
 ## Additional Support
 


### PR DESCRIPTION
- Fixed 1 typo in `README.md` and 2 broken URLs (they had a space in them, also breaking the hyperlink)
- Fixed 1 broken URL at `CODE_OF_CONDUCT.md` (it seems that the brackets were misplaced for the display text of the link)