### PR TITLE
support get javadoc description from getter method

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/JavadocPropertyCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/JavadocPropertyCustomizer.java
@@ -24,11 +24,11 @@
 
 package org.springdoc.core.customizers;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
@@ -76,15 +76,19 @@ public record JavadocPropertyCustomizer(JavadocProvider javadocProvider,
 				Class<?> cls = javaType.getRawClass();
 				Schema<?> resolvedSchema = chain.next().resolve(type, context, chain);
 				List<Field> fields = FieldUtils.getAllFieldsList(cls);
-				if (!CollectionUtils.isEmpty(fields)) {
+				List<PropertyDescriptor> clsProperties = new ArrayList<>();
+				try {
+					clsProperties = Arrays.asList(Introspector.getBeanInfo(cls).getPropertyDescriptors());
+				} catch (IntrospectionException ignored) {}
+				if (!CollectionUtils.isEmpty(fields) || !CollectionUtils.isEmpty(clsProperties)) {
 					if (!type.isSchemaProperty()) {
 						Schema existingSchema = context.resolve(type);
-						setJavadocDescription(cls, fields, existingSchema);
+						setJavadocDescription(cls, fields, clsProperties, existingSchema);
 					}
 					else if (resolvedSchema != null && resolvedSchema.get$ref() != null && resolvedSchema.get$ref().contains(AnnotationsUtils.COMPONENTS_REF)) {
 						String schemaName = resolvedSchema.get$ref().substring(21);
 						Schema existingSchema = context.getDefinedModels().get(schemaName);
-						setJavadocDescription(cls, fields, existingSchema);
+						setJavadocDescription(cls, fields, clsProperties, existingSchema);
 					}
 				}
 				return resolvedSchema;
@@ -96,7 +100,9 @@ public record JavadocPropertyCustomizer(JavadocProvider javadocProvider,
 	/**
 	 * Sets javadoc description.
 	 *
+	 * @param cls the cls
 	 * @param fields the fields
+	 * @param clsProperties the bean properties of cls
 	 * @param existingSchema the existing schema
 	 */
 	private void setJavadocDescription(Class<?> cls, List<Field> fields, Schema existingSchema) {
@@ -124,6 +130,14 @@ public record JavadocPropertyCustomizer(JavadocProvider javadocProvider,
 								if (StringUtils.isNotBlank(fieldJavadoc))
 									stringSchemaEntry.getValue().setDescription(fieldJavadoc);
 							});
+							if (StringUtils.isBlank(stringSchemaEntry.getValue().getDescription())) {
+								Optional<PropertyDescriptor> optionalPd = clsProperties.stream().filter(pd -> pd.getName().equals(stringSchemaEntry.getKey())).findAny();
+								optionalPd.ifPresent(pd1 -> {
+									String fieldJavadoc = javadocProvider.getMethodJavadocDescription(pd1.getReadMethod());
+									if (StringUtils.isNotBlank(fieldJavadoc))
+										stringSchemaEntry.getValue().setDescription(fieldJavadoc);
+								});
+							}
 						});
 			}
 		}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/HelloController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/HelloController.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *  * Copyright 2019-2023 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app170;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * The type Hello controller.
+ */
+@RestController
+public class HelloController {
+
+	/**
+	 * Persons string.
+	 *
+	 * @param dto the dto 
+	 * @return the PersonProjection
+	 */
+	@GetMapping(value = "/persons")
+	public PersonProjection persons(final PersonDTO dto) {
+		return new PersonDTO();
+	}
+
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/PersonDTO.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/PersonDTO.java
@@ -1,0 +1,73 @@
+/*
+ *
+ *  * Copyright 2019-2023 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app170;
+
+/**
+ * The type Person dto.
+ */
+public class PersonDTO implements PersonProjection {
+	private String email;
+
+	private String firstName;
+
+	private String lastName;
+
+	/**
+	 * Instantiates a new Person dto.
+	 */
+	public PersonDTO() {
+	}
+
+	/**
+	 * Instantiates a new Person dto.
+	 *
+	 * @param email the email 
+	 * @param firstName the first name 
+	 * @param lastName the last name
+	 */
+	public PersonDTO(final String email, final String firstName, final String lastName) {
+		this.email = email;
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(final String email) {
+		this.email = email;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(final String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(final String lastName) {
+		this.lastName = lastName;
+	}
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/PersonProjection.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/PersonProjection.java
@@ -1,0 +1,42 @@
+/*
+ *
+ *  * Copyright 2019-2023 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app170;
+
+/**
+ * The type Person dto.
+ */
+public interface PersonProjection {
+	/**
+	 * Gets email.
+	 *
+	 */
+	String getEmail();
+
+	/**
+	 * Gets first name.
+	 *
+	 */
+	String getFirstName();
+
+	/**
+	 * Gets last name.
+	 *
+	 */
+	String getLastName();
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/SpringDocApp170Test.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/app170/SpringDocApp170Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2019-2023 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app170;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.AbstractSpringDocTest;
+
+/**
+ * The type Spring doc app 170 test.
+ */
+public class SpringDocApp170Test extends AbstractSpringDocTest {
+
+	/**
+	 * The type Spring doc test app.
+	 */
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/app170.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/app170.json
@@ -1,0 +1,94 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "tags": [
+    {
+      "name": "hello-controller",
+      "description": "The type Hello controller."
+    }
+  ],
+  "paths": {
+    "/persons": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "Persons string.",
+        "description": "Persons string.",
+        "operationId": "persons",
+        "parameters": [
+          {
+            "name": "dto",
+            "in": "query",
+            "description": "the dto",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PersonDTO"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the PersonProjection",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonProjection"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PersonDTO": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "description": "The Email."
+          },
+          "firstName": {
+            "type": "string",
+            "description": "The First name."
+          },
+          "lastName": {
+            "type": "string",
+            "description": "The Last name."
+          }
+        },
+        "description": "The type Person dto."
+      },
+      "PersonProjection" : {
+        "type" : "object",
+        "properties" : {
+          "email" : {
+            "type" : "string",
+            "description" : "Gets email."
+          },
+          "firstName" : {
+            "type" : "string",
+            "description" : "Gets first name."
+          },
+          "lastName" : {
+            "type" : "string",
+            "description" : "Gets last name."
+          }
+        },
+        "description" : "The type Person dto."
+      }
+    }
+  }
+}


### PR DESCRIPTION
The API return [jpa projections](https://docs.spring.io/spring-data/jpa/docs/current/reference/html/#projections.interfaces) is a typical application scenario.