### PR TITLE
Fix JSON output order by using LinkedHashMap/LinkedHashSet

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -36,9 +36,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -269,7 +269,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 * @param classes the classes
 	 */
 	public static void addHiddenRestControllers(String... classes) {
-		Set<Class<?>> hiddenClasses = new HashSet<>();
+		Set<Class<?>> hiddenClasses = new LinkedHashSet<>();
 		for (String aClass : classes) {
 			try {
 				hiddenClasses.add(Class.forName(aClass));
@@ -865,7 +865,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 */
 	protected Set<RequestMethod> getDefaultAllowedHttpMethods() {
 		RequestMethod[] allowedRequestMethods = { RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.PATCH, RequestMethod.DELETE, RequestMethod.OPTIONS, RequestMethod.HEAD };
-		return new HashSet<>(Arrays.asList(allowedRequestMethods));
+		return new LinkedHashSet<>(Arrays.asList(allowedRequestMethods));
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
@@ -24,8 +24,8 @@
 
 package org.springdoc.core.converters;
 
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -48,17 +48,17 @@ public class AdditionalModelsConverter implements ModelConverter {
 	/**
 	 * The constant modelToClassMap.
 	 */
-	private static final Map<Class, Class> modelToClassMap = new HashMap<>();
+	private static final Map<Class, Class> modelToClassMap = new LinkedHashMap<>();
 
 	/**
 	 * The constant modelToSchemaMap.
 	 */
-	private static final Map<Class, Schema> modelToSchemaMap = new HashMap<>();
+	private static final Map<Class, Schema> modelToSchemaMap = new LinkedHashMap<>();
 
 	/**
 	 * The constant paramObjectReplacementMap.
 	 */
-	private static final Map<Class, Class> paramObjectReplacementMap = new HashMap<>();
+	private static final Map<Class, Class> paramObjectReplacementMap = new LinkedHashMap<>();
 
 	/**
 	 * The constant LOGGER.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/ActuatorOpenApiCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/ActuatorOpenApiCustomizer.java
@@ -25,7 +25,7 @@
 package org.springdoc.core.customizers;
 
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -100,7 +100,7 @@ public class ActuatorOpenApiCustomizer implements GlobalOpenApiCustomizer {
 	}
 
 	private void handleActuatorOperationIdUniqueness(OpenAPI openApi) {
-		Set<String> usedOperationIds = new HashSet<>();
+		Set<String> usedOperationIds = new LinkedHashSet<>();
 		actuatorPathEntryStream(openApi, null)
 				.sorted(Comparator.comparing(Entry::getKey))
 				.forEachOrdered(stringPathItemEntry -> {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/data/DataRestTagsService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/data/DataRestTagsService.java
@@ -25,7 +25,7 @@
 package org.springdoc.core.data;
 
 import java.lang.reflect.Method;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import io.swagger.v3.oas.models.Operation;
@@ -102,8 +102,8 @@ public class DataRestTagsService {
 		}
 		else {
 			Class<?> domainType = dataRestRepository.getDomainType();
-			Set<Tag> tags = new HashSet<>();
-			Set<String> tagsStr = new HashSet<>();
+			Set<Tag> tags = new LinkedHashSet<>();
+			Set<String> tagsStr = new LinkedHashSet<>();
 			Class<?> repositoryType = dataRestRepository.getRepositoryType();
 			openAPIService.buildTagsFromClass(repositoryType, tags, tagsStr, dataRestRepository.getLocale());
 			if (!CollectionUtils.isEmpty(tagsStr))

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/MethodParameterPojoExtractor.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/MethodParameterPojoExtractor.java
@@ -36,7 +36,7 @@ import java.time.Duration;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,7 +72,7 @@ public class MethodParameterPojoExtractor {
 	/**
 	 * The constant SIMPLE_TYPES.
 	 */
-	private static final Set<Class<?>> SIMPLE_TYPES = new HashSet<>();
+	private static final Set<Class<?>> SIMPLE_TYPES = new LinkedHashSet<>();
 
 	static {
 		SIMPLE_TYPES.add(CharSequence.class);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/AbstractRouterFunctionVisitor.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/AbstractRouterFunctionVisitor.java
@@ -25,7 +25,6 @@
 package org.springdoc.core.fn;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -281,7 +280,7 @@ public class AbstractRouterFunctionVisitor {
 	protected void commonRoute() {
 		this.routerFunctionDatas.addAll(currentRouterFunctionDatas);
 		currentRouterFunctionDatas.forEach(routerFunctionData -> routerFunctionData.addAttributes(this.attributes));
-		this.attributes = new HashMap<>();
+		this.attributes = new LinkedHashMap<>();
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
@@ -24,7 +24,7 @@
 
 package org.springdoc.core.properties;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -115,7 +115,7 @@ public class SpringDocConfigProperties {
 	/**
 	 * The Group configs.
 	 */
-	private Set<GroupConfig> groupConfigs = new HashSet<>();
+	private Set<GroupConfig> groupConfigs = new LinkedHashSet<>();
 
 	/**
 	 * The Auto tag classes.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigParameters.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigParameters.java
@@ -27,7 +27,6 @@ package org.springdoc.core.properties;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -177,7 +176,7 @@ public class SwaggerUiConfigParameters extends AbstractSwaggerUiConfigProperties
 		this.showExtensions = swaggerUiConfig.getShowExtensions();
 		this.supportedSubmitMethods = swaggerUiConfig.getSupportedSubmitMethods();
 		this.url = swaggerUiConfig.getUrl();
-		this.urls = swaggerUiConfig.getUrls() == null ? new HashSet<>() : swaggerUiConfig.cloneUrls();
+		this.urls = swaggerUiConfig.getUrls() == null ? new LinkedHashSet<>() : swaggerUiConfig.cloneUrls();
 		this.urlsPrimaryName = swaggerUiConfig.getUrlsPrimaryName();
 		this.groupsOrder = swaggerUiConfig.getGroupsOrder();
 		this.tryItOutEnabled = swaggerUiConfig.getTryItOutEnabled();

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/AbstractRequestService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/AbstractRequestService.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -577,7 +576,7 @@ public abstract class AbstractRequestService {
 	 * @param annotations the annotations
 	 */
 	public void applyBeanValidatorAnnotations(final Parameter parameter, final List<Annotation> annotations) {
-		Map<String, Annotation> annos = new HashMap<>();
+		Map<String, Annotation> annos = new LinkedHashMap<>();
 		if (annotations != null)
 			annotations.forEach(annotation -> annos.put(annotation.annotationType().getSimpleName(), annotation));
 		boolean annotationExists = Arrays.stream(ANNOTATIONS_FOR_REQUIRED).anyMatch(annos::containsKey);
@@ -595,7 +594,7 @@ public abstract class AbstractRequestService {
 	 * @param isOptional  the is optional
 	 */
 	public void applyBeanValidatorAnnotations(final RequestBody requestBody, final List<Annotation> annotations, boolean isOptional) {
-		Map<String, Annotation> annos = new HashMap<>();
+		Map<String, Annotation> annos = new LinkedHashMap<>();
 		boolean requestBodyRequired = false;
 		if (!CollectionUtils.isEmpty(annotations)) {
 			annotations.forEach(annotation -> annos.put(annotation.annotationType().getSimpleName(), annotation));

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
@@ -33,7 +33,7 @@ import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -440,7 +440,7 @@ public class GenericParameterService {
 	 * @param parameter the parameter
 	 */
 	private void setExamples(io.swagger.v3.oas.annotations.Parameter parameterDoc, Parameter parameter) {
-		Map<String, Example> exampleMap = new HashMap<>();
+		Map<String, Example> exampleMap = new LinkedHashMap<>();
 		if (parameterDoc.examples().length == 1 && StringUtils.isBlank(parameterDoc.examples()[0].name())) {
 			Optional<Example> exampleOptional = AnnotationsUtils.getExample(parameterDoc.examples()[0]);
 			exampleOptional.ifPresent(parameter::setExample);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
@@ -32,8 +32,8 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -768,7 +768,7 @@ public class GenericResponseService {
 				final io.swagger.v3.oas.annotations.Operation apiOperation = AnnotatedElementUtils.findMergedAnnotation(method,
 						io.swagger.v3.oas.annotations.Operation.class);
 				if (apiOperation != null) {
-					responseSet = new HashSet<>(Arrays.asList(apiOperation.responses()));
+					responseSet = new LinkedHashSet<>(Arrays.asList(apiOperation.responses()));
 					if (isHttpCodePresent(httpCode, responseSet))
 						result = true;
 				}
@@ -798,7 +798,7 @@ public class GenericResponseService {
 	 */
 	private Set<Class<?>> getExceptionsFromExceptionHandler(MethodParameter methodParameter) {
 		ExceptionHandler exceptionHandler = methodParameter.getExecutable().getAnnotation(ExceptionHandler.class);
-		Set<Class<?>> exceptions = new HashSet<>();
+		Set<Class<?>> exceptions = new LinkedHashSet<>();
 		if (exceptionHandler != null) {
 			if (exceptionHandler.value().length == 0) {
 				for (Parameter parameter : methodParameter.getExecutable().getParameters()) {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
@@ -28,7 +28,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -118,12 +117,12 @@ public class OpenAPIService implements ApplicationContextAware {
 	/**
 	 * The Mappings map.
 	 */
-	private final Map<String, Object> mappingsMap = new HashMap<>();
+	private final Map<String, Object> mappingsMap = new LinkedHashMap<>();
 
 	/**
 	 * The Springdoc tags.
 	 */
-	private final Map<HandlerMethod, io.swagger.v3.oas.models.tags.Tag> springdocTags = new HashMap<>();
+	private final Map<HandlerMethod, io.swagger.v3.oas.models.tags.Tag> springdocTags = new LinkedHashMap<>();
 
 	/**
 	 * The Open api builder customisers.
@@ -143,7 +142,7 @@ public class OpenAPIService implements ApplicationContextAware {
 	/**
 	 * The Cached open api map.
 	 */
-	private final Map<String, OpenAPI> cachedOpenAPI = new HashMap<>();
+	private final Map<String, OpenAPI> cachedOpenAPI = new LinkedHashMap<>();
 
 	/**
 	 * The Property resolver utils.
@@ -680,7 +679,7 @@ public class OpenAPIService implements ApplicationContextAware {
 		for (io.swagger.v3.oas.annotations.security.SecurityScheme securitySchemeAnnotation : apiSecurityScheme) {
 			Optional<SecuritySchemePair> securityScheme = securityParser.getSecurityScheme(securitySchemeAnnotation, locale);
 			if (securityScheme.isPresent()) {
-				Map<String, SecurityScheme> securitySchemeMap = new HashMap<>();
+				Map<String, SecurityScheme> securitySchemeMap = new LinkedHashMap<>();
 				if (StringUtils.isNotBlank(securityScheme.get().key())) {
 					securitySchemeMap.put(securityScheme.get().key(), securityScheme.get().securityScheme());
 					if (!CollectionUtils.isEmpty(components.getSecuritySchemes())) {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
@@ -28,8 +28,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -323,8 +323,8 @@ public class OpenAPIService implements ApplicationContextAware {
 	 */
 	public Operation buildTags(HandlerMethod handlerMethod, Operation operation, OpenAPI openAPI, Locale locale) {
 
-		Set<io.swagger.v3.oas.models.tags.Tag> tags = new HashSet<>();
-		Set<String> tagsStr = new HashSet<>();
+		Set<io.swagger.v3.oas.models.tags.Tag> tags = new LinkedHashSet<>();
+		Set<String> tagsStr = new LinkedHashSet<>();
 
 		buildTagsFromMethod(handlerMethod.getMethod(), tags, tagsStr, locale);
 		buildTagsFromClass(handlerMethod.getBeanType(), tags, tagsStr, locale);
@@ -346,7 +346,7 @@ public class OpenAPIService implements ApplicationContextAware {
 			if (CollectionUtils.isEmpty(operation.getTags()))
 				operation.setTags(new ArrayList<>(tagsStr));
 			else {
-				Set<String> operationTagsSet = new HashSet<>(operation.getTags());
+				Set<String> operationTagsSet = new LinkedHashSet<>(operation.getTags());
 				operationTagsSet.addAll(tagsStr);
 				operation.getTags().clear();
 				operation.getTags().addAll(operationTagsSet);
@@ -736,7 +736,7 @@ public class OpenAPIService implements ApplicationContextAware {
 	 */
 	private Set<io.swagger.v3.oas.annotations.security.SecurityScheme> getSecuritySchemesClasses(
 			ClassPathScanningCandidateComponentProvider scanner, List<String> packagesToScan) {
-		Set<io.swagger.v3.oas.annotations.security.SecurityScheme> apiSecurityScheme = new HashSet<>();
+		Set<io.swagger.v3.oas.annotations.security.SecurityScheme> apiSecurityScheme = new LinkedHashSet<>();
 		for (String pack : packagesToScan) {
 			for (BeanDefinition bd : scanner.findCandidateComponents(pack)) {
 				try {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
@@ -26,7 +26,6 @@ package org.springdoc.core.service;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -197,7 +196,7 @@ public class OperationService {
 
 		boolean doBreak = false;
 		for (io.swagger.v3.oas.annotations.callbacks.Callback methodCallback : apiCallbacks) {
-			Map<String, Callback> callbackMap = new HashMap<>();
+			Map<String, Callback> callbackMap = new LinkedHashMap<>();
 			if (methodCallback == null) {
 				callbacks.putAll(callbackMap);
 				doBreak = true;

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
@@ -26,8 +26,8 @@ package org.springdoc.core.service;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -356,7 +356,7 @@ public class OperationService {
 	 * @return the set
 	 */
 	private Set<String> extractOperationIdFromPathItem(PathItem path) {
-		Set<String> ids = new HashSet<>();
+		Set<String> ids = new LinkedHashSet<>();
 		if (path.getGet() != null && StringUtils.isNotBlank(path.getGet().getOperationId())) {
 			ids.add(path.getGet().getOperationId());
 		}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/SecurityService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/SecurityService.java
@@ -27,7 +27,7 @@ package org.springdoc.core.service;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -141,7 +141,7 @@ public class SecurityService {
 	public Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> getSecurityRequirementsForMethod(Method method, Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> allSecurityTags) {
 		io.swagger.v3.oas.annotations.security.SecurityRequirements methodSecurity = AnnotatedElementUtils.findMergedAnnotation(method, io.swagger.v3.oas.annotations.security.SecurityRequirements.class);
 		if (methodSecurity != null)
-			allSecurityTags = addSecurityRequirements(allSecurityTags, new HashSet<>(Arrays.asList(methodSecurity.value())));
+			allSecurityTags = addSecurityRequirements(allSecurityTags, new LinkedHashSet<>(Arrays.asList(methodSecurity.value())));
 		if (CollectionUtils.isEmpty(allSecurityTags)) {
 			// handlerMethod SecurityRequirement
 			Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> securityRequirementsMethodList = AnnotatedElementUtils.findMergedRepeatableAnnotations(method,
@@ -162,7 +162,7 @@ public class SecurityService {
 		Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> allSecurityTags = null;
 		io.swagger.v3.oas.annotations.security.SecurityRequirements classSecurity = AnnotatedElementUtils.findMergedAnnotation(beanType, io.swagger.v3.oas.annotations.security.SecurityRequirements.class);
 		if (classSecurity != null)
-			allSecurityTags = new HashSet<>(Arrays.asList(classSecurity.value()));
+			allSecurityTags = new LinkedHashSet<>(Arrays.asList(classSecurity.value()));
 		if (CollectionUtils.isEmpty(allSecurityTags)) {
 			// class SecurityRequirement
 			Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> securityRequirementsClassList = AnnotatedElementUtils.findMergedRepeatableAnnotations(
@@ -183,7 +183,7 @@ public class SecurityService {
 	 */
 	private Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> addSecurityRequirements(Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> allSecurityTags, Set<io.swagger.v3.oas.annotations.security.SecurityRequirement> securityRequirementsClassList) {
 		if (allSecurityTags == null)
-			allSecurityTags = new HashSet<>();
+			allSecurityTags = new LinkedHashSet<>();
 		allSecurityTags.addAll(securityRequirementsClassList);
 		return allSecurityTags;
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
@@ -25,7 +25,7 @@
 package org.springdoc.core.utils;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -202,12 +202,12 @@ public class PropertyResolverUtils {
 	 */
 	public Map<String, Object> resolveExtensions(Locale locale, Map<String, Object> extensions) {
 		if (!CollectionUtils.isEmpty(extensions)) {
-			Map<String, Object> extensionsResolved = new HashMap<>();
+			Map<String, Object> extensionsResolved = new LinkedHashMap<>();
 			extensions.forEach((key, value) -> {
 				String keyResolved = resolve(key, locale);
-				if (value instanceof HashMap<?, ?>) {
-					Map<String, Object> valueResolved = new HashMap<>();
-					((HashMap<?, ?>) value).forEach((key1, value1) -> {
+				if (value instanceof Map<?,?>) {
+					Map<String, Object> valueResolved = new LinkedHashMap<>();
+					((Map<?, ?>) value).forEach((key1, value1) -> {
 						String key1Resolved = resolve(key1.toString(), locale);
 						String value1Resolved = resolve(value1.toString(), locale);
 						valueResolved.put(key1Resolved, value1Resolved);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocDataRestUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocDataRestUtils.java
@@ -25,8 +25,8 @@
 package org.springdoc.core.utils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -92,7 +92,7 @@ public class SpringDocDataRestUtils {
 	/**
 	 * The Entity ino map.
 	 */
-	private final HashMap<String, EntityInfo> entityInoMap = new HashMap();
+	private final Map<String, EntityInfo> entityInoMap = new LinkedHashMap<>();
 
 	/**
 	 * The Repository rest configuration.

--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/api/OpenApiResource.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/api/OpenApiResource.java
@@ -25,8 +25,8 @@
 package org.springdoc.webflux.api;
 
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -151,7 +151,7 @@ public abstract class OpenApiResource extends AbstractOpenApiResource {
 			Optional<ActuatorProvider> actuatorProviderOptional = springDocProviders.getActuatorProvider();
 			if (actuatorProviderOptional.isPresent() && springDocConfigProperties.isShowActuator()) {
 				Map<RequestMappingInfo, HandlerMethod> actuatorMap = actuatorProviderOptional.get().getMethods();
-				this.openAPIService.addTag(new HashSet<>(actuatorMap.values()), getTag());
+				this.openAPIService.addTag(new LinkedHashSet<>(actuatorMap.values()), getTag());
 				map.putAll(actuatorMap);
 			}
 			calculatePath(restControllers, map, locale, openAPI);

--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/providers/ActuatorWebFluxProvider.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/providers/ActuatorWebFluxProvider.java
@@ -24,7 +24,7 @@
 
 package org.springdoc.webflux.core.providers;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -78,7 +78,7 @@ public class ActuatorWebFluxProvider extends ActuatorProvider {
 	}
 
 	public Map<RequestMappingInfo, HandlerMethod> getMethods() {
-		Map<RequestMappingInfo, HandlerMethod> mappingInfoHandlerMethodMap = new HashMap<>();
+		Map<RequestMappingInfo, HandlerMethod> mappingInfoHandlerMethodMap = new LinkedHashMap<>();
 
 		if (webFluxEndpointHandlerMapping == null)
 			webFluxEndpointHandlerMapping = managementApplicationContext.getBean(WebFluxEndpointHandlerMapping.class);

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/api/OpenApiResource.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/api/OpenApiResource.java
@@ -26,8 +26,8 @@ package org.springdoc.webmvc.api;
 
 
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -164,7 +164,7 @@ public abstract class OpenApiResource extends AbstractOpenApiResource {
 			Optional<ActuatorProvider> actuatorProviderOptional = springDocProviders.getActuatorProvider();
 			if (actuatorProviderOptional.isPresent() && springDocConfigProperties.isShowActuator()) {
 				Map<RequestMappingInfo, HandlerMethod> actuatorMap = actuatorProviderOptional.get().getMethods();
-				this.openAPIService.addTag(new HashSet<>(actuatorMap.values()), getTag());
+				this.openAPIService.addTag(new LinkedHashSet<>(actuatorMap.values()), getTag());
 				map.putAll(actuatorMap);
 			}
 			calculatePath(restControllers, map, locale, openAPI);

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/ActuatorWebMvcProvider.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/ActuatorWebMvcProvider.java
@@ -24,7 +24,7 @@
 
 package org.springdoc.webmvc.core.providers;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -81,7 +81,7 @@ public class ActuatorWebMvcProvider extends ActuatorProvider {
 
 	@Override
 	public Map<RequestMappingInfo, HandlerMethod> getMethods() {
-		Map<RequestMappingInfo, HandlerMethod> mappingInfoHandlerMethodMap = new HashMap<>();
+		Map<RequestMappingInfo, HandlerMethod> mappingInfoHandlerMethodMap = new LinkedHashMap<>();
 
 		if (webMvcEndpointHandlerMapping == null)
 			webMvcEndpointHandlerMapping = managementApplicationContext.getBean(WebMvcEndpointHandlerMapping.class);

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/RouterFunctionWebMvcProvider.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/RouterFunctionWebMvcProvider.java
@@ -25,7 +25,7 @@
 package org.springdoc.webmvc.core.providers;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -66,7 +66,7 @@ public class RouterFunctionWebMvcProvider implements RouterFunctionProvider, App
 		Map<String, RouterFunction> routerBeans = applicationContext.getBeansOfType(RouterFunction.class);
 		if (CollectionUtils.isEmpty(routerBeans))
 			return Optional.empty();
-		Map<String, AbstractRouterFunctionVisitor> routerFunctionVisitorMap = new HashMap<>();
+		Map<String, AbstractRouterFunctionVisitor> routerFunctionVisitorMap = new LinkedHashMap<>();
 		for (Map.Entry<String, RouterFunction> entry : routerBeans.entrySet()) {
 			RouterFunction routerFunction = entry.getValue();
 			RouterFunctionVisitor routerFunctionVisitor = new RouterFunctionVisitor();


### PR DESCRIPTION
## Proposed Changes

This pull request aims to fix the issue of inconsistent JSON output order by replacing `HashMap` and `HashSet` with `LinkedHashMap` and `LinkedHashSet`, respectively.

## Motivation

Currently, when using `HashMap` or `HashSet`, the order of elements in the JSON output is random and changes with each execution. This can lead to readability issues, especially when dealing with large and complex JSON structures.

## Implementation

- Replace all instances of `HashMap` with `LinkedHashMap` to preserve the insertion order of key-value pairs in the JSON output.
- Replace all instances of `HashSet` with `LinkedHashSet` to preserve the insertion order of elements in the JSON output.

By using `LinkedHashMap` and `LinkedHashSet`, the JSON output order will now follow the order in which elements were inserted, improving readability and consistency.

Please review the changes and let me know if any further modifications are needed.