### PR TITLE
Trim indent apply schema description

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -69,6 +69,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
 import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.responses.ApiResponses;
@@ -100,6 +101,7 @@ import org.springdoc.core.service.GenericParameterService;
 import org.springdoc.core.service.GenericResponseService;
 import org.springdoc.core.service.OpenAPIService;
 import org.springdoc.core.service.OperationService;
+import org.springdoc.core.utils.PropertyResolverUtils;
 import org.springdoc.core.utils.SpringDocUtils;
 
 import org.springframework.aop.support.AopUtils;
@@ -352,6 +354,9 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				}
 				getPaths(mappingsMap, finalLocale, openAPI);
 
+				if (springDocConfigProperties.isTrimKotlinIndent())
+					this.trimIndent(openAPI);
+
 				Optional<CloudFunctionProvider> cloudFunctionProviderOptional = springDocProviders.getSpringCloudFunctionProvider();
 				cloudFunctionProviderOptional.ifPresent(cloudFunctionProvider -> {
 							List<RouterOperation> routerOperationList = cloudFunctionProvider.getRouterOperations(openAPI);
@@ -384,7 +389,6 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				if (!CollectionUtils.isEmpty(openAPI.getServers()) && !openAPI.getServers().equals(serversCopy))
 					openAPIService.setServersPresent(true);
 
-
 				openAPIService.setCachedOpenAPI(openAPI, finalLocale);
 
 				LOGGER.info("Init duration for springdoc-openapi is: {} ms",
@@ -396,10 +400,60 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				openAPIService.updateServers(openAPI);
 			}
 			openAPIService.updateServers(openAPI);
-			return openAPI;		}
-		finally {
+			return openAPI;
+		} finally {
 			this.reentrantLock.unlock();
 		}
+	}
+
+	private void trimIndent(OpenAPI openAPI) {
+		trimComponents(openAPI);
+		trimPaths(openAPI);
+	}
+
+	private void trimComponents(OpenAPI openAPI) {
+		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
+		if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+			return;
+		}
+		for (Schema<?> schema : openAPI.getComponents().getSchemas().values()) {
+			schema.description(propertyResolverUtils.trimIndent(schema.getDescription()));
+			if (schema.getProperties() == null) {
+				continue;
+			}
+			for (Object prop : schema.getProperties().values()) {
+				if (prop instanceof Schema<?> schemaProp) {
+					schemaProp.setDescription(propertyResolverUtils.trimIndent(schemaProp.getDescription()));
+				}
+			}
+		}
+	}
+
+	private void trimPaths(OpenAPI openAPI) {
+		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
+		if (openAPI.getPaths() == null) {
+			return;
+		}
+		for (PathItem value : openAPI.getPaths().values()) {
+			value.setDescription(propertyResolverUtils.trimIndent(value.getDescription()));
+			trimIndentOperation(value.getGet());
+			trimIndentOperation(value.getPut());
+			trimIndentOperation(value.getPost());
+			trimIndentOperation(value.getDelete());
+			trimIndentOperation(value.getOptions());
+			trimIndentOperation(value.getHead());
+			trimIndentOperation(value.getPatch());
+			trimIndentOperation(value.getTrace());
+		}
+	}
+
+	private void trimIndentOperation(Operation operation) {
+		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
+		if (operation == null) {
+			return;
+		}
+		operation.setSummary(propertyResolverUtils.trimIndent(operation.getSummary()));
+		operation.setDescription(propertyResolverUtils.trimIndent(operation.getDescription()));
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -406,11 +406,19 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		}
 	}
 
+	/**
+	 * Indents are removed for properties that are mainly used as “explanations” using Open API.
+	 * @param openAPI the open api
+	 */
 	private void trimIndent(OpenAPI openAPI) {
 		trimComponents(openAPI);
 		trimPaths(openAPI);
 	}
 
+	/**
+	 * Trim the indent for descriptions in the 'components' of open api.
+	 * @param openAPI the open api
+	 */
 	private void trimComponents(OpenAPI openAPI) {
 		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
 		if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
@@ -429,6 +437,10 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		}
 	}
 
+	/**
+	 * Trim the indent for descriptions in the 'paths' of open api.
+	 * @param openAPI the open api
+	 */
 	private void trimPaths(OpenAPI openAPI) {
 		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
 		if (openAPI.getPaths() == null) {
@@ -447,6 +459,10 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		}
 	}
 
+	/**
+	 * Trim the indent for 'operation'
+	 * @param operation the operation
+	 */
 	private void trimIndentOperation(Operation operation) {
 		final PropertyResolverUtils propertyResolverUtils = operationParser.getPropertyResolverUtils();
 		if (operation == null) {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
@@ -646,4 +646,12 @@ public class OperationService {
 	public JavadocProvider getJavadocProvider() {
 		return parameterBuilder.getJavadocProvider();
 	}
+
+	/**
+	 * Gets propertyResolverUtils
+	 * @return propertyResolverUtils
+	 */
+	public PropertyResolverUtils getPropertyResolverUtils(){
+		return parameterBuilder.getPropertyResolverUtils();
+	}
 }

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
@@ -99,9 +99,6 @@ public class PropertyResolverUtils {
 				}
 			if (parameterProperty.equals(result))
 				try {
-                    if (springDocConfigProperties.isTrimKotlinIndent()) {
-                        parameterProperty = trimIndent(parameterProperty);
-                    }
 					result = factory.resolveEmbeddedValue(parameterProperty);
 				}
 				catch (IllegalArgumentException ex) {
@@ -119,18 +116,23 @@ public class PropertyResolverUtils {
 	 * @param text The original string with possible leading indentation.
 	 * @return The string with leading indentation removed from each line.
 	 */
-    private String trimIndent(String text) {
-		if (text == null) {
-			return null;
+	public String trimIndent(String text) {
+		try {
+			if (text == null) {
+				return null;
+			}
+			final String newLine = "\n";
+			String[] lines = text.split(newLine);
+			int minIndent = resolveMinIndent(lines);
+			return Arrays.stream(lines)
+				.map(line -> line.substring(Math.min(line.length(), minIndent)))
+				.reduce((a, b) -> a + newLine + b)
+				.orElse(StringUtils.EMPTY);
+		} catch (Exception ex){
+			LOGGER.warn(ex.getMessage());
+			return text;
 		}
-		final String newLine = "\n";
-		String[] lines = text.split(newLine);
-		int minIndent = resolveMinIndent(lines);
-        return Arrays.stream(lines)
-            .map(line -> line.substring(Math.min(line.length(), minIndent)))
-            .reduce((a, b) -> a + newLine + b)
-            .orElse(StringUtils.EMPTY);
-    }
+	}
 
 	private int resolveMinIndent(String[] lines) {
 		return Arrays.stream(lines)

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/ExampleController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app11/ExampleController.kt
@@ -1,7 +1,9 @@
 package test.org.springdoc.api.app11
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
@@ -20,11 +22,75 @@ class ExampleController {
         | 400         | STORE_NOT_FOUND       |Store not found.   |            |           |
         """
     )
-    @GetMapping("/foo/remove-kotlin-indent")
+    @GetMapping("/foo/trim-kotlin-indent")
     fun readFoo(@RequestParam name: String?) = FooResponse("Hello ${name ?: "world"}")
 
 }
 
 data class FooResponse(
-    private val name: String,
+    val name: String,
+)
+
+@RestController
+class ExampleController2 {
+
+    @GetMapping("/foo/trim-kotlin-indent/schema")
+    fun readFoo(
+        @RequestBody request: FooRequestWithSchema,
+    ) = FooResponseWithSchema(
+        name = "Hello ${request.age ?: "world"}",
+        subFoo = SubFooResponseWithSchema(subName = "sub foo name"),
+    )
+}
+
+@Schema(
+    name = "foo request",
+    description = """
+    foo request class description
+    with kotlin indent
+    """
+)
+data class FooRequestWithSchema(
+    @Schema(
+        name = "age",
+        description = """
+        foo request field with kotlin indent
+        """
+    )
+    val age: Int,
+)
+
+@Schema(
+    name = "foo response",
+    description = """
+    foo response class description
+    with kotlin indent
+    """
+)
+data class FooResponseWithSchema(
+    @Schema(
+        name = "name",
+        description = """
+        foo response fields with kotlin indent
+        """
+    )
+    val name: String,
+    val subFoo: SubFooResponseWithSchema
+)
+
+@Schema(
+    name = "sub foo response",
+    description = """
+    sub foo response class description
+    with kotlin indent
+    """
+)
+data class SubFooResponseWithSchema(
+    @Schema(
+        name = "subName",
+        description = """
+        sub foo response fields with kotlin indent
+        """
+    )
+    val subName: String,
 )

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app11.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app11.json
@@ -11,7 +11,7 @@
     }
   ],
   "paths": {
-    "/foo/remove-kotlin-indent": {
+    "/foo/trim-kotlin-indent": {
       "get": {
         "tags": [
           "example-controller"
@@ -42,18 +42,94 @@
           }
         }
       }
+    },
+    "/foo/trim-kotlin-indent/schema": {
+      "get": {
+        "tags": [
+          "example-controller-2"
+        ],
+        "operationId": "readFoo_1",
+        "parameters": [
+          {
+            "name": "request",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/foo request"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/foo response"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
       "FooResponse": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "foo request": {
+        "required": [
+          "age"
+        ],
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer",
+            "description": "\nfoo request field with kotlin indent\n",
+            "format": "int32"
+          }
+        },
+        "description": "\nfoo request class description\nwith kotlin indent\n"
+      },
+      "foo response": {
+        "required": [
+          "name",
+          "subFoo"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string",
-            "writeOnly": true
+            "description": "\nfoo response fields with kotlin indent\n"
+          },
+          "subFoo": {
+            "$ref": "#/components/schemas/sub foo response"
           }
-        }
+        },
+        "description": "\nfoo response class description\nwith kotlin indent\n"
+      },
+      "sub foo response": {
+        "required": [
+          "subName"
+        ],
+        "type": "object",
+        "properties": {
+          "subName": {
+            "type": "string",
+            "description": "\nsub foo response fields with kotlin indent\n"
+          }
+        },
+        "description": "\nsub foo response class description\nwith kotlin indent\n"
       }
     }
   }


### PR DESCRIPTION
implement #2645

While looking for where to implement the logic to remove the indent of the schema annotation, I wrote it in `AbstractOpenApiResource`. I thought it would be easy to track the implementation according to the `trim-kotlin-indent` setting and add features during future maintenance.

If you think there is a more appropriate class where this implementation should be located, please let me know. I will fix it.