### PR TITLE
Ensure default media type order is preserved using LinkedHashSet in mergeArrays. Fixes #2671

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
@@ -305,7 +305,7 @@ public class MethodAttributes {
 	 * @param array2 the array2
 	 * @return the string [ ]
 	 */
-    public String[] mergeArrays(@Nullable String[] array1, String[] array2) {
+    private String[] mergeArrays(@Nullable String[] array1, String[] array2) {
 		Set<String> uniqueValues = array1 == null ? new LinkedHashSet<>() : Arrays.stream(array1).collect(Collectors.toCollection(LinkedHashSet::new));
 		uniqueValues.addAll(Arrays.asList(array2));
 		return uniqueValues.toArray(new String[0]);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
@@ -26,8 +26,8 @@ package org.springdoc.core.models;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -305,11 +305,11 @@ public class MethodAttributes {
 	 * @param array2 the array2
 	 * @return the string [ ]
 	 */
-    private String[] mergeArrays(@Nullable String[] array1, String[] array2) {
-        Set<String> uniqueValues = array1 == null ? new HashSet<>() : Arrays.stream(array1).collect(Collectors.toSet());
-        uniqueValues.addAll(Arrays.asList(array2));
-        return uniqueValues.toArray(new String[0]);
-    }
+    public String[] mergeArrays(@Nullable String[] array1, String[] array2) {
+		Set<String> uniqueValues = array1 == null ? new LinkedHashSet<>() : Arrays.stream(array1).collect(Collectors.toCollection(LinkedHashSet::new));
+		uniqueValues.addAll(Arrays.asList(array2));
+		return uniqueValues.toArray(new String[0]);
+	}
 
 	/**
 	 * Is method overloaded boolean.

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
@@ -1,0 +1,64 @@
+package org.springdoc.core.model;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.models.MethodAttributes;
+
+import java.lang.reflect.Method;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+public class MethodAttributesTest {
+
+    @Test
+    public void testMergeArrays() {
+        MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+
+        String[] array1 = {"application/json", "application/xml"};
+        String[] array2 = {"application/xml", "application/yaml"};
+
+        String[] expected = {"application/json", "application/xml", "application/yaml"};
+        String[] result = methodAttributes.mergeArrays(array1, array2);
+
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testMergeArraysWithNullArray1() {
+        MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+
+        String[] array1 = null;
+        String[] array2 = {"application/xml", "application/yaml"};
+
+        String[] expected = {"application/xml", "application/yaml"};
+        String[] result = methodAttributes.mergeArrays(array1, array2);
+
+        assertArrayEquals(expected, result);
+    }
+
+    @Test
+    public void testDefaultProducesMediaType() {
+        MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+
+        Method method = this.getClass().getDeclaredMethods()[0];
+        methodAttributes.calculateConsumesProduces(method);
+
+        String[] expectedProduces = {"application/xml"};
+        String[] resultProduces = methodAttributes.getMethodProduces();
+
+        assertArrayEquals(expectedProduces, resultProduces);
+    }
+
+    @Test
+    public void testDefaultConsumesMediaType() {
+        MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+
+        Method method = this.getClass().getDeclaredMethods()[0];
+        methodAttributes.calculateConsumesProduces(method);
+
+        String[] expectedConsumes = {"application/json"};
+        String[] resultConsumes = methodAttributes.getMethodConsumes();
+
+        assertArrayEquals(expectedConsumes, resultConsumes);
+    }
+}

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
@@ -11,27 +11,33 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 public class MethodAttributesTest {
 
     @Test
-    public void testMergeArrays() {
+    public void testMergeArrays() throws Exception {
         MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
 
         String[] array1 = {"application/json", "application/xml"};
         String[] array2 = {"application/xml", "application/yaml"};
 
         String[] expected = {"application/json", "application/xml", "application/yaml"};
-        String[] result = methodAttributes.mergeArrays(array1, array2);
+
+        Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
+        mergeArraysMethod.setAccessible(true);
+        String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
 
         assertArrayEquals(expected, result);
     }
 
     @Test
-    public void testMergeArraysWithNullArray1() {
+    public void testMergeArraysWithNullArray1() throws Exception {
         MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
 
         String[] array1 = null;
         String[] array2 = {"application/xml", "application/yaml"};
 
         String[] expected = {"application/xml", "application/yaml"};
-        String[] result = methodAttributes.mergeArrays(array1, array2);
+
+        Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
+        mergeArraysMethod.setAccessible(true);
+        String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
 
         assertArrayEquals(expected, result);
     }


### PR DESCRIPTION
#2671 - Ensure default media type order is preserved using LinkedHashSet in mergeArrays

### Description

This PR addresses issue #2671 by ensuring that the order of media types is preserved in the `mergeArrays` method of the `MethodAttributes` class. Previously, `HashSet` was used, which did not guarantee the order of media types, causing the default media type not to be prioritized. This has been fixed by using `LinkedHashSet` to maintain the insertion order.

### Changes

- **MethodAttributes.java**:
  - Modified `mergeArrays` method to use `LinkedHashSet` instead of `HashSet` to preserve the order of media types.

- **MethodAttributesTest.java**:
  - Added unit tests to verify that the `mergeArrays` method preserves the order of media types and that the default media type is prioritized.
  - Tests include scenarios with both non-null and null arrays.

### Testing

Added the following tests to `MethodAttributesTest` to ensure the functionality:
- `testMergeArrays`: Verifies that the order of media types is preserved when merging two arrays.
- `testMergeArraysWithNullArray1`: Verifies that the method handles `null` as the first array correctly.
- `testDefaultProducesMediaType`: Verifies that the default `produces` media type is correctly set.
- `testDefaultConsumesMediaType`: Verifies that the default `consumes` media type is correctly set.

Please review the changes and let me know if any further adjustments are needed.

Thank you!
