### PR TITLE
fix defaultValue when using @PageableDefault together with one-indexed-parameters

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
@@ -64,6 +64,9 @@ import org.springframework.data.web.SortDefault;
 
 /**
  * The type Data rest delegating method parameter customizer.
+ *
+ *  @author bnasslahsen
+ *  @author pheyken
  */
 public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMethodParameterCustomizer {
 
@@ -1131,8 +1134,13 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 					defaultValue = defaultSchemaVal;
 				break;
 			case "page":
-				if (pageableDefault != null)
-					defaultValue = String.valueOf(pageableDefault.page());
+				if (pageableDefault != null) {
+					if (isSpringDataWebPropertiesPresent() && optionalSpringDataWebPropertiesProvider.get().getSpringDataWebProperties().getPageable().isOneIndexedParameters()) {
+						defaultValue = String.valueOf(pageableDefault.page() + 1);
+					} else {
+						defaultValue = String.valueOf(pageableDefault.page());
+					}
+				}
 				else if (isSpringDataWebPropertiesPresent() && optionalSpringDataWebPropertiesProvider.get().getSpringDataWebProperties().getPageable().isOneIndexedParameters())
 					defaultValue = "1";
 				else

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/java/test/org/springdoc/api/v31/app14/HelloController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/java/test/org/springdoc/api/v31/app14/HelloController.java
@@ -21,7 +21,7 @@
  *  *  *  *
  *  *  *
  *  *
- *  
+ *
  */
 
 package test.org.springdoc.api.v31.app14;
@@ -31,6 +31,8 @@ import java.util.List;
 import org.springdoc.core.annotations.ParameterObject;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -41,6 +43,13 @@ public class HelloController {
 	@GetMapping(value = "/search", produces = { "application/xml", "application/json" })
 	public ResponseEntity<List<PersonDTO>> getAllPets(@ParameterObject Pageable pageable) {
 		return null;
+	}
+
+	@GetMapping("/test1")
+	public String getPatientList1(@PageableDefault(size = 100, sort = { "someField", "someoTHER" },
+		direction = Sort.Direction.DESC)
+								  @ParameterObject Pageable pageable) {
+		return "bla";
 	}
 
 }

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app14.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app14.json
@@ -11,6 +11,66 @@
     }
   ],
   "paths": {
+    "/test1": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "getPatientList1",
+        "parameters": [
+          {
+            "name": "prefix_pages",
+            "in": "query",
+            "description": "One-based page index (1..N)",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "minimum": 0
+            }
+          },
+          {
+            "name": "prefix_sizes",
+            "in": "query",
+            "description": "The size of the page to be returned",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "sorts",
+            "in": "query",
+            "description": "Sorting criteria in the format: property,(asc|desc). Default sort order is ascending. Multiple sort criteria are supported.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "default": [
+                "someField,DESC",
+                "someoTHER,DESC"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/search": {
       "get": {
         "tags": [


### PR DESCRIPTION
Hi,

we noticed that the default value for the page was 0 when having a spring-boot application with `spring.data.web.pageable.one-indexed-parameters=true` as well as using a `@PageableDefault` on the controller.

The `@PageableDefault` annotation has 0 as the default value for the page (see [here](https://github.com/spring-projects/spring-data-commons/blob/f86ee7f97f800b34487322a36baa165fc3a4a739/src/main/java/org/springframework/data/web/PageableDefault.java#L62)). This is the desired behavior (as far as I can tell) as spring normalizes the pageable before injecting it into the controller method. This is done in [this](https://github.com/spring-projects/spring-data-commons/blob/f86ee7f97f800b34487322a36baa165fc3a4a739/src/main/java/org/springframework/data/web/PageableHandlerMethodArgumentResolverSupport.java#L284) method.

So, e.g., if the newly added test controller was to be called with the following query parameters
```
/test1?prefix_pages=1
```

the injected pageable in the controller would return 0 for getPageNumber()
```
@GetMapping("/test1")
public String getPatientList1(
    @PageableDefault(size = 100, sort = { "someField", "someoTHER" }, direction = Sort.Direction.DESC) 
    @ParameterObject 
    Pageable pageable
) {
        System.out.println(pageable.getPageNumber()) // prints 0
	return "bla";
}
```

Let me know if you prefer to have a separate TestApp for this, happy to adjust this.