### PR TITLE
fix: respect `@JsonUnwrapped` & `@Schema` on props not fields only

### DIFF
--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/RootModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/RootModel.java
@@ -1,4 +1,4 @@
-package test.org.springdoc.api.v31.app224;
+package test.org.springdoc.api.v30.app239;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/SpringDocApp239Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/SpringDocApp239Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2024 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app239;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+public class SpringDocApp239Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/TestController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/TestController.java
@@ -1,0 +1,15 @@
+package test.org.springdoc.api.v30.app239;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+    @GetMapping
+    public RootModel getRootModel() {
+        return new RootModel();
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/UnwrappedModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app239/UnwrappedModel.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v30.app239;
+
+public class UnwrappedModel {
+
+    private Integer unwrappedProperty;
+
+    public Integer getUnwrappedProperty() {
+        return unwrappedProperty;
+    }
+
+    public void setUnwrappedProperty(Integer unwrappedProperty) {
+        this.unwrappedProperty = unwrappedProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/RootModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/RootModel.java
@@ -1,4 +1,4 @@
-package test.org.springdoc.api.v31.app224;
+package test.org.springdoc.api.v31.app239;
 
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
@@ -6,6 +6,7 @@ public class RootModel {
 
     private Integer rootProperty;
 
+    @JsonUnwrapped
     private UnwrappedModel unwrappedModel;
 
     public Integer getRootProperty() {
@@ -16,7 +17,6 @@ public class RootModel {
         this.rootProperty = rootProperty;
     }
 
-    @JsonUnwrapped
     public UnwrappedModel getUnwrappedModel() {
         return unwrappedModel;
     }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/SpringDocApp239Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/SpringDocApp239Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2024 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app239;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v31.AbstractSpringDocTest;
+
+public class SpringDocApp239Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/TestController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/TestController.java
@@ -1,0 +1,15 @@
+package test.org.springdoc.api.v31.app239;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+    @GetMapping
+    public RootModel getRootModel() {
+        return new RootModel();
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/UnwrappedModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app239/UnwrappedModel.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v31.app239;
+
+public class UnwrappedModel {
+
+    private Integer unwrappedProperty;
+
+    public Integer getUnwrappedProperty() {
+        return unwrappedProperty;
+    }
+
+    public void setUnwrappedProperty(Integer unwrappedProperty) {
+        this.unwrappedProperty = unwrappedProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app239.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app239.json
@@ -1,0 +1,52 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "test-controller"
+        ],
+        "operationId": "getRootModel",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RootModel": {
+        "type": "object",
+        "properties": {
+          "rootProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedProperty": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app239.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app239.json
@@ -1,0 +1,52 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "test-controller"
+        ],
+        "operationId": "getRootModel",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RootModel": {
+        "type": "object",
+        "properties": {
+          "rootProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedProperty": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Rather than introspecting only fields for `@JsonUnwrapped` and `@Schema`, this PR switches to analyzing class _properties_ using Jackson's introspection API.

This fixes a regression introduced (supposedly) in v2.6.0, affecting codebases where `@JsonUnwrapped` is placed on getters instead of fields - a valid location per annotation's target and respected by Jackson. This change eliminates disparities between how Springdoc displays DTOs and how Jackson interprets them.

The test and expected JSON are copied from app224, with the only modification being the relocation of `@JsonUnwrapped` to the getter.

Fixes #2879