### PR TITLE
Add paths with params condition option

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
@@ -415,6 +415,11 @@ public final class Constants {
 	public static final String SPRINGDOC_NULLABLE_REQUEST_PARAMETER_ENABLED = "springdoc.nullable-request-parameter-enabled";
 
 	/**
+	 * The constant SPRINGDOC_PATHS_WITH_PARAMS_CONDITIONS.
+	 */
+	public static final String SPRINGDOC_PATHS_WITH_PARAMS_CONDITIONS = "springdoc.paths-with-params-condition";
+
+	/**
 	 * Instantiates a new Constants.
 	 */
 	private Constants() {

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/configuration/SpringDocWebMvcConfiguration.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/configuration/SpringDocWebMvcConfiguration.java
@@ -49,6 +49,7 @@ import org.springdoc.webmvc.api.OpenApiWebMvcResource;
 import org.springdoc.webmvc.core.providers.ActuatorWebMvcProvider;
 import org.springdoc.webmvc.core.providers.RouterFunctionWebMvcProvider;
 import org.springdoc.webmvc.core.providers.SpringWebMvcProvider;
+import org.springdoc.webmvc.core.providers.SpringWebMvcWithParamsConditionProvider;
 import org.springdoc.webmvc.core.service.RequestService;
 
 import org.springframework.beans.factory.ObjectFactory;
@@ -73,6 +74,7 @@ import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import static org.springdoc.core.utils.Constants.SPRINGDOC_ENABLED;
+import static org.springdoc.core.utils.Constants.SPRINGDOC_PATHS_WITH_PARAMS_CONDITIONS;
 import static org.springdoc.core.utils.SpringDocUtils.getConfig;
 
 /**
@@ -142,9 +144,24 @@ public class SpringDocWebMvcConfiguration {
 	 */
 	@Bean
 	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = SPRINGDOC_PATHS_WITH_PARAMS_CONDITIONS, havingValue = "false", matchIfMissing = true)
 	@Lazy(false)
 	SpringWebProvider springWebProvider() {
 		return new SpringWebMvcProvider();
+	}
+
+	/**
+	 * Spring web provider.
+	 * ActivePatterns will be specifically classified according to the params condition.
+	 *
+	 * @return the spring web provider according to the params condition.
+	 */
+	@Bean
+	@ConditionalOnMissingBean
+	@ConditionalOnProperty(name = SPRINGDOC_PATHS_WITH_PARAMS_CONDITIONS, havingValue = "true")
+	@Lazy(false)
+	SpringWebProvider springWebMvcWithParamsConditionProvider() {
+		return new SpringWebMvcWithParamsConditionProvider();
 	}
 
 	/**

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/SpringWebMvcWithParamsConditionProvider.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/SpringWebMvcWithParamsConditionProvider.java
@@ -1,0 +1,42 @@
+package org.springdoc.webmvc.core.providers;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.web.servlet.mvc.condition.NameValueExpression;
+import org.springframework.web.servlet.mvc.condition.ParamsRequestCondition;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+
+/**
+ * The type Spring web mvc provider with params condition.
+ *
+ * @author Jelicho
+ */
+public class SpringWebMvcWithParamsConditionProvider extends SpringWebMvcProvider {
+	@Override
+	public Set<String> getActivePatterns(Object requestMapping) {
+		Set<String> activePatterns = super.getActivePatterns(requestMapping);
+		RequestMappingInfo requestMappingInfo = (RequestMappingInfo) requestMapping;
+		String queryStringByParamsCondition = getQueryStringByParamsCondition(requestMappingInfo.getParamsCondition());
+
+		if (queryStringByParamsCondition.isEmpty()) {
+			return activePatterns;
+		}
+
+		return activePatterns.stream()
+				.map(activePattern -> activePattern + "?" + queryStringByParamsCondition)
+				.collect(Collectors.toSet());
+	}
+
+	private String getQueryStringByParamsCondition(ParamsRequestCondition paramsRequestCondition) {
+		return paramsRequestCondition
+				.getExpressions()
+				.stream()
+				.map(this::mapExpression)
+				.collect(Collectors.joining("&"));
+	}
+
+	private String mapExpression(NameValueExpression<String> expression) {
+		return expression.getName() + "=" + (expression.getValue() != null ? expression.getValue() : "");
+	}
+}


### PR DESCRIPTION
@bnasslahsen 

Hello, I propose a new option to expose params condition in the path, allowing the value to be differently exposed in the path as well.

I understand the comment you provided regarding this issue (#2691 )and respect the direction of using the path and HttpMethod as identifiers for API uniqueness.

While it's true that params condition alone may not guarantee uniqueness, it plays a role in refining the request, making it a valid option to offer. Additionally, the Spring Framework's RequestMappingHandler supports API mapping separation based on params condition, and I believe there are cases where others have similar requirements.

Therefore, I would like to gradually improve this feature by providing it as an option that users can use if needed.

Of course, this is just another direction I'm suggesting.

Thank you.

resolved : #2691 