### PR TITLE
Do not require JsonSubType annotation for sealed classes

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocConfiguration.java
@@ -423,7 +423,7 @@ public class SpringDocConfiguration {
 			Optional<RepositoryRestResourceProvider> repositoryRestResourceProvider, Optional<RouterFunctionProvider> routerFunctionProvider,
 			Optional<SpringWebProvider> springWebProvider,
 			ObjectMapperProvider objectMapperProvider) {
-		objectMapperProvider.jsonMapper().registerModule(new SpringDocRequiredModule());
+		objectMapperProvider.jsonMapper().registerModules(new SpringDocRequiredModule(), new SpringDocSealedClassModule());
 		return new SpringDocProviders(actuatorProvider, springCloudFunctionProvider, springSecurityOAuth2Provider, repositoryRestResourceProvider, routerFunctionProvider, springWebProvider, objectMapperProvider);
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSealedClassModule.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSealedClassModule.java
@@ -1,0 +1,64 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *
+ *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  * You may obtain a copy of the License at
+ *  *  *  *
+ *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *
+ *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ */
+
+package org.springdoc.core.configuration;
+
+import com.fasterxml.jackson.databind.introspect.Annotated;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.swagger.v3.core.jackson.SwaggerAnnotationIntrospector;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The type Spring doc sealed class module.
+ *
+ * @author sahil-ramagiri
+ */
+public class SpringDocSealedClassModule extends SimpleModule {
+
+	@Override
+	public void setupModule(SetupContext context) {
+		context.insertAnnotationIntrospector(new RespectSealedClassAnnotationIntrospector());
+	}
+
+	/**
+	 * The type sealed class annotation introspector.
+	 */
+	private static class RespectSealedClassAnnotationIntrospector extends SwaggerAnnotationIntrospector {
+
+		@Override
+		public List<NamedType> findSubtypes(Annotated annotated) {
+			ArrayList<NamedType> subTypes = new ArrayList<>();
+
+			if (annotated.getAnnotated() instanceof Class<?> clazz && clazz.isSealed()) {
+				Class<?>[] permittedSubClasses = clazz.getPermittedSubclasses();
+				if (permittedSubClasses.length > 0) {
+					Arrays.stream(permittedSubClasses).map(NamedType::new).forEach(subTypes::add);
+				}
+			}
+
+			return subTypes;
+		}
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/AbstractParent.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/AbstractParent.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app238;
+
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+public abstract sealed class AbstractParent {
+	private int id;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}
+
+final class ChildOfAbstract1 extends AbstractParent {
+	private String abstrachChild1Param;
+
+	public String getAbstrachChild1Param() {
+		return abstrachChild1Param;
+	}
+
+	public void setAbstrachChild1Param(String abstrachChild1Param) {
+		this.abstrachChild1Param = abstrachChild1Param;
+	}
+}
+
+final class ChildOfAbstract2 extends AbstractParent {
+	private String abstractChild2Param;
+
+	public String getAbstractChild2Param() {
+		return abstractChild2Param;
+	}
+
+	public void setAbstractChild2Param(String abstractChild2Param) {
+		this.abstractChild2Param = abstractChild2Param;
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/ConcreteParent.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/ConcreteParent.java
@@ -1,0 +1,66 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app238;
+
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+
+@JsonTypeInfo(use = Id.NAME, property = "type")
+public sealed class ConcreteParent {
+	private int id;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+}
+
+final class ChildOfConcrete1 extends ConcreteParent {
+	private String concreteChild1Param;
+
+	public String getConcreteChild1Param() {
+		return concreteChild1Param;
+	}
+
+	public void setConcreteChild1Param(String concreteChild1Param) {
+		this.concreteChild1Param = concreteChild1Param;
+	}
+}
+
+final class ChildOfConcrete2 extends ConcreteParent {
+	private String concreteChild2Param;
+
+	public String getConcreteChild2Param() {
+		return concreteChild2Param;
+	}
+
+	public void setConcreteChild2Param(String concreteChild2Param) {
+		this.concreteChild2Param = concreteChild2Param;
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/Controller.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/Controller.java
@@ -1,0 +1,68 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app238;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("class-hierarchy")
+public class Controller {
+	@PostMapping("abstract-parent")
+	public Response abstractParent(@RequestBody AbstractParent payload) {
+		return null;
+	}
+
+	@PostMapping("concrete-parent")
+	public Response concreteParent(@RequestBody ConcreteParent payload) {
+		return null;
+	}
+}
+
+class Response {
+	AbstractParent abstractParent;
+
+	List<ConcreteParent> concreteParents;
+
+	public AbstractParent getAbstractParent() {
+		return abstractParent;
+	}
+
+	public void setAbstractParent(AbstractParent abstractParent) {
+		this.abstractParent = abstractParent;
+	}
+
+	public List<ConcreteParent> getConcreteParents() {
+		return concreteParents;
+	}
+
+	public void setConcreteParents(List<ConcreteParent> concreteParents) {
+		this.concreteParents = concreteParents;
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/SpringDocApp238Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app238/SpringDocApp238Test.java
@@ -1,0 +1,36 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app238;
+
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+
+public class SpringDocApp238Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/HelloController.java
@@ -1,0 +1,51 @@
+package test.org.springdoc.api.v30.app239;
+
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+	
+    @PostMapping("/parent")
+    public void parentEndpoint(@RequestBody Superclass parent) {
+        
+    }
+	
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+sealed class Superclass permits IntermediateClass {
+
+	public Superclass() {}
+}
+
+@Schema(name = IntermediateClass.SCHEMA_NAME)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+sealed class IntermediateClass extends Superclass permits FirstChildClass, SecondChildClass {
+
+	public static final String SCHEMA_NAME = "IntermediateClass";
+}
+
+@Schema(name = FirstChildClass.SCHEMA_NAME)
+final class FirstChildClass extends IntermediateClass {
+
+	public static final String SCHEMA_NAME = "Image";
+}
+
+@Schema(name = SecondChildClass.SCHEMA_NAME)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+sealed class SecondChildClass extends IntermediateClass {
+
+	public static final String SCHEMA_NAME = "Mail";
+}
+
+@Schema(name = ThirdChildClass.SCHEMA_NAME)
+final class ThirdChildClass extends SecondChildClass {
+
+	public static final String SCHEMA_NAME = "Home";
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/SpringDocApp239Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/SpringDocApp239Test.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app239;
+
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+public class SpringDocApp239Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238.json
@@ -1,0 +1,227 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/class-hierarchy/concrete-parent": {
+      "post": {
+        "tags": [
+          "controller"
+        ],
+        "operationId": "concreteParent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ConcreteParent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ChildOfConcrete1"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ChildOfConcrete2"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/class-hierarchy/abstract-parent": {
+      "post": {
+        "tags": [
+          "controller"
+        ],
+        "operationId": "abstractParent",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ChildOfAbstract1"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ChildOfAbstract2"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ChildOfConcrete1": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ConcreteParent"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "concreteChild1Param": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ChildOfConcrete2": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ConcreteParent"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "concreteChild2Param": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ConcreteParent": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "AbstractParent": {
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "ChildOfAbstract1": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractParent"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "abstrachChild1Param": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "ChildOfAbstract2": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/AbstractParent"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "abstractChild2Param": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Response": {
+        "type": "object",
+        "properties": {
+          "abstractParent": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChildOfAbstract1"
+              },
+              {
+                "$ref": "#/components/schemas/ChildOfAbstract2"
+              }
+            ]
+          },
+          "concreteParents": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ConcreteParent"
+                },
+                {
+                  "$ref": "#/components/schemas/ChildOfConcrete1"
+                },
+                {
+                  "$ref": "#/components/schemas/ChildOfConcrete2"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app239.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app239.json
@@ -1,0 +1,132 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/parent": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "parentEndpoint",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Superclass"
+                  },
+                  {
+                    "$ref": "#/components/schemas/IntermediateClass"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Image"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Mail"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Home"
+                  }
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Home": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Mail"
+          }
+        ]
+      },
+      "Image": {
+        "type": "object",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IntermediateClass"
+          }
+        ]
+      },
+      "IntermediateClass": {
+        "required": [
+          "@type"
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "@type"
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Superclass"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Mail": {
+        "required": [
+          "@type"
+        ],
+        "type": "object",
+        "discriminator": {
+          "propertyName": "@type"
+        },
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/IntermediateClass"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "@type": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "Superclass": {
+        "required": [
+          "@type"
+        ],
+        "type": "object",
+        "properties": {
+          "@type": {
+            "type": "string"
+          }
+        },
+        "discriminator": {
+          "propertyName": "@type"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description of Changes

1. SpringDocSealedClassModule.java
    -  Provides swagger and jackson with the ability to introspect annotations and resolve subclasses from the permits list of sealed classes.
    - Ensures that subclasses are correctly identified without the need for JsonSubType annotations.
2. SpringDocConfiguration.java
    - Registers the new SpringDocSealedClassModule with objectmapper.
3. API Tests 224, 225
    - Includes polymorphic deserialization tests to verify functionality without JsonSubType annotations.

### Important Note

- This PR requires the following PR on Swagger to be merged first: https://github.com/swagger-api/swagger-core/pull/4728
- Swagger caches the annotation introspector, so modules configured after Swagger are not considered in Swagger's subclass resolving logic.
- This also implies that the existing SpringDocRequiredModule may be flaky and might not work if SpringDoc is configured after Swagger.