### PR TITLE
fixed DefaultFlatParamObject to work with annotated parameters. Fixes…

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/DelegatingMethodParameter.java
@@ -125,21 +125,12 @@ public class DelegatingMethodParameter extends MethodParameter {
 					explodedParameters.add(methodParameter);
 				});
 			}
-			else if (defaultFlatParamObject) {
-				boolean isSimpleType = MethodParameterPojoExtractor.isSimpleType(paramClass);
-				boolean hasAnnotation = p.hasParameterAnnotations();
-				boolean shouldFlat = !isSimpleType && !hasAnnotation;
-				if (shouldFlat && !AbstractRequestService.isRequestTypeToIgnore(paramClass)) {
-					MethodParameterPojoExtractor.extractFrom(paramClass).forEach(methodParameter -> {
-						optionalDelegatingMethodParameterCustomizer
-								.ifPresent(customizer -> customizer.customize(p, methodParameter));
-						explodedParameters.add(methodParameter);
-					});
-				}
-				else {
-					String name = pNames != null ? pNames[i] : p.getParameterName();
-					explodedParameters.add(new DelegatingMethodParameter(p, name, null, false, false));
-				}
+			else if (defaultFlatParamObject && !MethodParameterPojoExtractor.isSimpleType(paramClass) && !AbstractRequestService.isRequestTypeToIgnore(paramClass)) {
+				MethodParameterPojoExtractor.extractFrom(paramClass).forEach(methodParameter -> {
+					optionalDelegatingMethodParameterCustomizer
+							.ifPresent(customizer -> customizer.customize(p, methodParameter));
+					explodedParameters.add(methodParameter);
+				});
 			}
 			else {
 				String name = pNames != null ? pNames[i] : p.getParameterName();

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/DefaultFlatParamObjectController.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/DefaultFlatParamObjectController.java
@@ -1,0 +1,20 @@
+package test.org.springdoc.api.v30.app204;
+
+import org.springdoc.api.annotations.ParameterObject;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.SortDefault;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DefaultFlatParamObjectController {
+	@GetMapping("/test1")
+	public String test1(@RequestParam String email, @Validated Person person, @SortDefault("name") @ParameterObject Sort sort) {
+		return null;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/Person.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/Person.java
@@ -1,0 +1,33 @@
+package test.org.springdoc.api.v30.app204;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+public class Person {
+	private long id;
+
+	private String firstName;
+
+	@NotBlank
+	@Size(max = 10)
+	private String lastName;
+
+	public Person(long id, String firstName, String lastName) {
+		this.id = id;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+}

--- a/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/SpringDocApp204Test.java
+++ b/springdoc-openapi-webmvc-core/src/test/java/test/org/springdoc/api/v30/app204/SpringDocApp204Test.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  * Copyright 2019-2023 the original author or authors.
+ *  *  *  *
+ *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  * You may obtain a copy of the License at
+ *  *  *  *
+ *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *
+ *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app204;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.Constants;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = { "springdoc.default-flat-param-object=true" })
+public class SpringDocApp204Test extends AbstractSpringDocV30Test {
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-webmvc-core/src/test/resources/results/3.0.1/app204.json
+++ b/springdoc-openapi-webmvc-core/src/test/resources/results/3.0.1/app204.json
@@ -1,0 +1,88 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/test1": {
+      "get": {
+        "tags": [
+          "default-flat-param-object-controller"
+        ],
+        "operationId": "test1",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "firstName",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lastName",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "maxLength": 10,
+              "minLength": 0,
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "default": [
+                "name,ASC"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
fix #2181

Since there is no test code in the repository from before, I don't know why it is doing annotation checks.
However, since the target parameter can be determined by `AbstractRequestService.isRequestTypeToIgnore`, I would like to remove the annotation retention confirmation process.

Related PR: https://github.com/springdoc/springdoc-openapi/pull/1805/files

