### PR TITLE
Resolve infinite recursion and add example test with OpenAPI v3.1

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PolymorphicModelConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PolymorphicModelConverter.java
@@ -134,7 +134,7 @@ public class PolymorphicModelConverter implements ModelConverter {
 		if(resolvedSchema.get$ref().contains(Components.COMPONENTS_SCHEMAS_REF)) {
 			String schemaName = resolvedSchema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length());
 			Schema existingSchema = context.getDefinedModels().get(schemaName);
-			if (existingSchema != null && existingSchema.getOneOf() != null) {
+			if (existingSchema != null && (existingSchema.getOneOf() != null || existingSchema.getAllOf() != null || existingSchema.getAnyOf() != null)) {
 				return resolvedSchema;
 			}
 		}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/SpringDocApp13Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/SpringDocApp13Test.kt
@@ -18,10 +18,30 @@
 
 package test.org.springdoc.api.app13
 
+import org.springdoc.core.properties.SpringDocConfigProperties
+import org.springdoc.core.properties.SpringDocConfigProperties.ApiDocs.OpenApiVersion
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import test.org.springdoc.api.AbstractKotlinSpringDocMVCTest
 
+
+@SpringBootTest//(classes = [Config::class])
 class SpringDocApp13Test : AbstractKotlinSpringDocMVCTest() {
+
+
+    @Configuration
+    class Config{
+        @Bean
+        fun springDocConfigProperties():SpringDocConfigProperties{
+            val x= SpringDocConfigProperties()
+            x.apiDocs.version = OpenApiVersion.OPENAPI_3_1
+            return x
+        }
+
+    }
+
 
     @SpringBootApplication
     class DemoApplication

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/SpringDocApp13Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/SpringDocApp13Test.kt
@@ -1,0 +1,29 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app13
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import test.org.springdoc.api.AbstractKotlinSpringDocMVCTest
+
+class SpringDocApp13Test : AbstractKotlinSpringDocMVCTest() {
+
+    @SpringBootApplication
+    class DemoApplication
+
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
@@ -19,6 +19,7 @@
 package test.org.springdoc.api.app13
 
 
+import io.swagger.v3.oas.annotations.OpenAPI31
 import io.swagger.v3.oas.annotations.media.Schema
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -36,6 +37,7 @@ data class SomeDTO(
     @Schema(description = "Description A", allOf = [KeyValue::class]) val fieldA: KeyValue,
     @Schema(description = "Description B", allOf = [KeyValue::class]) val fieldB: KeyValue,
 )
+
 
 
 @RestController

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2019-2020 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.app13
+
+
+import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Schema(description = "Generic description")
+data class KeyValue(
+    val key: String,
+    val value: String,
+)
+
+@Schema
+data class SomeDTO(
+    @Schema(description = "Description A", allOf = [KeyValue::class]) val fieldA: KeyValue,
+    @Schema(description = "Description B", allOf = [KeyValue::class]) val fieldB: KeyValue,
+)
+
+
+@RestController
+@RequestMapping("/test")
+class TestController {
+    @PostMapping("/test")
+    fun create(@RequestBody some: SomeDTO) {
+
+    }
+}
+

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/app13/TestController.kt
@@ -34,8 +34,8 @@ data class KeyValue(
 
 @Schema
 data class SomeDTO(
-    @Schema(description = "Description A", allOf = [KeyValue::class]) val fieldA: KeyValue,
-    @Schema(description = "Description B", allOf = [KeyValue::class]) val fieldB: KeyValue,
+    @Schema(description = "Description A") val fieldA: KeyValue,
+    @Schema(description = "Description B") val fieldB: KeyValue,
 )
 
 

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
@@ -1,0 +1,71 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
+  },
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/test/test" : {
+      "post" : {
+        "tags" : [ "test-controller" ],
+        "operationId" : "create",
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SomeDTO"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "OK"
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "KeyValue" : {
+        "required" : [ "key", "value" ],
+        "type" : "object",
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        },
+        "description" : "Generic description"
+      },
+      "SomeDTO" : {
+        "required" : [ "fieldA", "fieldB" ],
+        "type" : "object",
+        "properties" : {
+          "fieldA" : {
+            "type" : "object",
+            "description" : "Description A",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/KeyValue"
+            } ]
+          },
+          "fieldB" : {
+            "type" : "object",
+            "description" : "Description B",
+            "allOf" : [ {
+              "$ref" : "#/components/schemas/KeyValue"
+            } ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
@@ -36,33 +36,30 @@
       "KeyValue" : {
         "required" : [ "key", "value" ],
         "type" : "object",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
+        "description" : "Generic description",
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/KeyValue"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "key" : {
+              "type" : "string"
+            },
+            "value" : {
+              "type" : "string"
+            }
           }
-        },
-        "description" : "Generic description"
+        } ]
       },
       "SomeDTO" : {
         "required" : [ "fieldA", "fieldB" ],
         "type" : "object",
         "properties" : {
           "fieldA" : {
-            "type" : "object",
-            "description" : "Description A",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/KeyValue"
-            } ]
+            "$ref" : "#/components/schemas/KeyValue"
           },
           "fieldB" : {
-            "type" : "object",
-            "description" : "Description B",
-            "allOf" : [ {
-              "$ref" : "#/components/schemas/KeyValue"
-            } ]
+            "$ref" : "#/components/schemas/KeyValue"
           }
         }
       }

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
@@ -1,5 +1,5 @@
 {
-  "openapi" : "3.0.1",
+  "openapi" : "3.1.0",
   "info" : {
     "title" : "OpenAPI definition",
     "version" : "v0"
@@ -37,19 +37,14 @@
         "required" : [ "key", "value" ],
         "type" : "object",
         "description" : "Generic description",
-        "allOf" : [ {
-          "$ref" : "#/components/schemas/KeyValue"
-        }, {
-          "type" : "object",
-          "properties" : {
-            "key" : {
-              "type" : "string"
-            },
-            "value" : {
-              "type" : "string"
-            }
+        "properties" : {
+          "key" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
           }
-        } ]
+        }
       },
       "SomeDTO" : {
         "required": [
@@ -59,22 +54,12 @@
         "type": "object",
         "properties": {
           "fieldA": {
-            "type": "object",
             "description": "Description A",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/KeyValue"
-              }
-            ]
+            "$ref": "#/components/schemas/KeyValue"
           },
           "fieldB": {
-            "type": "object",
             "description": "Description B",
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/KeyValue"
-              }
-            ]
+            "$ref": "#/components/schemas/KeyValue"
           }
         }
       }

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/app13.json
@@ -52,14 +52,29 @@
         } ]
       },
       "SomeDTO" : {
-        "required" : [ "fieldA", "fieldB" ],
-        "type" : "object",
-        "properties" : {
-          "fieldA" : {
-            "$ref" : "#/components/schemas/KeyValue"
+        "required": [
+          "fieldA",
+          "fieldB"
+        ],
+        "type": "object",
+        "properties": {
+          "fieldA": {
+            "type": "object",
+            "description": "Description A",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyValue"
+              }
+            ]
           },
-          "fieldB" : {
-            "$ref" : "#/components/schemas/KeyValue"
+          "fieldB": {
+            "type": "object",
+            "description": "Description B",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/KeyValue"
+              }
+            ]
           }
         }
       }


### PR DESCRIPTION
Resolves #2801.

It turns out, that my desired workaround is no longer necessary, as one can now (since v3.1) have both a description and a `$ref` within a OpenAPI schema.

The PR still resolves the potential infinite recursion and gives the schema resolution a small refactor - makes it nicer to read - but thats obviously subjective.

Anyway, I think the testcase can serve as a hint to other users that had similar problems, and it shows that the workaround documented [here](https://springdoc.org/#how-can-i-define-different-description-for-a-class-attribute-depending-on-usage) may no longer be necessary when using OpenAPI v3.1.

As a side note: It also demonstrates, that https://github.com/swagger-api/swagger-core/issues/3900 may potentially be resolved already!