### PR TITLE
Fix typo in SpringRepositoryRestResourceProvider.java

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/SpringRepositoryRestResourceProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/SpringRepositoryRestResourceProvider.java
@@ -92,7 +92,7 @@ public class SpringRepositoryRestResourceProvider implements RepositoryRestResou
 	/**
 	 * The constant REPOSITORY_SEARCH_CONTROLLER.
 	 */
-	private static final String REPOSITORY_SERACH_CONTROLLER = SPRING_DATA_REST_PACKAGE + ".webmvc.RepositorySearchController";
+	private static final String REPOSITORY_SEARCH_CONTROLLER = SPRING_DATA_REST_PACKAGE + ".webmvc.RepositorySearchController";
 
 	/**
 	 * The constant REPOSITORY_PROPERTY_CONTROLLER.


### PR DESCRIPTION
"REPOSITORY_SERACH_CONTROLLER" becomes "REPOSITORY_SEARCH_CONTROLLER".

This is the only instance of term "SERACH" in the repository.

Close #2536