### PR TITLE
Ensure compatibility with previous version of spring data

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocPageableConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocPageableConfiguration.java
@@ -43,6 +43,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedModel;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.data.web.config.SpringDataWebSettings;
 
@@ -85,15 +86,16 @@ public class SpringDocPageableConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
-	@ConditionalOnBean(SpringDataWebSettings.class)
+	@ConditionalOnClass({ PagedModel.class, SpringDataWebSettings.class })
 	@Lazy(false)
-	PageOpenAPIConverter pageOpenAPIConverter(SpringDataWebSettings settings,
+	PageOpenAPIConverter pageOpenAPIConverter(Optional<SpringDataWebSettings> settings,
 			ObjectMapperProvider objectMapperProvider) {
-		return new PageOpenAPIConverter(
-				settings.pageSerializationMode() == EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO,
-				objectMapperProvider);
+		boolean replacePageWithPagedModel = settings.map(SpringDataWebSettings::pageSerializationMode)
+			.map(EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO::equals)
+			.orElse(false);
+		return new PageOpenAPIConverter(replacePageWithPagedModel, objectMapperProvider);
 	}
-	
+
 	/**
 	 * Delegating method parameter customizer delegating method parameter customizer.
 	 *


### PR DESCRIPTION
First of all,  thank you very much for accepting my previous contribution :D

This is a follow up to https://github.com/springdoc/springdoc-openapi/pull/2626

I saw that you did some changes to it, in particular moving the bean declaration from a dedicated configuration class to the already present `SpringDocPageableConfiguration`.

This sadly breaks compatibility with spring data < 3.3.0 because without the `@ConditionalOnClass(PagedModel.class)` as a safeguard the `@ConditionalOnBean` alone isn't safe to use and a `ClassNotFoundException` is thrown when the class isn't on the classpath.

I tweaked a bit the bean declaration to make sure that it doesn't break anymore if `SpringDataWebSettings` isn't present.