### PR TITLE
Upgrade Swagger UI to 5.1.0 for OpenAPI 3.1 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
 		<swagger-api.version>2.2.11</swagger-api.version>
-		<swagger-ui.version>4.19.0</swagger-ui.version>
+		<swagger-ui.version>5.1.0</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jaxb-impl.version>2.1</jaxb-impl.version>
 		<javax.jws-api.version>1.1</javax.jws-api.version>


### PR DESCRIPTION
See https://github.com/springdoc/springdoc-openapi/issues/2261#issue-1753930746 for more.

Anyone who wants to add OpenAPI 3.1 support can set properties like this:

```diff
springdoc:
  api-docs:
    enabled: true
+   version: OPENAPI_3_1
  swagger-ui:
    enabled: true
```

Resolves #2261, resolves #2037, resolves #1438, resolves #1181
