### PR TITLE
Check both SerDe `BeanPropertyDefinition` for `@JsonUnwrapped`/`@Schema`

### DIFF
--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/RootModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/RootModel.java
@@ -1,0 +1,41 @@
+package test.org.springdoc.api.v30.app242;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public class RootModel {
+
+    private Integer rootProperty;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonUnwrapped
+    private UnwrappedModelOne unwrappedModelOne;
+
+    private UnwrappedModelTwo unwrappedModelTwo;
+
+    public Integer getRootProperty() {
+        return rootProperty;
+    }
+
+    public void setRootProperty(Integer rootProperty) {
+        this.rootProperty = rootProperty;
+    }
+
+    public UnwrappedModelOne getUnwrappedModelOne() {
+        return unwrappedModelOne;
+    }
+
+    public void setUnwrappedModelOne(UnwrappedModelOne unwrappedModelOne) {
+        this.unwrappedModelOne = unwrappedModelOne;
+    }
+
+    public UnwrappedModelTwo getUnwrappedModelTwo() {
+        return unwrappedModelTwo;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonUnwrapped
+    public void setUnwrappedModelTwo(UnwrappedModelTwo unwrappedModelTwo) {
+        this.unwrappedModelTwo = unwrappedModelTwo;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/SpringDocApp242Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/SpringDocApp242Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2024 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app242;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+public class SpringDocApp242Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/TestController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/TestController.java
@@ -1,0 +1,15 @@
+package test.org.springdoc.api.v30.app242;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+    @GetMapping
+    public RootModel getRootModel() {
+        return new RootModel();
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/UnwrappedModelOne.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/UnwrappedModelOne.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v30.app242;
+
+public class UnwrappedModelOne {
+
+    private Integer unwrappedOneProperty;
+
+    public Integer getUnwrappedOneProperty() {
+        return unwrappedOneProperty;
+    }
+
+    public void setUnwrappedOneProperty(Integer unwrappedOneProperty) {
+        this.unwrappedOneProperty = unwrappedOneProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/UnwrappedModelTwo.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app242/UnwrappedModelTwo.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v30.app242;
+
+public class UnwrappedModelTwo {
+
+    private Integer unwrappedTwoProperty;
+
+    public Integer getUnwrappedTwoProperty() {
+        return unwrappedTwoProperty;
+    }
+
+    public void setUnwrappedTwoProperty(Integer unwrappedTwoProperty) {
+        this.unwrappedTwoProperty = unwrappedTwoProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/RootModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/RootModel.java
@@ -1,0 +1,41 @@
+package test.org.springdoc.api.v31.app242;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+public class RootModel {
+
+    private Integer rootProperty;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+    @JsonUnwrapped
+    private UnwrappedModelOne unwrappedModelOne;
+
+    private UnwrappedModelTwo unwrappedModelTwo;
+
+    public Integer getRootProperty() {
+        return rootProperty;
+    }
+
+    public void setRootProperty(Integer rootProperty) {
+        this.rootProperty = rootProperty;
+    }
+
+    public UnwrappedModelOne getUnwrappedModelOne() {
+        return unwrappedModelOne;
+    }
+
+    public void setUnwrappedModelOne(UnwrappedModelOne unwrappedModelOne) {
+        this.unwrappedModelOne = unwrappedModelOne;
+    }
+
+    public UnwrappedModelTwo getUnwrappedModelTwo() {
+        return unwrappedModelTwo;
+    }
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    @JsonUnwrapped
+    public void setUnwrappedModelTwo(UnwrappedModelTwo unwrappedModelTwo) {
+        this.unwrappedModelTwo = unwrappedModelTwo;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/SpringDocApp242Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/SpringDocApp242Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2024 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app242;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+public class SpringDocApp242Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/TestController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/TestController.java
@@ -1,0 +1,15 @@
+package test.org.springdoc.api.v31.app242;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class TestController {
+
+    @GetMapping
+    public RootModel getRootModel() {
+        return new RootModel();
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/UnwrappedModelOne.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/UnwrappedModelOne.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v31.app242;
+
+public class UnwrappedModelOne {
+
+    private Integer unwrappedOneProperty;
+
+    public Integer getUnwrappedOneProperty() {
+        return unwrappedOneProperty;
+    }
+
+    public void setUnwrappedOneProperty(Integer unwrappedOneProperty) {
+        this.unwrappedOneProperty = unwrappedOneProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/UnwrappedModelTwo.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app242/UnwrappedModelTwo.java
@@ -1,0 +1,14 @@
+package test.org.springdoc.api.v31.app242;
+
+public class UnwrappedModelTwo {
+
+    private Integer unwrappedTwoProperty;
+
+    public Integer getUnwrappedTwoProperty() {
+        return unwrappedTwoProperty;
+    }
+
+    public void setUnwrappedTwoProperty(Integer unwrappedTwoProperty) {
+        this.unwrappedTwoProperty = unwrappedTwoProperty;
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app242.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app242.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "test-controller"
+        ],
+        "operationId": "getRootModel",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RootModel": {
+        "type": "object",
+        "properties": {
+          "rootProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedOneProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedTwoProperty": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app242.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app242.json
@@ -1,0 +1,56 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "test-controller"
+        ],
+        "operationId": "getRootModel",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RootModel": {
+        "type": "object",
+        "properties": {
+          "rootProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedOneProperty": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unwrappedTwoProperty": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
In https://github.com/springdoc/springdoc-openapi/pull/2894 we switched from just looking at the fields for `@JsonUnwrapped`/`@Schema` to relying on Jackson introspection. That however wrongly relied on deserialization view only, which lead to https://github.com/springdoc/springdoc-openapi/issues/2879#issuecomment-2666530132.

In this PR both Serialisation and Deserialization `BeanPropertyDefinition`s are introspected.

A test covers both readonly and writeonly fields annotated with `@JsonUnwrapped`.

Fixes https://github.com/springdoc/springdoc-openapi/issues/2879#issuecomment-2666530132