### PR TITLE
Only filter out actuator endpoints with double asterisks. Fixes #2895

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -661,8 +661,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			}
 			
 			PathItem pathItemObject = buildPathItem(requestMethod, operation, operationPath, paths);
-			if (!StringUtils.contains(operationPath, "**"))
-				paths.addPathItem(operationPath, pathItemObject);
+			paths.addPathItem(operationPath, pathItemObject);
 		}
 	}
 

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/api/OpenApiResource.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/api/OpenApiResource.java
@@ -167,6 +167,11 @@ public abstract class OpenApiResource extends AbstractOpenApiResource {
 			Optional<ActuatorProvider> actuatorProviderOptional = springDocProviders.getActuatorProvider();
 			if (actuatorProviderOptional.isPresent() && springDocConfigProperties.isShowActuator()) {
 				Map<RequestMappingInfo, HandlerMethod> actuatorMap = actuatorProviderOptional.get().getMethods();
+				List<RequestMappingInfo> globMatchActuators = actuatorMap.keySet().stream()
+					.filter(requestMappingInfo -> requestMappingInfo.getPatternValues().stream()
+						.anyMatch(patternValues -> patternValues.contains("**")))
+					.toList();
+				globMatchActuators.forEach(actuatorMap::remove);
 				this.openAPIService.addTag(new HashSet<>(actuatorMap.values()), getTag());
 				map.putAll(actuatorMap);
 			}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app240/SpringDocApp240Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app240/SpringDocApp240Test.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  * Copyright 2019-2025 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *	  https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.v31.app240;
+
+import test.org.springdoc.api.v31.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+public class SpringDocApp240Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {
+
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app240/WildcardController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app240/WildcardController.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Copyright 2019-2025 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *	  https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.api.v31.app240;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class WildcardController {
+	@PostMapping("/**")
+	@Operation(summary = "My Wildcard Operation")
+	public String getItem(HttpServletRequest request) {
+		return request.getPathInfo();
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app240.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app240.json
@@ -1,0 +1,37 @@
+{
+	"openapi": "3.1.0",
+	"info": {
+		"title": "OpenAPI definition",
+		"version": "v0"
+	},
+	"servers": [
+		{
+			"url": "http://localhost",
+			"description": "Generated server url"
+		}
+	],
+	"paths": {
+		"/**": {
+			"post": {
+				"tags": [
+					"wildcard-controller"
+				],
+				"summary": "My Wildcard Operation",
+				"operationId": "getItem",
+				"responses": {
+					"200": {
+						"description": "OK",
+						"content": {
+							"*/*": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	},
+	"components": {}
+}


### PR DESCRIPTION
All endpoints that contain a double-asterisks in the path are currently being excluded from the output Swagger definition, rather than just excluding match-all actuator endpoints. The endpoint matching is therefore being altered to pre-filter the actuator endpoints to remove any that contain a double-asterisks in the path, and remove the subsequent filtering of double asterisks in the combined endpoints list so that non-actuator endpoints aren't dropped by the actuator filtering.