### PR TITLE
Same model name converter

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/SameModelNameConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/SameModelNameConverter.java
@@ -1,0 +1,115 @@
+package org.springdoc.core.converters;
+
+import com.fasterxml.jackson.databind.JavaType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.media.Schema;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springdoc.core.providers.ObjectMapperProvider;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Multiple models with the same class name will be parsed into the same.
+ * For example, given 2 models crm.model.User and sys.model.User as model classes,
+ * only 1 will appear in openapi specification. The resulting specification may be incorrect.
+ * </p>
+ * Finds model classes with same name but different package, and renames model in specification.
+ *
+ * @author dsankouski
+ */
+public class SameModelNameConverter implements ModelConverter {
+
+    private final Logger logger = LogManager.getLogger(SameModelNameConverter.class);
+
+    private List<String> packagesToScan = new ArrayList<>();
+    /**
+     * The Spring doc object mapper.
+     */
+    private final ObjectMapperProvider springDocObjectMapper;
+    private Map<String, String> models = new HashMap<>();
+    /**
+     * Openapi doc generator calls model converters several times for each type.
+     * This lead to log polluting with same log entries.
+     * <p>
+     * Saving already reported duplications, to log problem only once.
+     */
+    private final Set<String> reportedDuplications = new HashSet<>();
+
+    public SameModelNameConverter(
+            ObjectMapperProvider springDocObjectMapper,
+            List<String> packagesToScan
+    ) {
+        this.packagesToScan = packagesToScan;
+        this.springDocObjectMapper = springDocObjectMapper;
+    }
+
+    /**
+     * Instantiates a new Polymorphic model converter.
+     *
+     * @param springDocObjectMapper the spring doc object mapper
+     */
+    public SameModelNameConverter(ObjectMapperProvider springDocObjectMapper) {
+        this.springDocObjectMapper = springDocObjectMapper;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public Schema resolve(
+            AnnotatedType type,
+            ModelConverterContext context,
+            Iterator<ModelConverter> chain) {
+        final Schema schema = chain.hasNext() ? chain.next().resolve(type, context, chain) : null;
+        JavaType javaType = springDocObjectMapper.jsonMapper().constructType(type.getType());
+        var rawClass = javaType.getRawClass();
+        var customSchemaName = Arrays.stream(rawClass.getAnnotations())
+                .filter(a -> a instanceof io.swagger.v3.oas.annotations.media.Schema)
+                .map(a -> (io.swagger.v3.oas.annotations.media.Schema) a)
+                .map(io.swagger.v3.oas.annotations.media.Schema::name)
+                .reduce(String::concat)
+                .orElse("");
+        var fullTypeName = rawClass.getCanonicalName();
+        var isEnum = rawClass.isEnum();
+        var modelName = customSchemaName.isEmpty() ? rawClass.getSimpleName() : customSchemaName;
+        var shouldScan = packagesToScan.stream().anyMatch(p -> {
+            Pattern pattern = Pattern.compile(wildcardPatternToRegex(p));
+            Matcher m = pattern.matcher(fullTypeName);
+
+            return m.find();
+        });
+
+        logger.debug(String.format("model: %s", modelName));
+        if (!shouldScan) {
+            return schema;
+        }
+        if (!models.containsKey(fullTypeName) && !isEnum && schema != null) {
+            if (models.containsValue(modelName)) {
+                var duplicateType = models.entrySet().stream().filter(e -> e.getValue().equals(modelName)).findFirst().orElseThrow();
+                var errorMessage = String.format("Cannot add %s model, because model with name '%s' already present (%s). Please, rename",
+                        fullTypeName, modelName, duplicateType);
+                if (!reportedDuplications.contains(errorMessage)) {
+                    logger.error(errorMessage);
+                    reportedDuplications.add(errorMessage);
+                }
+                var renameCandidateName = String.format("%sRenameCandidate", modelName);
+                schema.name(renameCandidateName)
+                        .description(errorMessage)
+                        .type("object")
+                        .set$ref(null);
+                context.defineModel(renameCandidateName, schema);
+                return schema;
+            } else {
+                models.put(fullTypeName, modelName);
+            }
+        }
+        return schema;
+    }
+
+    private String wildcardPatternToRegex(String wildcardPattern) {
+        return ("\\Q" + wildcardPattern + "\\E").replaceAll("\\*", "\\E.*\\Q");
+    }
+}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
@@ -98,6 +98,7 @@ public final class Constants {
 	 * The constant SPRINGDOC_POLYMORPHIC_CONVERTER_ENABLED.
 	 */
 	public static final String SPRINGDOC_POLYMORPHIC_CONVERTER_ENABLED = "springdoc.model-converters.polymorphic-converter.enabled";
+	public static final String SPRINGDOC_SAME_MODEL_NAME_CONVERTER_ENABLED = "springdoc.model-converters.same-model-name-converter.enabled";
 
 	/**
 	 * The constant SPRINGDOC_SCHEMA_RESOLVE_PROPERTIES.

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app114/SpringDocApp114Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app114/SpringDocApp114Test.java
@@ -28,12 +28,14 @@ import java.math.BigDecimal;
 
 import javax.money.MonetaryAmount;
 
+import org.springdoc.core.utils.Constants;
 import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.test.context.TestPropertySource;
 import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-
+@TestPropertySource(properties = Constants.SPRINGDOC_SAME_MODEL_NAME_CONVERTER_ENABLED + "=false")
 public class SpringDocApp114Test extends AbstractSpringDocV30Test {
 
 	static {

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/SpringDocApp210Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/SpringDocApp210Test.java
@@ -1,0 +1,20 @@
+package test.org.springdoc.api.v30.app210;
+
+import org.springdoc.core.utils.Constants;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+
+@TestPropertySource(properties = {
+        Constants.SPRINGDOC_SAME_MODEL_NAME_CONVERTER_ENABLED + "=true",
+        "springdoc.group-configs[0].group=first",
+        "springdoc.group-configs[0].packages-to-scan=test.org.springdoc.api.v30.app210"
+})
+public class SpringDocApp210Test extends AbstractSpringDocV30Test {
+
+    @SpringBootApplication
+    static class SpringDocTestApp {
+    }
+
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/controller/SysUserController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/controller/SysUserController.java
@@ -1,0 +1,18 @@
+package test.org.springdoc.api.v30.app210.controller;
+
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import test.org.springdoc.api.v30.app210.model.domain.User;
+
+@RestController
+@RequestMapping("/api/sysUser")
+public class SysUserController {
+
+    @PostMapping("abstract-parent")
+    public test.org.springdoc.api.v30.app210.model.database.User endpoint(@RequestBody User payload) {
+        return new test.org.springdoc.api.v30.app210.model.database.User();
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/model/database/User.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/model/database/User.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.v30.app210.model.database;
+
+public class User {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/model/domain/User.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app210/model/domain/User.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.v30.app210.model.domain;
+
+public class User {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app210.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app210.json
@@ -1,0 +1,61 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api/sysUser/abstract-parent": {
+      "post": {
+        "tags": [
+          "sys-user-controller"
+        ],
+        "operationId": "endpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserRenameCandidate"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "UserRenameCandidate": {
+        "type": "object",
+        "description": "Cannot add test.org.springdoc.api.v30.app210.model.database.User model, because model with name 'User' already present (test.org.springdoc.api.v30.app210.model.domain.User=User). Please, rename"
+      }
+    }
+  }
+}


### PR DESCRIPTION
add new converter to rename model name duplications #130

Finds model classes with same name but different package,
and renames model in specification.
Ignore SameModelNameConverter in test 114, because AdditionalModelsConverter
used to pick the right class from 2 classes with the same name.

add unit test for SameModelConverter #130