### PR TITLE
fix: add support for leading tab characters with `trim-kotlin-indent`.

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
@@ -143,7 +143,7 @@ public class PropertyResolverUtils {
 	private int countLeadingSpaces(String line) {
         int count = 0;
         for (char ch : line.toCharArray()) {
-            if (ch != ' ') break;
+            if (ch != ' ' && ch != '\t') break;
             count++;
         }
         return count;


### PR DESCRIPTION
We're using Springdoc with Kotlin + Ktlint. We have configured Ktlint to use tabs instead of spaces as indents.

```kt
	@GetMapping("/assets")
	@Operation(
		operationId = "getAssets",
		summary = "Get the assets of the signed in user",
		description = """
			Get the assets owned by the currently signed in user.
		""",
		// ^^^^ Tab characters here turned into a code block.
	)
	@[WithExternalEndUser ScopesAllowed("...")]
	fun getAssets(
		@RequestParam(required = false, defaultValue = "nb-NO") locale: String,
	): List<AssetCard> = TODO()
```

This pull request appends on the condition in the `countLeadingSpaces` method where the count loop filters on spaces. The change makes the condition break on a non space or tab character.
