### PR TITLE
#2193 Fix Swagger UI with provided spec

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUIConfiguration.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/core/SpringDocUIConfiguration.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
@@ -46,7 +45,6 @@ import org.springframework.util.AntPathMatcher;
  * @author bnasslahsen
  */
 @Lazy(false)
-@ConditionalOnExpression("${springdoc.api-docs.enabled:true}")
 @ConditionalOnWebApplication
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnBean(SpringDocConfiguration.class)


### PR DESCRIPTION
Fixes #2193.

For cases where Swagger UI should be deactivated completely, `@ConditionalOnBean(SpringDocConfiguration.class)` should still be sufficient for excluding the config - at least that is my understanding :)