### PR TITLE
Add support for swagger-ui.url property

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerIndexTransformer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerIndexTransformer.java
@@ -136,6 +136,16 @@ public class AbstractSwaggerIndexTransformer {
 	}
 
 	/**
+	 * Setting the url configured with swagger ui properties
+	 *
+	 * @param html
+	 * @return modifed html
+	 */
+	protected String setConfiguredApiDocsUrl(String html){
+		return html.replace(Constants.SWAGGER_UI_DEFAULT_URL, swaggerUiConfig.getUrl());
+	}
+
+	/**
 	 * Default transformations string.
 	 *
 	 * @param inputStream the input stream
@@ -166,6 +176,10 @@ public class AbstractSwaggerIndexTransformer {
 
 		if (swaggerUiConfig.isDisableSwaggerDefaultUrl())
 			html = overwriteSwaggerDefaultUrl(html);
+
+		if(StringUtils.isNotEmpty(swaggerUiConfig.getUrl())){
+			html = setConfiguredApiDocsUrl(html);
+		}
 
 		return html;
 	}

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/ui/AbstractSwaggerIndexTransformerTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/ui/AbstractSwaggerIndexTransformerTest.java
@@ -1,0 +1,68 @@
+package org.springdoc.ui;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springdoc.core.properties.SwaggerUiConfigParameters;
+import org.springdoc.core.properties.SwaggerUiConfigProperties;
+import org.springdoc.core.properties.SwaggerUiOAuthProperties;
+import org.springdoc.core.providers.ObjectMapperProvider;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+@ExtendWith(MockitoExtension.class)
+public class AbstractSwaggerIndexTransformerTest {
+
+    private SwaggerUiConfigProperties swaggerUiConfig;
+    @Mock
+    private SwaggerUiOAuthProperties swaggerUiOAuthProperties;
+    @Mock
+    private SwaggerUiConfigParameters swaggerUiConfigParameters;
+    @Mock
+    private ObjectMapperProvider objectMapperProvider;
+
+    private AbstractSwaggerIndexTransformer underTest;
+
+    private final String swaggerInitJs = "window.onload = function() {\n" +
+            "\n" +
+            "  window.ui = SwaggerUIBundle({\n" +
+            "    url: \"https://petstore.swagger.io/v2/swagger.json\",\n" +
+            "    dom_id: '#swagger-ui',\n" +
+            "    deepLinking: true,\n" +
+            "    presets: [\n" +
+            "      SwaggerUIBundle.presets.apis,\n" +
+            "      SwaggerUIStandalonePreset\n" +
+            "    ],\n" +
+            "    plugins: [\n" +
+            "      SwaggerUIBundle.plugins.DownloadUrl\n" +
+            "    ],\n" +
+            "    layout: \"StandaloneLayout\"\n" +
+            "  });\n" +
+            "\n" +
+            "  //</editor-fold>\n" +
+            "};";
+    private final InputStream is = new ByteArrayInputStream(swaggerInitJs.getBytes());
+
+    private final String apiDocUrl = "http://test.springdoc.com/apidoc";
+
+    @BeforeEach
+    public void setup(){
+        swaggerUiConfig = new SwaggerUiConfigProperties();
+        swaggerUiConfig.setUrl(apiDocUrl);
+        underTest = new AbstractSwaggerIndexTransformer(swaggerUiConfig, swaggerUiOAuthProperties, swaggerUiConfigParameters, objectMapperProvider);
+
+    }
+
+    @Test
+    void setApiDocUrlCorrectly() throws IOException {
+        var html = underTest.defaultTransformations(is);
+        assertThat(html, containsString(apiDocUrl));
+    }
+}


### PR DESCRIPTION
As setting the url via application.properties is not supported with the current release (2.0.4) i had to implement a Workaround until this PR get merged and release.

With this change it will be possible to set the api-docs url in the config without activating QueryConfig to be able to load the api-docs directly on loading the swagger ui.

HotFix/Workaroung:

`
springdoc:
  swagger-ui:
    disable-swagger-default-url: true
`

`
@Bean
    @Primary
    @ConditionalOnMissingBean
    @Lazy(false)
    SwaggerIndexTransformer indexPageTransformer(SwaggerUiConfigProperties swaggerUiConfig, SwaggerUiOAuthProperties swaggerUiOAuthProperties,
            SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerWelcomeCommon swaggerWelcomeCommon, ObjectMapperProvider objectMapperProvider) {
        return new FixingSwaggerIndexTransformer(swaggerUiConfig, swaggerUiOAuthProperties, swaggerUiConfigParameters, swaggerWelcomeCommon, objectMapperProvider);
    }
`

`
public class FixingSwaggerIndexTransformer extends SwaggerIndexPageTransformer {
    /**
     * Instantiates a new Swagger index transformer.
     *
     * @param swaggerUiConfig           the swagger ui config
     * @param swaggerUiOAuthProperties  the swagger ui o auth properties
     * @param swaggerUiConfigParameters the swagger ui config parameters
     * @param swaggerWelcomeCommon      the swagger welcome common
     * @param objectMapperProvider      the object mapper provider
     */
    public FixingSwaggerIndexTransformer(SwaggerUiConfigProperties swaggerUiConfig, SwaggerUiOAuthProperties swaggerUiOAuthProperties,
            SwaggerUiConfigParameters swaggerUiConfigParameters, SwaggerWelcomeCommon swaggerWelcomeCommon, ObjectMapperProvider objectMapperProvider) {
        super(swaggerUiConfig, swaggerUiOAuthProperties, swaggerUiConfigParameters, swaggerWelcomeCommon, objectMapperProvider);
    }

    @Override
    protected String overwriteSwaggerDefaultUrl(String html) {
        return html.replace(Constants.SWAGGER_UI_DEFAULT_URL, swaggerUiConfig.getUrl());
    }
}
`