### PR TITLE
Add missing builder methods in SchemaBuilder

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/builders/schema/Builder.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/builders/schema/Builder.java
@@ -838,6 +838,50 @@ public class Builder {
 	}
 
 	/**
+	 * Dependent required map builder.
+	 *
+	 * @param dependentRequiredMap the dependent required map
+	 * @return the builder
+	 */
+	public Builder dependentRequiredMap(DependentRequired[] dependentRequiredMap) {
+		this.dependentRequiredMap = dependentRequiredMap;
+		return this;
+	}
+
+	/**
+	 * Dependent schemas builder.
+	 *
+	 * @param dependentSchemas the dependent schemas
+	 * @return the builder
+	 */
+	public Builder dependentSchemas(StringToClassMapItem[] dependentSchemas) {
+		this.dependentSchemas = dependentSchemas;
+		return this;
+	}
+
+	/**
+	 * Pattern properties builder.
+	 *
+	 * @param patternProperties the pattern properties
+	 * @return the builder
+	 */
+	public Builder patternProperties(StringToClassMapItem[] patternProperties) {
+		this.patternProperties = patternProperties;
+		return this;
+	}
+
+	/**
+	 * Properties builder.
+	 *
+	 * @param properties the properties
+	 * @return the builder
+	 */
+	public Builder properties(StringToClassMapItem[] properties) {
+		this.properties = properties;
+		return this;
+	}
+
+	/**
 	 * Additional properties builder.
 	 *
 	 * @param additionalProperties the additional properties


### PR DESCRIPTION
This PR adds missing builder methods for properties, patternProperties, dependentSchemas, and dependentRequiredMap in SchemaBuilder. 

> They were introduced in <https://github.com/springdoc/springdoc-openapi/commit/21659612d44d10d73fb08438be7ba830937ddcb4#diff-a0d88cfa7fc735585a392b2c387cca34b1ec04721d65db35512bdda3ed7f6015> but no builder methods added.