### PR TITLE
Avoid `example: null` when sorted

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/mixins/SortedSchemaMixin.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/mixins/SortedSchemaMixin.java
@@ -71,7 +71,7 @@ public interface SortedSchemaMixin {
 	 *
 	 * @return the example
 	 */
-	@JsonInclude(JsonInclude.Include.CUSTOM)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	Object getExample();
 
 	/**

--- a/springdoc-openapi-common/src/main/java/org/springdoc/api/mixins/SortedSchemaMixin31.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/api/mixins/SortedSchemaMixin31.java
@@ -135,7 +135,7 @@ public interface SortedSchemaMixin31 {
 	 *
 	 * @return the example
 	 */
-	@JsonInclude(JsonInclude.Include.CUSTOM)
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	Object getExample();
 
 	/**


### PR DESCRIPTION
- Seen when `springdoc.writer-with-order-by-keys` is enabled, but not when disabled.
- Avoids unnecessary entry in api specification.

While this fix seems good, I wonder what the original intent was of using `JsonInclude.Include.CUSTOM`... 