### PR TITLE
Fix the failed test due to hardcoded file separators

### DIFF
--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/ui/AbstractSwaggerResourceResolverTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/ui/AbstractSwaggerResourceResolverTest.java
@@ -1,5 +1,6 @@
 package org.springdoc.ui;
 
+import java.io.File;
 import java.util.Objects;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -28,7 +29,7 @@ class AbstractSwaggerResourceResolverTest {
 		String path = "swagger-ui/swagger-initializer.js";
 
 		String actual = abstractSwaggerResourceResolver.findWebJarResourcePath(path);
-		assertEquals("swagger-ui/4.18.2/swagger-initializer.js", actual);
+		assertEquals("swagger-ui" + File.separator + "4.18.2" + File.separator + "swagger-initializer.js", actual);
 	}
 
 	@Test


### PR DESCRIPTION
This specific test fails under Windows: the `actual` path utilized `File.separator` but not the expected one.