### PR TITLE
fix: Update Response Code

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
@@ -147,7 +147,7 @@ public class SpringDocSecurityConfiguration {
 						operation.requestBody(requestBody);
 						ApiResponses apiResponses = new ApiResponses();
 						apiResponses.addApiResponse(String.valueOf(HttpStatus.OK.value()), new ApiResponse().description(HttpStatus.OK.getReasonPhrase()));
-						apiResponses.addApiResponse(String.valueOf(HttpStatus.UNAUTHORIZED.value()), new ApiResponse().description(HttpStatus.FORBIDDEN.getReasonPhrase()));
+						apiResponses.addApiResponse(String.valueOf(HttpStatus.UNAUTHORIZED.value()), new ApiResponse().description(HttpStatus.UNAUTHORIZED.getReasonPhrase()));
 						operation.responses(apiResponses);
 						operation.addTagsItem("login-endpoint");
 						PathItem pathItem = new PathItem().post(operation);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
@@ -147,7 +147,7 @@ public class SpringDocSecurityConfiguration {
 						operation.requestBody(requestBody);
 						ApiResponses apiResponses = new ApiResponses();
 						apiResponses.addApiResponse(String.valueOf(HttpStatus.OK.value()), new ApiResponse().description(HttpStatus.OK.getReasonPhrase()));
-						apiResponses.addApiResponse(String.valueOf(HttpStatus.FORBIDDEN.value()), new ApiResponse().description(HttpStatus.FORBIDDEN.getReasonPhrase()));
+						apiResponses.addApiResponse(String.valueOf(HttpStatus.UNAUTHORIZED.value()), new ApiResponse().description(HttpStatus.FORBIDDEN.getReasonPhrase()));
 						operation.responses(apiResponses);
 						operation.addTagsItem("login-endpoint");
 						PathItem pathItem = new PathItem().post(operation);


### PR DESCRIPTION
Updated the response code for login failures from 403 Frobidden to 401 UnAuthorized to more accurately reflect the correct HTTP status code for authentication failures.  
  
Changes include:  
- Response code adjustment in OpenAPI Customizer  
  
This improves code readability and ensures proper HTTP status code usage.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses
![image](https://github.com/user-attachments/assets/fbe40b5f-bb3d-46a2-bfe1-1dc9c89ab753)
