### PR TITLE
Bump swagger-core to version 2.2.19. Fixes #2360

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<nexus-staging-maven-plugin>1.6.8</nexus-staging-maven-plugin>
-		<swagger-api.version>2.2.17</swagger-api.version>
+		<swagger-api.version>2.2.19</swagger-api.version>
 		<swagger-ui.version>5.9.0</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jaxb-impl.version>2.1</jaxb-impl.version>


### PR DESCRIPTION
The problem mentioned in [this issue](https://github.com/springdoc/springdoc-openapi/issues/2360)  was caused by a bug in swagger core. It's fixed in version [2.2.19](https://github.com/swagger-api/swagger-core/releases/tag/v2.2.19) "give precedence to requiredMode annotation".