### PR TITLE
Refactor Replace hardcoded schema prefix length

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/JavadocPropertyCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/JavadocPropertyCustomizer.java
@@ -24,6 +24,7 @@
 
 package org.springdoc.core.customizers;
 
+import io.swagger.v3.oas.models.Components;
 import java.beans.IntrospectionException;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
@@ -95,7 +96,7 @@ public record JavadocPropertyCustomizer(JavadocProvider javadocProvider,
 						setJavadocDescription(cls, fields, clsProperties, existingSchema, false);
 					}
 					else if (resolvedSchema != null && resolvedSchema.get$ref() != null && resolvedSchema.get$ref().contains(AnnotationsUtils.COMPONENTS_REF)) {
-						String schemaName = resolvedSchema.get$ref().substring(21);
+						String schemaName = resolvedSchema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 						Schema existingSchema = context.getDefinedModels().get(schemaName);
 						setJavadocDescription(cls, fields, clsProperties, existingSchema, false);
 					}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
@@ -407,7 +407,7 @@ public class GenericParameterService {
 		if (schemaN != null && StringUtils.isEmpty(schemaN.getDescription()) && parameterInfo.getParameterModel() != null) {
 			String description = parameterInfo.getParameterModel().getDescription();
 			if (schemaN.get$ref() != null && schemaN.get$ref().contains(AnnotationsUtils.COMPONENTS_REF)) {
-				String key = schemaN.get$ref().substring(21);
+				String key = schemaN.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 				Schema existingSchema = components.getSchemas().get(key);
 				if (!StringUtils.isEmpty(description))
 					existingSchema.setDescription(description);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocDataRestUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocDataRestUtils.java
@@ -161,7 +161,7 @@ public class SpringDocDataRestUtils {
 			apiResponse.getContent().values().forEach(mediaType -> {
 				Schema schema = mediaType.getSchema();
 				if (schema.get$ref() != null && !schema.get$ref().endsWith(RESPONSE)) {
-					String key = schema.get$ref().substring(21);
+					String key = schema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 					Set<String> entitiesNames = entityInoMap.keySet();
 					entitiesNames.forEach(entityName -> {
 						if (key.endsWith(entityName))
@@ -184,7 +184,7 @@ public class SpringDocDataRestUtils {
 			requestBody.getContent().values().forEach(mediaType -> {
 				Schema schema = mediaType.getSchema();
 				if (schema.get$ref() != null && !schema.get$ref().endsWith(REQUEST_BODY)) {
-					String key = schema.get$ref().substring(21);
+					String key = schema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 					if (entityInoMap.containsKey(key))
 						updateRequestBodySchema(key, schema, openAPI.getComponents(), openapi31);
 				}
@@ -285,7 +285,7 @@ public class SpringDocDataRestUtils {
 			Schema itemsSchema = arraySchema.getItems();
 			Set<String> entitiesNames = entityInoMap.keySet();
 			if (itemsSchema.get$ref() != null && !itemsSchema.get$ref().endsWith(RESPONSE)) {
-				String key = itemsSchema.get$ref().substring(21);
+				String key = itemsSchema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 				if (entitiesNames.contains(key)) {
 					String newKey = itemsSchema.get$ref() + RESPONSE;
 					createNewResponseSchema(key, components, openapi31);
@@ -380,7 +380,7 @@ public class SpringDocDataRestUtils {
 		if (!CollectionUtils.isEmpty(allSchemas))
 			for (Schema allSchema : allSchemas) {
 				if (allSchema.get$ref() != null) {
-					String allKey = allSchema.get$ref().substring(21);
+					String allKey = allSchema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 					updateSingleKey(suffix, components, allSchema, allKey, openapi31);
 				}
 			}


### PR DESCRIPTION
HI 🙋🏻‍♀️

The code was previously hardcoding the length of the string [ `#/components/schemas/` ] (21) directly in the code. It has now been modified to use the length of the constant value declared in the [ `Components` ] class of [ io.swagger.v3.oas.models ].

Thank you 🙇🏻‍♀️