### PR TITLE
Using both generated and configured specs stoped working in 1.6.5

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
@@ -132,10 +132,11 @@ public abstract class AbstractSwaggerWelcome {
 			else
 				swaggerUiConfigParameters.addUrl(apiDocsUrl);
 			if (!CollectionUtils.isEmpty(swaggerUiConfig.getUrls())) {
-				swaggerUiConfigParameters.setUrls(swaggerUiConfig.cloneUrls());
-				swaggerUiConfigParameters.getUrls().forEach(swaggerUrl -> {
+				swaggerUiConfig.cloneUrls().forEach(swaggerUrl -> {
+					swaggerUiConfigParameters.getUrls().remove(swaggerUrl);
 					if (!swaggerUiConfigParameters.isValidUrl(swaggerUrl.getUrl()))
 						swaggerUrl.setUrl(buildUrlWithContextPath(swaggerUrl.getUrl()));
+					swaggerUiConfigParameters.getUrls().add(swaggerUrl);
 				});
 			}
 		}

--- a/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocSwaggerConfigWithBothFileGeneratedSpecsTest.java
+++ b/springdoc-openapi-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocSwaggerConfigWithBothFileGeneratedSpecsTest.java
@@ -19,24 +19,30 @@
 package test.org.springdoc.ui.app1;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.test.annotation.DirtiesContext;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/*
+	Test showing how specs generated at runtime and specs configured in can work at the same time.
 
+	The expectation is that the openapi.yml file will be shown together with the generated ones.
+ */
 @DirtiesContext
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
 		properties = { "spring.jackson.property-naming-strategy=UPPER_CAMEL_CASE", "springdoc.show-actuator=true",
 				"management.endpoints.web.base-path=/management",
-				"server.servlet.context-path=/demo/api", "management.server.port=9002", "management.server.base-path=/demo/api" })
-public class SpringDocSwaggerConfigTest extends AbstractSpringDocActuatorTest {
+				"server.servlet.context-path=/demo/api", "management.server.port=9002", "management.server.base-path=/demo/api",
+				"springdoc.swagger-ui.urls[0].url=/api-docs/xxx/v1/openapi.yml",
+				"springdoc.swagger-ui.urls[0].name=toto",
+})
+public class SpringDocSwaggerConfigWithBothFileGeneratedSpecsTest extends AbstractSpringDocActuatorTest {
 
 	@Test
 	public void testIndexSwaggerConfig() throws Exception {
@@ -47,8 +53,10 @@ public class SpringDocSwaggerConfigTest extends AbstractSpringDocActuatorTest {
 				.andExpect(jsonPath("url").doesNotExist())
 				.andExpect(jsonPath("urls[0].url", equalTo("/demo/api/v3/api-docs/springdocDefault")))
 				.andExpect(jsonPath("urls[0].name", equalTo("springdocDefault")))
-				.andExpect(jsonPath("urls[1].url", equalTo("/demo/api/v3/api-docs/x-actuator")))
-				.andExpect(jsonPath("urls[1].name", equalTo("x-actuator")));
+				.andExpect(jsonPath("urls[1].url", equalTo("/demo/api/api-docs/xxx/v1/openapi.yml")))
+				.andExpect(jsonPath("urls[1].name", equalTo("toto")))
+				.andExpect(jsonPath("urls[2].url", equalTo("/demo/api/v3/api-docs/x-actuator")))
+				.andExpect(jsonPath("urls[2].name", equalTo("x-actuator")));
 	}
 
 

--- a/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app145/SpringDocApp1451Test.java
+++ b/springdoc-openapi-webflux-core/src/test/java/test/org/springdoc/api/app145/SpringDocApp1451Test.java
@@ -19,6 +19,7 @@
 package test.org.springdoc.api.app145;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.annotation.DirtiesContext;
 import test.org.springdoc.api.AbstractSpringDocActuatorTest;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -32,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 
+@DirtiesContext
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT,
 		properties = { "management.endpoints.web.exposure.include=*",
 				"server.port=55594",


### PR DESCRIPTION
Hi, prior to version 1.6.5 I could you use both a spec file and generated spec from annotations. This behavior is something I need to be able to upgrade to a later version. I am not sure if this feature that I have been using was even ment to work but it did and I would very much appreciate if we could bring it back.

You can find in this pull request a test and a fix for my problem. I think I put the test in the wrong place so I would appreciate if you could help me improve the test. Also as I don't know the code I think the fix might also be in the wrong place.

Best regards
Björn Blomqvist