### PR TITLE
String Index Out of Bounce Exception Fix when deployed on Azure

### DIFF
--- a/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerResourceResolver.java
+++ b/springdoc-openapi-common/src/main/java/org/springdoc/ui/AbstractSwaggerResourceResolver.java
@@ -67,7 +67,7 @@ public class AbstractSwaggerResourceResolver {
 	 * @return the string
 	 */
 	private String path(String webjar, String path) {
-		if (path.startsWith(webjar)) {
+		if (path.startsWith(webjar) && path.length() > webjar.length()) {
 			path = path.substring(webjar.length() + 1);
 		}
 		return path;


### PR DESCRIPTION
Hi,

I have fixed the issue (string index out of bounce when deployed on Azure). This exception occurs when the length of the path is less than the length of the webjar. So I added a condition to check the length of the path must be greater than webjar length. Hope you merge the PR.

Thanks,
Nithish