### PR TITLE
Add SortAsQueryParam annotation

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/models/SortAsQueryParam.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/models/SortAsQueryParam.java
@@ -1,0 +1,26 @@
+package org.springdoc.core.converters.models;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * The Sort class as query param.
+ *
+ * @author ondrejkrpec
+ */
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(in = ParameterIn.QUERY
+        , description = "Sorting criteria in the format: property,(asc|desc). "
+        + "Default sort order is ascending. " + "Multiple sort criteria are supported."
+        , name = "sort"
+        , array = @ArraySchema(schema = @Schema(type = "string"))
+)
+public @interface SortAsQueryParam {}

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/java/test/org/springdoc/api/app3/HelloController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/java/test/org/springdoc/api/app3/HelloController.java
@@ -20,6 +20,7 @@ package test.org.springdoc.api.app3;
 
 import org.springdoc.core.converters.models.PageableAsQueryParam;
 
+import org.springdoc.core.converters.models.SortAsQueryParam;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,6 +35,12 @@ public class HelloController {
 	@PageableAsQueryParam
 	public String operation4() {
 		return "operation4";
+	}
+
+	@GetMapping("operation5")
+	@SortAsQueryParam
+	public String operation5() {
+		return "operation5";
 	}
 
 }

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/app3.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/app3.json
@@ -11,6 +11,39 @@
     }
   ],
   "paths": {
+    "/demo/operation5": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "operation5",
+        "parameters": [
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/demo/operation4": {
       "get": {
         "tags": [


### PR DESCRIPTION
Hello,

I would like to propose a new annotation: `@SortAsQueryParam`. This annotation allows the use of the `Sort` object in query parameters. Currently, the project supports using the `Pageable` object in query parameters through the `@PageableAsQueryParam` annotation.

However, there isn't an easy way to utilize the Sort object independently without involving pagination. This limitation means that developers who need sorting capabilities without pagination have to implement workarounds.

By introducing the `@SortAsQueryParam` annotation, we can provide users with a straightforward option to include sorting in their API endpoints without the need for pagination. This enhancement will offer greater flexibility and convenience for those who require sorting functionality on its own.

Thank you for considering this proposal.

