### PR TITLE
Align Swagger-UI Prefix Path with Swagger-WebMvc Behavior

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
@@ -175,7 +175,7 @@ public final class Constants {
 	/**
 	 * The constant DEFAULT_WEB_JARS_PREFIX_URL.
 	 */
-	public static final String DEFAULT_WEB_JARS_PREFIX_URL = "/webjars";
+	public static final String DEFAULT_WEB_JARS_PREFIX_URL = "/webjars/swagger-ui/5.18.2";
 
 	/**
 	 * The constant CLASSPATH_RESOURCE_LOCATION.

--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/providers/SpringWebFluxProvider.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/providers/SpringWebFluxProvider.java
@@ -25,17 +25,10 @@
  */
 package org.springdoc.webflux.core.providers;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
-
+import org.springdoc.core.utils.Constants;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.reactive.result.condition.PatternsRequestCondition;
@@ -43,6 +36,13 @@ import org.springframework.web.reactive.result.method.AbstractHandlerMethodMappi
 import org.springframework.web.reactive.result.method.RequestMappingInfo;
 import org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping;
 import org.springframework.web.util.pattern.PathPattern;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -66,8 +66,8 @@ public class SpringWebFluxProvider extends SpringWebProvider {
 			Set<String> patterns = getActivePatterns(requestMappingInfo);
 			if (!CollectionUtils.isEmpty(patterns)) {
 				for (String operationPath : patterns) {
-					if (operationPath.endsWith(springDocConfigProperties.getApiDocs().getPath()))
-						return operationPath.replace(springDocConfigProperties.getApiDocs().getPath(), StringUtils.EMPTY);
+					if (operationPath.endsWith(Constants.DEFAULT_API_DOCS_URL))
+						return operationPath.replace(Constants.DEFAULT_API_DOCS_URL, StringUtils.EMPTY);
 				}
 			}
 		}

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
@@ -26,8 +26,6 @@
 
 package org.springdoc.webflux.ui;
 
-import java.util.Optional;
-
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
@@ -36,7 +34,6 @@ import org.springdoc.core.providers.ActuatorProvider;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.providers.SpringWebProvider;
 import org.springdoc.webflux.core.providers.SpringWebFluxProvider;
-
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
@@ -53,6 +50,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+import java.util.Optional;
 
 import static org.springdoc.core.utils.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
 import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_MANAGEMENT_PORT;
@@ -129,9 +128,9 @@ public class SwaggerConfig implements WebFluxConfigurer {
 	@ConditionalOnMissingBean
 	@Lazy(false)
 	SwaggerWebFluxConfigurer swaggerWebFluxConfigurer(SwaggerUiConfigProperties swaggerUiConfigProperties,
-			SpringDocConfigProperties springDocConfigProperties, SwaggerIndexTransformer swaggerIndexTransformer,
+													  SpringDocConfigProperties springDocConfigProperties, SwaggerIndexTransformer swaggerIndexTransformer,
 			Optional<ActuatorProvider> actuatorProvider, SwaggerResourceResolver swaggerResourceResolver) {
-		return new SwaggerWebFluxConfigurer(swaggerUiConfigProperties,springDocConfigProperties, swaggerIndexTransformer, actuatorProvider, swaggerResourceResolver);
+		return new SwaggerWebFluxConfigurer(swaggerUiConfigProperties, springDocConfigProperties, swaggerIndexTransformer, actuatorProvider, swaggerResourceResolver);
 	}
 
 	/**
@@ -207,7 +206,7 @@ public class SwaggerConfig implements WebFluxConfigurer {
 		@Lazy(false)
 		SwaggerWelcomeActuator swaggerActuatorWelcome(SwaggerUiConfigProperties swaggerUiConfig, SpringDocConfigProperties springDocConfigProperties,
 				WebEndpointProperties webEndpointProperties, ManagementServerProperties managementServerProperties) {
-			return new SwaggerWelcomeActuator(swaggerUiConfig, springDocConfigProperties, webEndpointProperties, managementServerProperties);
+			return new SwaggerWelcomeActuator(swaggerUiConfig, springDocConfigProperties, webEndpointProperties);
 		}
 	}
 }

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
@@ -21,23 +21,22 @@
  *  *  *  *
  *  *  *
  *  *
- *  
+ *
  */
 
 package org.springdoc.webflux.ui;
 
-import java.util.Optional;
-
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.core.providers.ActuatorProvider;
-
 import org.springframework.web.reactive.config.ResourceHandlerRegistry;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
 
+import java.util.Optional;
+
 import static org.springdoc.core.utils.Constants.ALL_PATTERN;
 import static org.springdoc.core.utils.Constants.CLASSPATH_RESOURCE_LOCATION;
-import static org.springdoc.core.utils.Constants.DEFAULT_WEB_JARS_PREFIX_URL;
+import static org.springdoc.core.utils.Constants.SWAGGER_UI_PREFIX;
 import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
 /**
@@ -82,8 +81,8 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 	 * @param swaggerResourceResolver   the swagger resource resolver
 	 */
 	public SwaggerWebFluxConfigurer(SwaggerUiConfigProperties swaggerUiConfigProperties,
-			SpringDocConfigProperties springDocConfigProperties,
-			SwaggerIndexTransformer swaggerIndexTransformer,
+									SpringDocConfigProperties springDocConfigProperties,
+									SwaggerIndexTransformer swaggerIndexTransformer,
 			Optional<ActuatorProvider> actuatorProvider, SwaggerResourceResolver swaggerResourceResolver) {
 		this.swaggerIndexTransformer = swaggerIndexTransformer;
 		this.actuatorProvider = actuatorProvider;
@@ -100,8 +99,9 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 			uiRootPath.append(swaggerPath, 0, swaggerPath.lastIndexOf(DEFAULT_PATH_SEPARATOR));
 		if (actuatorProvider.isPresent() && actuatorProvider.get().isUseManagementPort())
 			uiRootPath.append(actuatorProvider.get().getBasePath());
-		registry.addResourceHandler(uiRootPath + springDocConfigProperties.getWebjars().getPrefix() + ALL_PATTERN)
-				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR)
+
+		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + ALL_PATTERN)
+				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + springDocConfigProperties.getWebjars().getPrefix() + DEFAULT_PATH_SEPARATOR)
 				.resourceChain(false)
 				.addResolver(swaggerResourceResolver)
 				.addTransformer(swaggerIndexTransformer);

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeActuator.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeActuator.java
@@ -26,24 +26,20 @@
 
 package org.springdoc.webflux.ui;
 
-import java.util.Map;
-
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
-import reactor.core.publisher.Mono;
-
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
-import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.boot.actuate.endpoint.web.annotation.ControllerEndpoint;
 import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
 
 import static org.springdoc.core.utils.Constants.DEFAULT_API_DOCS_ACTUATOR_URL;
 import static org.springdoc.core.utils.Constants.DEFAULT_SWAGGER_UI_ACTUATOR_PATH;
@@ -69,25 +65,17 @@ public class SwaggerWelcomeActuator extends SwaggerWelcomeCommon {
 	private final WebEndpointProperties webEndpointProperties;
 
 	/**
-	 * The Management server properties.
-	 */
-	private final ManagementServerProperties managementServerProperties;
-
-	/**
 	 * Instantiates a new Swagger welcome.
 	 *
-	 * @param swaggerUiConfig            the swagger ui config
-	 * @param springDocConfigProperties  the spring doc config properties
-	 * @param webEndpointProperties      the web endpoint properties
-	 * @param managementServerProperties the management server properties
+	 * @param swaggerUiConfig           the swagger ui config
+	 * @param springDocConfigProperties the swagger ui config parameters
+	 * @param webEndpointProperties     the web endpoint properties
 	 */
 	public SwaggerWelcomeActuator(SwaggerUiConfigProperties swaggerUiConfig
 			, SpringDocConfigProperties springDocConfigProperties,
-			WebEndpointProperties webEndpointProperties,
-			ManagementServerProperties managementServerProperties) {
+								  WebEndpointProperties webEndpointProperties) {
 		super(swaggerUiConfig, springDocConfigProperties);
 		this.webEndpointProperties = webEndpointProperties;
-		this.managementServerProperties = managementServerProperties;
 	}
 
 	/**
@@ -104,39 +92,30 @@ public class SwaggerWelcomeActuator extends SwaggerWelcomeCommon {
 		return super.redirectToUi(request, response);
 	}
 
-
 	/**
-	 * Gets swagger ui config.
+	 * Openapi yaml map.
 	 *
 	 * @param request the request
-	 * @return the swagger ui config
+	 * @return the map
 	 */
 	@Operation(hidden = true)
 	@GetMapping(value = SWAGGER_CONFIG_ACTUATOR_URL, produces = MediaType.APPLICATION_JSON_VALUE)
 	@ResponseBody
 	@Override
-	public Map<String, Object> getSwaggerUiConfig(ServerHttpRequest request) {
-		return super.getSwaggerUiConfig(request);
+	public Map<String, Object> openapiJson(ServerHttpRequest request) {
+		return super.openapiJson(request);
 	}
 
 	@Override
-	protected void calculateUiRootPath(SwaggerUiConfigParameters swaggerUiConfigParameters,StringBuilder... sbUrls) {
+	protected void calculateUiRootPath(SwaggerUiConfigParameters swaggerUiConfigParameters, StringBuilder... sbUrls) {
 		StringBuilder sbUrl = new StringBuilder();
 		sbUrl.append(webEndpointProperties.getBasePath());
-		calculateUiRootCommon(swaggerUiConfigParameters,sbUrl, sbUrls);
-	}
-
-	@Override
-	protected void calculateOauth2RedirectUrl(SwaggerUiConfigParameters swaggerUiConfigParameters, UriComponentsBuilder uriComponentsBuilder) {
-		if (StringUtils.isBlank(swaggerUiConfig.getOauth2RedirectUrl()) || !swaggerUiConfigParameters.isValidUrl(swaggerUiConfig.getOauth2RedirectUrl())) {
-			UriComponentsBuilder oauthPrefix = uriComponentsBuilder.path(managementServerProperties.getBasePath() + swaggerUiConfigParameters.getUiRootPath()).path(webJarsPrefixUrl);
-			swaggerUiConfigParameters.setOauth2RedirectUrl(oauthPrefix.path(getOauth2RedirectUrl()).build().toString());
-		}
+		calculateUiRootCommon(swaggerUiConfigParameters, sbUrl, sbUrls);
 	}
 
 	@Override
 	protected void buildApiDocUrl(SwaggerUiConfigParameters swaggerUiConfigParameters) {
-		swaggerUiConfigParameters.setApiDocsUrl( buildUrl(swaggerUiConfigParameters.getContextPath() + webEndpointProperties.getBasePath(), DEFAULT_API_DOCS_ACTUATOR_URL));
+		swaggerUiConfigParameters.setApiDocsUrl(buildUrl(swaggerUiConfigParameters.getContextPath() + webEndpointProperties.getBasePath(), DEFAULT_API_DOCS_ACTUATOR_URL));
 	}
 
 	@Override

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
@@ -21,25 +21,24 @@
  *  *  *  *
  *  *  *
  *  *
- *  
+ *
  */
 
 package org.springdoc.webflux.ui;
 
-import java.net.URI;
-import java.util.Map;
-
+import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.ui.AbstractSwaggerWelcome;
-import reactor.core.publisher.Mono;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Map;
 
 /**
  * The type Swagger welcome common.
@@ -47,11 +46,6 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author bnasslashen
  */
 public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
-
-	/**
-	 * The Web jars prefix url.
-	 */
-	protected String webJarsPrefixUrl;
 
 
 	/**
@@ -62,7 +56,6 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 	 */
 	protected SwaggerWelcomeCommon(SwaggerUiConfigProperties swaggerUiConfig, SpringDocConfigProperties springDocConfigProperties) {
 		super(swaggerUiConfig, springDocConfigProperties);
-		this.webJarsPrefixUrl = springDocConfigProperties.getWebjars().getPrefix();
 	}
 
 	/**
@@ -74,12 +67,37 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 	 */
 	protected Mono<Void> redirectToUi(ServerHttpRequest request, ServerHttpResponse response) {
 		SwaggerUiConfigParameters swaggerUiConfigParameters = new SwaggerUiConfigParameters(swaggerUiConfig);
-		this.buildFromCurrentContextPath(swaggerUiConfigParameters, request);
-		String sbUrl = this.buildUrl(swaggerUiConfigParameters.getContextPath(), swaggerUiConfigParameters.getUiRootPath() + springDocConfigProperties.getWebjars().getPrefix() + getSwaggerUiUrl());
+		buildFromCurrentContextPath(swaggerUiConfigParameters, request);
+		String sbUrl = swaggerUiConfigParameters.getContextPath() + swaggerUiConfigParameters.getUiRootPath() + getSwaggerUiUrl();
 		UriComponentsBuilder uriBuilder = getUriComponentsBuilder(swaggerUiConfigParameters, sbUrl);
+
+		// forward all queryParams from original request
+		request.getQueryParams().forEach(uriBuilder::queryParam);
+
 		response.setStatusCode(HttpStatus.FOUND);
 		response.getHeaders().setLocation(URI.create(uriBuilder.build().encode().toString()));
 		return response.setComplete();
+	}
+
+	/**
+	 * Openapi json map.
+	 *
+	 * @param request the request
+	 * @return the map
+	 */
+	protected Map<String, Object> openapiJson(ServerHttpRequest request) {
+		SwaggerUiConfigParameters swaggerUiConfigParameters = new SwaggerUiConfigParameters(swaggerUiConfig);
+		buildFromCurrentContextPath(swaggerUiConfigParameters, request);
+		return swaggerUiConfigParameters.getConfigParameters();
+	}
+
+	@Override
+	protected void calculateOauth2RedirectUrl(SwaggerUiConfigParameters swaggerUiConfigParameters, UriComponentsBuilder uriComponentsBuilder) {
+		if (StringUtils.isBlank(swaggerUiConfig.getOauth2RedirectUrl()) || !swaggerUiConfigParameters.isValidUrl(swaggerUiConfig.getOauth2RedirectUrl())) {
+			swaggerUiConfigParameters.setOauth2RedirectUrl(uriComponentsBuilder
+					.path(swaggerUiConfigParameters.getUiRootPath())
+					.path(getOauth2RedirectUrl()).build().toString());
+		}
 	}
 
 	/**
@@ -105,8 +123,13 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 		super.init(swaggerUiConfigParameters);
 		swaggerUiConfigParameters.setContextPath(request.getPath().contextPath().value());
 		String url = UriComponentsBuilder.fromHttpRequest(request).toUriString();
-		if (!AntPathMatcher.DEFAULT_PATH_SEPARATOR.equals(request.getPath().toString()))
+		String target = UriComponentsBuilder.fromPath(request.getPath().contextPath().value()).toUriString();
+		int endIndex = url.indexOf(target) + target.length();
+		if (endIndex > 0) {
+			url = url.substring(0, endIndex);
+		} else {
 			url = url.replace(request.getPath().toString(), "");
+		}
 		buildConfigUrl(swaggerUiConfigParameters, UriComponentsBuilder.fromUriString(url));
 	}
 

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeWebFlux.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeWebFlux.java
@@ -27,18 +27,15 @@
 package org.springdoc.webflux.ui;
 
 import io.swagger.v3.oas.annotations.Operation;
-import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
-import reactor.core.publisher.Mono;
-
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 
 import static org.springdoc.core.utils.Constants.SWAGGER_CONFIG_FILE;
 import static org.springdoc.core.utils.Constants.SWAGGER_UI_PATH;
@@ -91,14 +88,6 @@ public class SwaggerWelcomeWebFlux extends SwaggerWelcomeCommon {
 	}
 
 	@Override
-	protected void calculateOauth2RedirectUrl(SwaggerUiConfigParameters swaggerUiConfigParameters, UriComponentsBuilder uriComponentsBuilder) {
-		if (StringUtils.isBlank(swaggerUiConfig.getOauth2RedirectUrl()) || !swaggerUiConfigParameters.isValidUrl(swaggerUiConfig.getOauth2RedirectUrl())) {
-			UriComponentsBuilder oauthPrefix = uriComponentsBuilder.path(swaggerUiConfigParameters.getContextPath()).path(swaggerUiConfigParameters.getUiRootPath()).path(webJarsPrefixUrl);
-			swaggerUiConfigParameters.setOauth2RedirectUrl(oauthPrefix.path(getOauth2RedirectUrl()).build().toString());
-		}
-	}
-
-	@Override
 	protected void buildApiDocUrl(SwaggerUiConfigParameters swaggerUiConfigParameters) {
 		swaggerUiConfigParameters.setApiDocsUrl(buildUrlWithContextPath(swaggerUiConfigParameters, springDocConfigProperties.getApiDocs().getPath()));
 	}
@@ -107,7 +96,11 @@ public class SwaggerWelcomeWebFlux extends SwaggerWelcomeCommon {
 	protected String buildUrlWithContextPath(SwaggerUiConfigParameters swaggerUiConfigParameters, String swaggerUiUrl) {
 		if (swaggerUiConfigParameters.getPathPrefix() == null)
 			swaggerUiConfigParameters.setPathPrefix(springWebProvider.findPathPrefix(springDocConfigProperties));
-		return buildUrl(swaggerUiConfigParameters.getContextPath() + swaggerUiConfigParameters.getPathPrefix(), swaggerUiUrl);
+		if (swaggerUiUrl.startsWith(swaggerUiConfigParameters.getPathPrefix())) {
+			return buildUrl(swaggerUiConfigParameters.getContextPath(), swaggerUiUrl);
+		} else {
+			return buildUrl(swaggerUiConfigParameters.getContextPath() + swaggerUiConfigParameters.getPathPrefix(), swaggerUiUrl);
+		}
 	}
 
 	@Override

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/AbstractSpringDocTest.java
@@ -27,7 +27,6 @@ import org.springdoc.core.properties.SwaggerUiOAuthProperties;
 import org.springdoc.core.utils.Constants;
 import org.springdoc.webflux.core.configuration.SpringDocWebFluxConfiguration;
 import org.springdoc.webflux.ui.SwaggerConfig;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
 import org.springframework.test.context.ContextConfiguration;
@@ -44,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 		SwaggerConfig.class, SwaggerUiOAuthProperties.class, SpringDocUIConfiguration.class })
 public abstract class AbstractSpringDocTest extends AbstractCommonTest {
 
-	private static final String DEFAULT_SWAGGER_INITIALIZER_URL = Constants.DEFAULT_WEB_JARS_PREFIX_URL + Constants.SWAGGER_INITIALIZER_URL;
+	private static final String DEFAULT_SWAGGER_INITIALIZER_URL = Constants.SWAGGER_INITIALIZER_URL;
 
 	@Autowired
 	protected WebTestClient webTestClient;

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirecFilterTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirecFilterTest.java
@@ -20,11 +20,10 @@ package test.org.springdoc.ui.app1;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 
 @TestPropertySource(properties = "springdoc.swagger-ui.filter=false")
@@ -36,7 +35,7 @@ public class SpringDocApp1RedirecFilterTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/webjars/swagger-ui/index.html"));
+				.value("Location", Matchers.is("/swagger-ui/index.html"));
 		super.checkJS("index1-filter");
 	}
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectConfigUrlTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectConfigUrlTest.java
@@ -20,11 +20,10 @@ package test.org.springdoc.ui.app1;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 
 @TestPropertySource(properties = {
@@ -39,7 +38,7 @@ public class SpringDocApp1RedirectConfigUrlTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/webjars/swagger-ui/index.html"));
+                .value("Location", Matchers.is("/swagger-ui/index.html"));
 
 		super.checkJS("index1-configurl");
 	}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectDefaultTest.java
@@ -20,10 +20,9 @@ package test.org.springdoc.ui.app1;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 
 public class SpringDocApp1RedirectDefaultTest extends AbstractSpringDocTest {
@@ -33,7 +32,7 @@ public class SpringDocApp1RedirectDefaultTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/webjars/swagger-ui/index.html"));
+                .value("Location", Matchers.is("/swagger-ui/index.html"));
 
 		webTestClient.get().uri("/v3/api-docs/swagger-config").exchange()
 				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl").isEqualTo("");

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectLayoutTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectLayoutTest.java
@@ -20,11 +20,10 @@ package test.org.springdoc.ui.app1;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 
 @TestPropertySource(properties = "springdoc.swagger-ui.layout=BaseLayout")
@@ -36,7 +35,7 @@ public class SpringDocApp1RedirectLayoutTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/webjars/swagger-ui/index.html"));
+                .value("Location", Matchers.is("/swagger-ui/index.html"));
 
 		super.checkJS("index1-layout");
 	}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocApp1RedirectWithConfigTest.java
@@ -20,11 +20,10 @@ package test.org.springdoc.ui.app1;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.validatorUrl=/foo/validate",
@@ -38,7 +37,7 @@ public class SpringDocApp1RedirectWithConfigTest extends AbstractSpringDocTest {
 				.expectStatus().isFound();
 
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/webjars/swagger-ui/index.html"));
+                .value("Location", Matchers.is("/swagger-ui/index.html"));
 
 		webTestClient.get().uri("/baf/batz/swagger-config").exchange()
 				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl").isEqualTo("/foo/validate");

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app13/SpringDocApp13Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app13/SpringDocApp13Test.java
@@ -25,14 +25,13 @@
 package test.org.springdoc.ui.app13;
 
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -47,7 +46,7 @@ class SpringDocApp13Test extends AbstractSpringDocActuatorTest {
 
 	@Test
 	void testIndex() {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app14/SpringDocApp14Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app14/SpringDocApp14Test.java
@@ -25,14 +25,13 @@
 package test.org.springdoc.ui.app14;
 
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -45,7 +44,7 @@ class SpringDocApp14Test extends AbstractSpringDocActuatorTest {
 
 	@Test
 	void testIndex() {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app15/SpringDocApp15Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app15/SpringDocApp15Test.java
@@ -25,14 +25,13 @@
 package test.org.springdoc.ui.app15;
 
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -48,7 +47,7 @@ class SpringDocApp15Test extends AbstractSpringDocActuatorTest {
 
 	@Test
 	void testIndex() {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app16/SpringDocApp16Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app16/SpringDocApp16Test.java
@@ -25,14 +25,13 @@
 package test.org.springdoc.ui.app16;
 
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -48,7 +47,7 @@ class SpringDocApp16Test extends AbstractSpringDocActuatorTest {
 
 	@Test
 	void testIndex() {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/webjars/swagger-ui/index.html")
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/application/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app17/SpringDocApp17Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app17/SpringDocApp17Test.java
@@ -19,11 +19,10 @@
 package test.org.springdoc.ui.app17;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import test.org.springdoc.ui.AbstractSpringDocActuatorTest;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -38,7 +37,7 @@ class SpringDocApp17Test extends AbstractSpringDocActuatorTest {
 
 	@Test
 	void testIndex() {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/webjars/swagger-ui/index.html")
+		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/swagger-ui/index.html")
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app18/SpringDocApp18Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app18/SpringDocApp18Test.java
@@ -26,9 +26,6 @@ package test.org.springdoc.ui.app18;
 
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractCommonTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -36,6 +33,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractCommonTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -45,8 +44,7 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 		properties = { "spring.webflux.base-path=/test",
 				"server.port=9218",
 				"springdoc.swagger-ui.path=/documentation/swagger-ui.html",
-				"springdoc.api-docs.path=/documentation/v3/api-docs",
-				"springdoc.webjars.prefix= /webjars-pref" })
+                "springdoc.api-docs.path=/documentation/v3/api-docs"})
 class SpringDocApp18Test extends AbstractCommonTest {
 
 	@LocalServerPort
@@ -66,7 +64,7 @@ class SpringDocApp18Test extends AbstractCommonTest {
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
-		httpStatusMono = webClient.get().uri("/test/documentation/webjars-pref/swagger-ui/index.html")
+        httpStatusMono = webClient.get().uri("/test/documentation/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app19/SpringDocApp19Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app19/SpringDocApp19Test.java
@@ -26,9 +26,6 @@ package test.org.springdoc.ui.app19;
 
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractCommonTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -36,6 +33,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractCommonTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -63,7 +62,7 @@ class SpringDocApp19Test extends AbstractCommonTest {
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
-		httpStatusMono = webClient.get().uri("/webjars/swagger-ui/index.html")
+        httpStatusMono = webClient.get().uri("/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app20/SpringDocApp20Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app20/SpringDocApp20Test.java
@@ -27,9 +27,6 @@ package test.org.springdoc.ui.app20;
 
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractCommonTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -37,6 +34,8 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractCommonTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -63,7 +62,7 @@ class SpringDocApp20Test extends AbstractCommonTest {
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
-		httpStatusMono = webClient.get().uri("/webjars/swagger-ui/index.html")
+        httpStatusMono = webClient.get().uri("/swagger-ui/index.html")
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app24/SpringDocApp24Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app24/SpringDocApp24Test.java
@@ -19,11 +19,10 @@
 package test.org.springdoc.ui.app24;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = {
 		"springdoc.api-docs.enabled=false",
@@ -40,7 +39,7 @@ public class SpringDocApp24Test extends AbstractSpringDocTest {
 				.jsonPath("$.url").isEqualTo("/api-docs/xxx/v1/openapi.yml")
 				.jsonPath("$.configUrl").isEqualTo("/api-docs/swagger-config")
 				.jsonPath("$.validatorUrl").isEqualTo("")
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("/swagger-ui/oauth2-redirect.html");
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectDefaultTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectDefaultTest.java
@@ -21,11 +21,10 @@ package test.org.springdoc.ui.app3;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.utils.Constants;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 
 @TestPropertySource(properties = {
@@ -39,14 +38,14 @@ public class SpringDocApp3RedirectDefaultTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/documentation/webjars/swagger-ui/index.html"));
+                .value("Location", Matchers.is("/documentation/swagger-ui/index.html"));
 
 		webTestClient.get().uri("/documentation/v3/api-docs/swagger-config").exchange()
 				.expectStatus().isOk().expectBody()
 				.jsonPath("$.validatorUrl").isEqualTo("")
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("/documentation/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("/documentation/swagger-ui/oauth2-redirect.html");
 
-		super.checkJS("index3", "/documentation/webjars" + Constants.SWAGGER_INITIALIZER_URL);
+		super.checkJS("index3", "/documentation" + Constants.SWAGGER_INITIALIZER_URL);
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectWithPrefixTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3RedirectWithPrefixTest.java
@@ -20,16 +20,14 @@ package test.org.springdoc.ui.app3;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.path=/documentation/swagger-ui.html",
-		"springdoc.api-docs.path=/documentation/v3/api-docs",
-		"springdoc.webjars.prefix= /webjars-pref"
+		"springdoc.api-docs.path=/documentation/v3/api-docs"
 })
 public class SpringDocApp3RedirectWithPrefixTest extends AbstractSpringDocTest {
 
@@ -38,8 +36,8 @@ public class SpringDocApp3RedirectWithPrefixTest extends AbstractSpringDocTest {
 		WebTestClient.ResponseSpec responseSpec = webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
 				.expectStatus().isFound();
 		responseSpec.expectHeader()
-				.value("Location", Matchers.is("/documentation/webjars-pref/swagger-ui/index.html"));
-		webTestClient.get().uri("/documentation/webjars-pref/swagger-ui/index.html").exchange()
+				.value("Location", Matchers.is("/documentation/swagger-ui/index.html"));
+		webTestClient.get().uri("/documentation/swagger-ui/index.html").exchange()
 				.expectStatus().isOk();
 		webTestClient.get().uri("/documentation/v3/api-docs/swagger-config").exchange()
 				.expectStatus().isOk().expectBody().jsonPath("$.validatorUrl").isEqualTo("");

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app3/SpringDocApp3Test.java
@@ -19,10 +19,9 @@
 package test.org.springdoc.ui.app3;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.path=/documentation/swagger-ui.html",
@@ -34,7 +33,7 @@ public class SpringDocApp3Test extends AbstractSpringDocTest {
 	void shouldDisplaySwaggerUiPage() {
 		webTestClient.get().uri("/documentation/swagger-ui.html").exchange()
 				.expectStatus().isFound();
-		webTestClient.get().uri("/documentation/webjars/swagger-ui/index.html").exchange()
+        webTestClient.get().uri("/documentation/swagger-ui/index.html").exchange()
 				.expectStatus().isOk();
 	}
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyTest.java
@@ -18,15 +18,14 @@
 
 package test.org.springdoc.ui.app32;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.IntStream;
-
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,14 +39,14 @@ public class SpringDocBehindProxyTest extends AbstractSpringDocTest {
 
 	@Test
 	void shouldServeSwaggerUIAtDefaultPath() {
-		webTestClient.get().uri("/webjars/swagger-ui/index.html").exchange()
+        webTestClient.get().uri("/swagger-ui/index.html").exchange()
 				.expectStatus().isOk();
 	}
 
 	@Test
 	void shouldReturnCorrectInitializerJS() throws Exception {
 		webTestClient
-				.get().uri("/webjars/swagger-ui/swagger-initializer.js")
+                .get().uri("/swagger-ui/swagger-initializer.js")
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isOk()
@@ -67,7 +66,7 @@ public class SpringDocBehindProxyTest extends AbstractSpringDocTest {
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isOk().expectBody()
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("https://proxy-host/path/prefix/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("https://proxy-host/path/prefix/swagger-ui/oauth2-redirect.html");
 	}
 
 	@Test
@@ -87,7 +86,7 @@ public class SpringDocBehindProxyTest extends AbstractSpringDocTest {
 	void shouldReturnCorrectInitializerJSWhenChangingForwardedPrefixHeader() throws Exception {
 		var tasks = IntStream.range(0, 10).mapToObj(i -> CompletableFuture.runAsync(() -> {
 			try {
-				webTestClient.get().uri("/webjars/swagger-ui/swagger-initializer.js")
+                webTestClient.get().uri("/swagger-ui/swagger-initializer.js")
 						.header("X-Forwarded-Prefix", "/path/prefix" + i)
 						.exchange()
 						.expectStatus().isOk()

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathTest.java
@@ -19,11 +19,10 @@
 package test.org.springdoc.ui.app32;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -43,13 +42,13 @@ public class SpringDocBehindProxyWithCustomUIPathTest extends AbstractSpringDocT
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isFound()
-				.expectHeader().location("/path/prefix/foo/documentation/webjars/swagger-ui/index.html");
+                .expectHeader().location("/path/prefix/foo/documentation/swagger-ui/index.html");
 	}
 
 	@Test
 	void shouldReturnCorrectInitializerJS() {
 		webTestClient
-				.get().uri("/foo/documentation/webjars/swagger-ui/swagger-initializer.js")
+                .get().uri("/foo/documentation/swagger-ui/swagger-initializer.js")
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isOk()

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app32/SpringDocBehindProxyWithCustomUIPathWithApiDocsTest.java
@@ -19,11 +19,10 @@
 package test.org.springdoc.ui.app32;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,13 +43,13 @@ public class SpringDocBehindProxyWithCustomUIPathWithApiDocsTest extends Abstrac
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isFound()
-				.expectHeader().location("/path/prefix/foo/documentation/webjars/swagger-ui/index.html");
+				.expectHeader().location("/path/prefix/foo/documentation/swagger-ui/index.html");
 	}
 
 	@Test
 	void shouldReturnCorrectInitializerJS() {
 		webTestClient
-				.get().uri("/foo/documentation/webjars/swagger-ui/swagger-initializer.js")
+				.get().uri("/foo/documentation/swagger-ui/swagger-initializer.js")
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchange()
 				.expectStatus().isOk()

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app33/SpringDocBehindProxyBasePathTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app33/SpringDocBehindProxyBasePathTest.java
@@ -20,9 +20,6 @@ package test.org.springdoc.ui.app33;
 
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-import test.org.springdoc.ui.AbstractCommonTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
@@ -31,6 +28,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import test.org.springdoc.ui.AbstractCommonTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
@@ -41,8 +40,7 @@ import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 				"server.forward-headers-strategy=framework",
 				"server.port=9318",
 				"springdoc.swagger-ui.path=/documentation/swagger-ui.html",
-				"springdoc.api-docs.path=/documentation/v3/api-docs",
-				"springdoc.webjars.prefix= /webjars-pref" })
+				"springdoc.api-docs.path=/documentation/v3/api-docs"})
 
 @Import(SpringDocConfig.class)
 public class SpringDocBehindProxyBasePathTest extends AbstractCommonTest {
@@ -68,7 +66,7 @@ public class SpringDocBehindProxyBasePathTest extends AbstractCommonTest {
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.FOUND);
 
-		httpStatusMono = webClient.get().uri(WEBFLUX_BASE_PATH+"/documentation/webjars-pref/swagger-ui/index.html")
+		httpStatusMono = webClient.get().uri(WEBFLUX_BASE_PATH + "/documentation/swagger-ui/index.html")
 				.header("X-Forwarded-Prefix", X_FORWARD_PREFIX)
 				.exchangeToMono(clientResponse -> Mono.just(clientResponse.statusCode())).block();
 		assertThat(httpStatusMono).isEqualTo(HttpStatus.OK);

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthPathsTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthPathsTest.java
@@ -19,9 +19,8 @@
 package test.org.springdoc.ui.app4;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 public class SpringDocOauthPathsTest extends AbstractSpringDocTest {
 
@@ -29,7 +28,7 @@ public class SpringDocOauthPathsTest extends AbstractSpringDocTest {
 	void oauth2_redirect_url_calculated() throws Exception {
 		webTestClient.get().uri("/v3/api-docs/swagger-config").exchange()
 				.expectStatus().isOk().expectBody()
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("/swagger-ui/oauth2-redirect.html");
 	}
 
 	@SpringBootApplication

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthRedirectUrlRecalculateTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthRedirectUrlRecalculateTest.java
@@ -19,10 +19,9 @@
 package test.org.springdoc.ui.app4;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = { "server.forward-headers-strategy=framework" })
 public class SpringDocOauthRedirectUrlRecalculateTest extends AbstractSpringDocTest {
@@ -36,7 +35,7 @@ public class SpringDocOauthRedirectUrlRecalculateTest extends AbstractSpringDocT
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody()
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("https://host1/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("https://host1/swagger-ui/oauth2-redirect.html");
 
 
 		webTestClient.get().uri("/v3/api-docs/swagger-config")
@@ -45,7 +44,7 @@ public class SpringDocOauthRedirectUrlRecalculateTest extends AbstractSpringDocT
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody()
-				.jsonPath("$.oauth2RedirectUrl").isEqualTo("http://host2:8080/webjars/swagger-ui/oauth2-redirect.html");
+                .jsonPath("$.oauth2RedirectUrl").isEqualTo("http://host2:8080/swagger-ui/oauth2-redirect.html");
 
 	}
 

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthServletPathsTest.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app4/SpringDocOauthServletPathsTest.java
@@ -19,10 +19,9 @@
 package test.org.springdoc.ui.app4;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.path=/test/swagger.html"
@@ -30,13 +29,13 @@ import org.springframework.test.context.TestPropertySource;
 public class SpringDocOauthServletPathsTest extends AbstractSpringDocTest {
 
 	@Test
-	void should_display_oauth2_redirect_page() throws Exception {
-		webTestClient.get().uri("/test/webjars/swagger-ui/oauth2-redirect.html").exchange()
+	void should_display_oauth2_redirect_page() {
+		webTestClient.get().uri("/test/swagger-ui/oauth2-redirect.html").exchange()
 				.expectStatus().isOk();
 	}
 
 	@Test
-	void oauth2_redirect_url_calculated_with_context_path_and_servlet_path() throws Exception {
+	void oauth2_redirect_url_calculated_with_context_path_and_servlet_path() {
 		webTestClient.get().uri("/v3/api-docs/swagger-config").exchange()
 				.expectStatus().isOk();
 	}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app6/SpringDocApp6Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app6/SpringDocApp6Test.java
@@ -25,18 +25,17 @@ package test.org.springdoc.ui.app6;
 
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.utils.Constants;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = { "springdoc.swagger-ui.oauth.clientId=myClientId", "springdoc.swagger-ui.disable-swagger-default-url=true" })
 public class SpringDocApp6Test extends AbstractSpringDocTest {
 
 	@Test
 	void transformed_index_with_oauth() throws Exception {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/webjars" + Constants.SWAGGER_INITIALIZER_URL)
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri(Constants.SWAGGER_INITIALIZER_URL)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app7/SpringDocApp7Test.java
@@ -25,18 +25,17 @@ package test.org.springdoc.ui.app7;
 
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.utils.Constants;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 @TestPropertySource(properties = "springdoc.swagger-ui.disable-swagger-default-url=true")
 public class SpringDocApp7Test extends AbstractSpringDocTest {
 
 	@Test
 	void transformed_index_with_oauth() throws Exception {
-		EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/webjars" + Constants.SWAGGER_INITIALIZER_URL)
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri(Constants.SWAGGER_INITIALIZER_URL)
 				.exchange()
 				.expectStatus().isOk()
 				.expectBody().returnResult();

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app13-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app13-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/application/swagger-ui/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9292/application/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9292/application/swagger-ui/oauth2-redirect.html",
   "url": "/application/openapi",
   "validatorUrl": ""
 }

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app14-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app14-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/application/swagger-ui/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9293/application/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9293/application/swagger-ui/oauth2-redirect.html",
   "urls": [
     {
       "url": "/application/openapi/users",

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app15-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app15-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/test/application/swagger-ui/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9294/test/application/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9294/test/application/swagger-ui/oauth2-redirect.html",
   "url": "/test/application/openapi",
   "validatorUrl": ""
 }

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app16-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app16-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/test/application/swagger-ui/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9295/test/application/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9295/test/application/swagger-ui/oauth2-redirect.html",
   "urls": [
     {
       "url": "/test/application/openapi/users",

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app18-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app18-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/test/documentation/v3/api-docs/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9218/test/documentation/webjars-pref/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9218/test/documentation/swagger-ui/oauth2-redirect.html",
   "urls": [
     {
       "url": "/test/documentation/v3/api-docs/users",

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app19-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app19-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/v3/api-docs/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9219/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9219/swagger-ui/oauth2-redirect.html",
   "urls": [
     {
       "url": "/v3/api-docs/users",

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app20-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app20-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/test/v3/api-docs/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9220/webjars/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9220/swagger-ui/oauth2-redirect.html",
   "url": "/test/v3/api-docs",
   "validatorUrl": ""
 }

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app32-1.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app32-1.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/path/prefix/documentation/v3/api-docs/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9318/path/prefix/documentation/webjars-pref/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9318/path/prefix/documentation/swagger-ui/oauth2-redirect.html",
   "url": "/path/prefix/documentation/v3/api-docs",
   "validatorUrl": ""
 }

--- a/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app33.json
+++ b/springdoc-openapi-starter-webflux-ui/src/test/resources/results/app33.json
@@ -1,6 +1,6 @@
 {
   "configUrl": "/path/prefix/test/documentation/v3/api-docs/swagger-config",
-  "oauth2RedirectUrl": "http://localhost:9318/path/prefix/test/documentation/webjars-pref/swagger-ui/oauth2-redirect.html",
+  "oauth2RedirectUrl": "http://localhost:9318/path/prefix/test/documentation/swagger-ui/oauth2-redirect.html",
   "url": "/path/prefix/test/documentation/v3/api-docs",
   "validatorUrl": ""
 }

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/SpringWebMvcProvider.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/providers/SpringWebMvcProvider.java
@@ -25,17 +25,10 @@
  */
 package org.springdoc.webmvc.core.providers;
 
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
-
+import org.springdoc.core.utils.Constants;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.AbstractHandlerMethodMapping;
@@ -43,6 +36,13 @@ import org.springframework.web.servlet.mvc.condition.PathPatternsRequestConditio
 import org.springframework.web.servlet.mvc.condition.PatternsRequestCondition;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * The type Spring web mvc provider.
@@ -65,8 +65,8 @@ public class SpringWebMvcProvider extends SpringWebProvider {
 			Set<String> patterns = getActivePatterns(requestMappingInfo);
 			if (!CollectionUtils.isEmpty(patterns)) {
 				for (String operationPath : patterns) {
-					if (operationPath.endsWith(springDocConfigProperties.getApiDocs().getPath()))
-						return operationPath.replace(springDocConfigProperties.getApiDocs().getPath(), StringUtils.EMPTY);
+					if (operationPath.endsWith(Constants.DEFAULT_API_DOCS_URL))
+						return operationPath.replace(Constants.DEFAULT_API_DOCS_URL, StringUtils.EMPTY);
 				}
 			}
 		}

--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
@@ -26,8 +26,6 @@
 
 package org.springdoc.webmvc.ui;
 
-import java.util.Optional;
-
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
@@ -36,7 +34,6 @@ import org.springdoc.core.providers.ActuatorProvider;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.providers.SpringWebProvider;
 import org.springdoc.webmvc.core.providers.SpringWebMvcProvider;
-
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
@@ -50,6 +47,8 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplicat
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+
+import java.util.Optional;
 
 import static org.springdoc.core.utils.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
 import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_MANAGEMENT_PORT;
@@ -153,8 +152,9 @@ public class SwaggerConfig {
 	@ConditionalOnMissingBean
 	@Lazy(false)
 	SwaggerWebMvcConfigurer swaggerWebMvcConfigurer(SwaggerUiConfigProperties swaggerUiConfigProperties,
-			SwaggerIndexTransformer swaggerIndexTransformer, Optional<ActuatorProvider> actuatorProvider, SwaggerResourceResolver swaggerResourceResolver) {
-		return new SwaggerWebMvcConfigurer(swaggerUiConfigProperties, swaggerIndexTransformer, actuatorProvider, swaggerResourceResolver);
+													SpringDocConfigProperties springDocConfigProperties, SwaggerIndexTransformer swaggerIndexTransformer,
+													Optional<ActuatorProvider> actuatorProvider, SwaggerResourceResolver swaggerResourceResolver) {
+		return new SwaggerWebMvcConfigurer(swaggerUiConfigProperties, springDocConfigProperties, swaggerIndexTransformer, actuatorProvider, swaggerResourceResolver);
 	}
 
 	/**

--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
@@ -26,12 +26,9 @@
 
 package org.springdoc.webmvc.ui;
 
-import java.util.List;
-import java.util.Optional;
-
+import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.core.providers.ActuatorProvider;
-
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.lang.Nullable;
@@ -51,9 +48,11 @@ import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.ViewResolverRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+import java.util.Optional;
+
+import static org.springdoc.core.utils.Constants.ALL_PATTERN;
 import static org.springdoc.core.utils.Constants.CLASSPATH_RESOURCE_LOCATION;
-import static org.springdoc.core.utils.Constants.DEFAULT_WEB_JARS_PREFIX_URL;
-import static org.springdoc.core.utils.Constants.SWAGGER_INITIALIZER_JS;
 import static org.springdoc.core.utils.Constants.SWAGGER_UI_PREFIX;
 import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
 
@@ -85,20 +84,28 @@ public class SwaggerWebMvcConfigurer implements WebMvcConfigurer {
 	private final SwaggerResourceResolver swaggerResourceResolver;
 
 	/**
+	 * The Spring doc config properties.
+	 */
+	private final SpringDocConfigProperties springDocConfigProperties;
+
+	/**
 	 * Instantiates a new Swagger web mvc configurer.
 	 *
 	 * @param swaggerUiConfigProperties the swagger ui calculated config
+	 * @param springDocConfigProperties
 	 * @param swaggerIndexTransformer   the swagger index transformer
 	 * @param actuatorProvider          the actuator provider
 	 * @param swaggerResourceResolver   the swagger resource resolver
 	 */
 	public SwaggerWebMvcConfigurer(SwaggerUiConfigProperties swaggerUiConfigProperties,
+								   SpringDocConfigProperties springDocConfigProperties,
 			SwaggerIndexTransformer swaggerIndexTransformer,
 			Optional<ActuatorProvider> actuatorProvider, SwaggerResourceResolver swaggerResourceResolver) {
 		this.swaggerIndexTransformer = swaggerIndexTransformer;
 		this.actuatorProvider = actuatorProvider;
 		this.swaggerResourceResolver = swaggerResourceResolver;
 		this.swaggerUiConfigProperties = swaggerUiConfigProperties;
+		this.springDocConfigProperties = springDocConfigProperties;
 	}
 
 	@Override
@@ -110,15 +117,9 @@ public class SwaggerWebMvcConfigurer implements WebMvcConfigurer {
 		if (actuatorProvider.isPresent() && actuatorProvider.get().isUseManagementPort())
 			uiRootPath.append(actuatorProvider.get().getBasePath());
 
-		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + "*/*" + SWAGGER_INITIALIZER_JS)
-				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR)
+		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + ALL_PATTERN)
+				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + springDocConfigProperties.getWebjars().getPrefix() + DEFAULT_PATH_SEPARATOR)
 				.setCachePeriod(0)
-				.resourceChain(false)
-				.addResolver(swaggerResourceResolver)
-				.addTransformer(swaggerIndexTransformer);
-
-		registry.addResourceHandler(uiRootPath + SWAGGER_UI_PREFIX + "*/**")
-				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR)
 				.resourceChain(false)
 				.addResolver(swaggerResourceResolver)
 				.addTransformer(swaggerIndexTransformer);

--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeWebMvc.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWelcomeWebMvc.java
@@ -33,7 +33,6 @@ import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.core.providers.SpringWebProvider;
 import org.springdoc.core.utils.SpringDocUtils;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -107,7 +106,11 @@ public class SwaggerWelcomeWebMvc extends SwaggerWelcomeCommon {
 	protected String buildUrlWithContextPath(SwaggerUiConfigParameters swaggerUiConfigParameters, String swaggerUiUrl) {
 		if (swaggerUiConfigParameters.getPathPrefix() == null)
 			swaggerUiConfigParameters.setPathPrefix(springWebProvider.findPathPrefix(springDocConfigProperties));
-		return buildUrl(swaggerUiConfigParameters.getContextPath() + swaggerUiConfigParameters.getPathPrefix(), swaggerUiUrl);
+		if (swaggerUiUrl.startsWith(swaggerUiConfigParameters.getPathPrefix())) {
+			return buildUrl(swaggerUiConfigParameters.getContextPath(), swaggerUiUrl);
+		} else {
+			return buildUrl(swaggerUiConfigParameters.getContextPath() + swaggerUiConfigParameters.getPathPrefix(), swaggerUiUrl);
+		}
 	}
 	
 	@Override

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocAppRedirectWithPrefixTest.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app1/SpringDocAppRedirectWithPrefixTest.java
@@ -21,10 +21,9 @@ package test.org.springdoc.ui.app1;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.springdoc.core.utils.Constants;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.test.context.TestPropertySource;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,8 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @TestPropertySource(properties = {
 		"springdoc.swagger-ui.path=/documentation/swagger-ui.html",
-		"springdoc.api-docs.path=/documentation/v3/api-docs",
-		"springdoc.webjars.prefix= /webjars-pref"
+		"springdoc.api-docs.path=/documentation/v3/api-docs"
 })
 public class SpringDocAppRedirectWithPrefixTest extends AbstractSpringDocTest {
 

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app21/SpringDocApp21Test.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app21/SpringDocApp21Test.java
@@ -19,9 +19,8 @@
 package test.org.springdoc.ui.app21;
 
 import org.junit.jupiter.api.Test;
-import test.org.springdoc.ui.AbstractSpringDocTest;
-
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.ui.AbstractSpringDocTest;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;


### PR DESCRIPTION
This pull request modifies the Swagger-UI prefix path behavior in the springdoc-openapi-starter-webflux-ui module to align it with the behavior of springdoc-openapi-starter-webmvc-ui. With this update, the Swagger-UI will be accessible at /swagger-ui/index.html instead of /webjars/swagger-ui/index.html.
Key Changes:

1. Updated Resource Handler Path:

    Changed the resource handler registration to use the SWAGGER_UI_PREFIX constant, ensuring that Swagger-UI assets are now served from /swagger-ui/ instead of /webjars/swagger-ui/.

2. Removed Unused Dependencies:

    Eliminated the SpringDocConfigProperties parameter from the SwaggerWebFluxConfigurer constructor and related references, simplifying the configuration.

3. Unified Behavior:

    Standardized the path prefix behavior to match that of springdoc-openapi-starter-webmvc-ui, making the behavior consistent across different SpringDoc modules.

4. Code Cleanup:

    Refactored imports, removed unused parameters, and improved formatting for clarity and maintainability.