### PR TITLE
Fix missing exception response types in OpenAPI spec

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
@@ -66,6 +66,7 @@ import org.springdoc.core.models.MethodAttributes;
 import org.springdoc.core.parsers.ReturnTypeParser;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.JavadocProvider;
+import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.utils.PropertyResolverUtils;
 import org.springdoc.core.utils.SpringDocAnnotationsUtils;
 
@@ -736,7 +737,7 @@ public class GenericResponseService {
 
 			LinkedHashMap<String, ApiResponse> genericApiResponsesClone;
 			try {
-				ObjectMapper objectMapper = new ObjectMapper();
+				ObjectMapper objectMapper = ObjectMapperProvider.createJson(springDocConfigProperties);
 				genericApiResponsesClone = objectMapper.readValue(objectMapper.writeValueAsString(genericApiResponseMap), ApiResponses.class);
 				return genericApiResponsesClone;
 			}


### PR DESCRIPTION
Since e893628d5494808fcc8a9ee9be0c1d446a805f47, some error response types referenced by the schema in `$ref`'s were missing from the spec.

For example, we have a custom error response type that gets returned via `@ControllerAdvice` when we throw a specific exception type.  In v2.3.0, these were correctly included in the OpenAPI spec.  Starting in v2.4.0 these were missing, creating an invalid schema.

e.g.:

```
"400": {
            "description": "Bad Request",
            "content": {
              "*/*": {
                "schema": {
                  "oneOf": [
                    {
                      "$ref": "#/components/schemas/BadRequestExceptionResponse"
                    },
                    {
                      "$ref": "#/components/schemas/ValidationErrorResponse"
                    }
                  ]
                }
              }
            }
```

and then later down, we should have `BadRequestExceptionResponse` in the spec under `.compoents.schemas` like this:

```
"BadRequestExceptionResponse": {
        "type": "object",
        "properties": {
          "error": {
            "type": "string"
          }
        }
      },
```

Quick `git bisect` revealed that this broke in e893628d5494808fcc8a9ee9be0c1d446a805f47.  I don't fully know the logic behind that commit, but the attached pull request gets the missing items back in the schema for us by changing how the ObjectMapper is constructed back to the way it was before e893628d5494808fcc8a9ee9be0c1d446a805f47