### PR TITLE
fix loop when reponse inherits generic class #2271

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/parsers/ReturnTypeParser.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/parsers/ReturnTypeParser.java
@@ -27,6 +27,7 @@ package org.springdoc.core.parsers;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
 import java.util.Objects;
 
 import org.springframework.core.MethodParameter;
@@ -92,7 +93,8 @@ public interface ReturnTypeParser {
 					resolvableTypes[i] = resolvableType;
 			}
 			else if (resolvableTypes[i].hasGenerics()) {
-				resolveType(resolvableTypes[i].getGenerics(), contextClass);
+				if(!Arrays.equals(resolvableTypes[i].getGenerics(), resolvableTypes))
+					resolveType(resolvableTypes[i].getGenerics(), contextClass);
 				if (resolvableTypes[i].getRawClass() != null)
 					resolvableTypes[i] = ResolvableType.forClassWithGenerics(Objects.requireNonNull(resolvableTypes[i].getRawClass()), resolvableTypes[i].getGenerics());
 			}


### PR DESCRIPTION
#2271

The code was a recursive loop when the generics of resolvableTypes are the same resolvableTypes.

Before (2.0.9):
![image](https://github.com/springdoc/springdoc-openapi/assets/8590404/61847083-94a3-4bea-b74e-650c4684f5fc)

After (2.1.1-SNAPSHOT fixed):
![image](https://github.com/springdoc/springdoc-openapi/assets/8590404/520048b7-740f-407e-885f-40d49cbd4caa)

App of to simulation:
https://github.com/marcospds/springdoc-inherits-generic-class