### PR TITLE
:bug: Fix properties `show-oauth2-endpoints` and `SpringDocConfigProperties#showOauth2Endpoint` properties name mismatch

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocConfigProperties.java
@@ -203,9 +203,9 @@ public class SpringDocConfigProperties {
 	private boolean nullableRequestParameterEnabled;
 
 	/**
-	 * The Show oauth 2 endpoint.
+	 * The Show oauth2 endpoints.
 	 */
-	private boolean showOauth2Endpoint;
+	private boolean showOauth2Endpoints;
 
 	/**
 	 * Gets override with generic response.
@@ -1506,11 +1506,11 @@ public class SpringDocConfigProperties {
 		}
 	}
 
-	public boolean isShowOauth2Endpoint() {
-		return showOauth2Endpoint;
+	public boolean isShowOauth2Endpoints() {
+		return showOauth2Endpoints;
 	}
 
-	public void setShowOauth2Endpoint(boolean showOauth2Endpoint) {
-		this.showOauth2Endpoint = showOauth2Endpoint;
+	public void setShowOauth2Endpoints(boolean showOauth2Endpoint) {
+		this.showOauth2Endpoints = showOauth2Endpoint;
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20430677/226374391-e0a7edde-9dc1-4a75-b02e-53a1ac65e3c3.png)

![image](https://user-images.githubusercontent.com/20430677/226375001-462f609b-68b6-4061-b75c-802d1d2d9adb.png)


The attribute name is incorrect, causing the IDE to generate an error prompt.