### PR TITLE
Improve performance of getGenericMapResponse

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
@@ -145,14 +145,14 @@ public class GenericResponseService implements ApplicationContextAware {
 	private final Lock reentrantLock = new ReentrantLock();
 
 	/**
-	 * The Context.
-	 */
-	private ApplicationContext applicationContext;
-
-	/**
 	 * The constant LOGGER.
 	 */
 	private static final Logger LOGGER = LoggerFactory.getLogger(GenericResponseService.class);
+
+	/**
+	 * A list of all beans annotated with {@code @ControllerAdvice}
+	 */
+	private List<ControllerAdviceBean> controllerAdviceBeans;
 
 	/**
 	 * Instantiates a new Generic response builder.
@@ -702,8 +702,6 @@ public class GenericResponseService implements ApplicationContextAware {
 					.map(ControllerAdviceInfo::getApiResponseMap)
 					.collect(LinkedHashMap::new, Map::putAll, Map::putAll);
 
-			List<ControllerAdviceBean> controllerAdviceBeans = ControllerAdviceBean.findAnnotatedBeans(applicationContext);
-			
 			List<ControllerAdviceInfo> controllerAdviceInfosNotInThisBean = controllerAdviceInfos.stream()
 					.filter(controllerAdviceInfo -> 
 							getControllerAdviceBean(controllerAdviceBeans, controllerAdviceInfo.getControllerAdvice())
@@ -834,6 +832,6 @@ public class GenericResponseService implements ApplicationContextAware {
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		this.applicationContext = applicationContext;
+		controllerAdviceBeans = ControllerAdviceBean.findAnnotatedBeans(applicationContext);
 	}
 }


### PR DESCRIPTION
I migrate a bigger project from Springfox to Springdoc 1.8.0 (as a temporary step) and to Springdoc 2.8.3.
With Springfox the performance to generate the API definition was pretty good with approximately 5 seconds. After migrating to Springdoc 1.8.0 this increased to 20 seconds. Since the calculation happens only once this was still ok.

But with the update to Springdoc 2.8.3 it increased considerably. Now it takes **120 seconds** to generate the same API definition.

I did some profiling and found this easy fix to help improve performance a little. With this fix I'm now down to 83 seconds. This is still too high and I'll try to find further improvements.

Here is a screenshot of the CPU time analysis in JProfiler. As you can see, the call to `ControllerAdviceBean.findAnnotatedBeans(applicationContext)` is quite expensive in total.

![image](https://github.com/user-attachments/assets/f550620f-32b8-4cac-8a9c-9229dd9067ef)
