### PR TITLE
fix: Missing descriptions on Kotlin ByteArray fields

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
@@ -44,7 +44,6 @@ class SpringDocKotlinConfiguration() {
 	init {
 		SpringDocUtils.getConfig()
 			.addRequestWrapperToIgnore(Continuation::class.java)
-			.replaceWithSchema(ByteArray::class.java, ByteArraySchema())
 			.addDeprecatedType(Deprecated::class.java)
 	}
 

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/src/test/kotlin/test/org/springdoc/api/app6/ByteArrayController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/src/test/kotlin/test/org/springdoc/api/app6/ByteArrayController.kt
@@ -18,11 +18,15 @@
 
 package test.org.springdoc.api.app6
 
+import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
-data class Foo(val data: ByteArray)
+data class Foo(
+	@Schema(description = "Some description about a byte array.")
+	val data: ByteArray
+)
 
 @RestController
 @RequestMapping("/bytearray")

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/src/test/resources/results/app6.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/src/test/resources/results/app6.json
@@ -42,6 +42,7 @@
         "properties": {
           "data": {
             "type": "string",
+            "description":"Some description about a byte array.",
             "format": "byte"
           }
         }


### PR DESCRIPTION
This fixes the issue where information specified via {{@Schema}} annotations on {{ByteArray}} fields was missing if Kotlin transformations were enabled.

As far as I can tell, the code I removed was only necessary as a workaround for https://github.com/swagger-api/swagger-core/issues/3944, which has now been fixed.

I've extended a related test added in #2006 to show that the {{description}} is now present in the generated schema.

Fixes #2275 (The issue is currently closed as wontfix, but I hope you'll accept this fix.)