### PR TITLE
Add 'springdoc.trim-kotlin-indent' property to handle Kotlin multiline string indentation

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
@@ -257,6 +257,29 @@ public class SpringDocConfigProperties {
 	private boolean nullableRequestParameterEnabled;
 
 	/**
+	 * The trim kotlin indent.
+	 */
+	private boolean trimKotlinIndent;
+
+	/**
+	 * Gets trim kotlin indent.
+	 *
+	 * @return the trim kotlin indent.
+	 */
+	public boolean isTrimKotlinIndent() {
+		return trimKotlinIndent;
+	}
+
+	/**
+	 * Sets trim kotlin indent
+	 *
+	 * @param trimKotlinIndent the trim kotlin indent.
+	 */
+	public void setTrimKotlinIndent(boolean trimKotlinIndent) {
+		this.trimKotlinIndent = trimKotlinIndent;
+	}
+
+	/**
 	 * Gets override with generic response.
 	 *
 	 * @return the override with generic response

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/ExampleController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/ExampleController.kt
@@ -1,0 +1,30 @@
+package test.org.springdoc.api.app11
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class ExampleController {
+
+    @Operation(
+        summary = "foo api",
+        description = """
+        this api is foo
+        
+        #### Custom exception case
+        | Http Status | Error Code  | Error Message | Error Data | Remark   |
+        |-------------|-------------|--------------|------------|-----------|
+        | 403         | NO_PERMISSION       |This request is only available to administrators.  |            |           |
+        | 400         | STORE_NOT_FOUND       |Store not found.   |            |           |
+        """
+    )
+    @GetMapping("/foo/remove-kotlin-indent")
+    fun readFoo(@RequestParam name: String?) = FooResponse("Hello ${name ?: "world"}")
+
+}
+
+data class FooResponse(
+    private val name: String,
+)

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/SpringDocApp11Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/SpringDocApp11Test.kt
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Copyright 2019-2023 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app11
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.test.context.TestPropertySource
+import test.org.springdoc.api.AbstractKotlinSpringDocMVCTest
+
+@TestPropertySource(properties = ["springdoc.trim-kotlin-indent=true"])
+class SpringDocApp11Test : AbstractKotlinSpringDocMVCTest() {
+	@SpringBootApplication
+	@ComponentScan(basePackages = ["org.springdoc", "test.org.springdoc.api.app11"])
+	class DemoApplication
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app11.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app11.json
@@ -1,0 +1,60 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/foo/remove-kotlin-indent": {
+      "get": {
+        "tags": [
+          "example-controller"
+        ],
+        "summary": "foo api",
+        "description": "\nthis api is foo\n\n#### Custom exception case\n| Http Status | Error Code  | Error Message | Error Data | Remark   |\n|-------------|-------------|--------------|------------|-----------|\n| 403         | NO_PERMISSION       |This request is only available to administrators.  |            |           |\n| 400         | STORE_NOT_FOUND       |Store not found.   |            |           |\n",
+        "operationId": "readFoo",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/FooResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FooResponse": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "writeOnly": true
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes: #2446 