### PR TITLE
Fix SpringDocApp193Test for Java 21 and above. Fixes #2442.

### DIFF
--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app193/SpringDocApp193Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app193/SpringDocApp193Test.java
@@ -23,12 +23,37 @@
 package test.org.springdoc.api.v30.app193;
 
 
-import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+import org.apache.commons.lang3.JavaVersion;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.utils.Constants;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MvcResult;
+import test.org.springdoc.api.AbstractCommonTest;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
+import static org.hamcrest.Matchers.is;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class SpringDocApp193Test extends AbstractSpringDocV30Test {
+@SpringBootTest
+public class SpringDocApp193Test extends AbstractCommonTest {
+
+	@Test
+	public void testApp() throws Exception {
+		final MvcResult mockMvcResult = mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL)).andExpect(status().isOk())
+				.andExpect(jsonPath("$.openapi", is("3.0.1"))).andReturn();
+		final String result = mockMvcResult.getResponse().getContentAsString();
+		// In Java 21 the getFirst() and getLast() methods were added to the List interface.
+		// Those are the POJO getters, therefore Jackson will add them during serialization.
+		// So there are two different expected results for Java prior 21 and starting from Java 21.
+		final var expectedResponseFile = isJavaVersionAtLeast(JavaVersion.JAVA_21) ? "app193-1.json" : "app193.json";
+		final String expected = getContent("results/3.0.1/" + expectedResponseFile);
+		assertEquals(expected, result, true);
+	}
 
 	@SpringBootApplication
 	static class SpringDocTestApp {}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app193-1.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app193-1.json
@@ -1,0 +1,158 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/test": {
+      "get": {
+        "tags": [
+          "basic-controller"
+        ],
+        "summary": "get",
+        "description": "Provides a list of books.",
+        "operationId": "get",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Books"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/test1": {
+      "get": {
+        "tags": [
+          "basic-controller"
+        ],
+        "summary": "get1",
+        "description": "Provides an animal.",
+        "operationId": "get1",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/Cat"
+                    },
+                    {
+                      "$ref": "#/components/schemas/Dog"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Book":
+      {
+        "type": "object",
+        "properties":
+        {
+          "title":
+          {
+            "type": "string"
+          }
+        },
+        "description": "Represents a Book."
+      },
+      "Books": {
+        "type": "array",
+        "description": "Represents a list of Books.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Knowledge"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "empty": {
+                "type": "boolean"
+              },
+              "first":
+              {
+                "$ref": "#/components/schemas/Book"
+              },
+              "last":
+              {
+                "$ref": "#/components/schemas/Book"
+              }
+            }
+          }
+        ]
+      },
+      "Knowledge": {
+        "type": "object",
+        "description": "Represents the knowledge."
+      },
+      "Animal": {
+        "type": "object",
+        "description": "Represents an Animal class."
+      },
+      "Cat": {
+        "type": "object",
+        "description": "Represents a Cat class.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "speed": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      },
+      "Dog": {
+        "type": "object",
+        "description": "Represents a Dog class.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Animal"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "age": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fix `SpringDocApp193Test` for Java 21 and above. In Java 21 the `getFirst()` and `getLast()` methods were added to the `java.util.List` interface. Those are the POJO getters, therefore Jackson will add them during serialization. There are two different expected results for Java prior 21 and starting from Java 21. Fixes #2442.