### PR TITLE
ISSUE-2969 fix path to register resource handler to work SwaggerIndexPageTransformer considering /webjar path prefix

### DIFF
--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
@@ -103,15 +103,23 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 			uiRootPath.append(actuatorProvider.get().getBasePath());
 
 		String webjarsPrefix = springDocConfigProperties.getWebjars().getPrefix();
-		String resourcePath,swaggerUiPrefix;
+		String resourcePath,swaggerUiPrefix,swaggerUiWebjarsPrefix;
 
 		if (DEFAULT_WEB_JARS_PREFIX_URL.equals(webjarsPrefix)) {
-			swaggerUiPrefix = webjarsPrefix + SWAGGER_UI_PREFIX;
-			resourcePath = webjarsPrefix + SWAGGER_UI_PREFIX + DEFAULT_PATH_SEPARATOR + swaggerUiConfigProperties.getVersion() + DEFAULT_PATH_SEPARATOR;
+			swaggerUiPrefix = SWAGGER_UI_PREFIX;
+            resourcePath = webjarsPrefix + SWAGGER_UI_PREFIX + DEFAULT_PATH_SEPARATOR + swaggerUiConfigProperties.getVersion() + DEFAULT_PATH_SEPARATOR;
+            swaggerUiWebjarsPrefix = webjarsPrefix + swaggerUiPrefix;
 		} else {
 			swaggerUiPrefix = webjarsPrefix;
 			resourcePath = DEFAULT_WEB_JARS_PREFIX_URL + DEFAULT_PATH_SEPARATOR;
+            swaggerUiWebjarsPrefix = swaggerUiPrefix;
 		}
+
+        registry.addResourceHandler(uiRootPath + swaggerUiWebjarsPrefix + ALL_PATTERN)
+                .addResourceLocations(CLASSPATH_RESOURCE_LOCATION + resourcePath)
+                .resourceChain(false)
+                .addResolver(swaggerResourceResolver)
+                .addTransformer(swaggerIndexTransformer);
 
 		registry.addResourceHandler(uiRootPath + swaggerUiPrefix + ALL_PATTERN)
 				.addResourceLocations(CLASSPATH_RESOURCE_LOCATION + resourcePath)

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
@@ -106,7 +106,7 @@ public class SwaggerWebFluxConfigurer implements WebFluxConfigurer {
 		String resourcePath,swaggerUiPrefix;
 
 		if (DEFAULT_WEB_JARS_PREFIX_URL.equals(webjarsPrefix)) {
-			swaggerUiPrefix = SWAGGER_UI_PREFIX;
+			swaggerUiPrefix = webjarsPrefix + SWAGGER_UI_PREFIX;
 			resourcePath = webjarsPrefix + SWAGGER_UI_PREFIX + DEFAULT_PATH_SEPARATOR + swaggerUiConfigProperties.getVersion() + DEFAULT_PATH_SEPARATOR;
 		} else {
 			swaggerUiPrefix = webjarsPrefix;

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app34/HelloController.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app34/HelloController.java
@@ -1,0 +1,40 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  * Copyright 2019-2020 the original author or authors.
+ *  *  *  *
+ *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  * You may obtain a copy of the License at
+ *  *  *  *
+ *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *
+ *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ *
+ */
+
+package test.org.springdoc.ui.app34;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+	@GetMapping(value = "/persons")
+	public void persons(@Valid @RequestParam @Size(min = 4, max = 6) String name) {
+
+	}
+
+}

--- a/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app34/SpringDocApp34Test.java
+++ b/springdoc-openapi-starter-webflux-ui/src/test/java/test/org/springdoc/ui/app34/SpringDocApp34Test.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  * Copyright 2019-2020 the original author or authors.
+ *  *  *  *
+ *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  * You may obtain a copy of the License at
+ *  *  *  *
+ *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *
+ *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  * limitations under the License.
+ *  *  *
+ *  *
+ *
+ *
+ */
+
+package test.org.springdoc.ui.app34;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.reactive.server.EntityExchangeResult;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestPropertySource(properties = "springdoc.swagger-ui.disable-swagger-default-url=true")
+public class SpringDocApp34Test extends AbstractSpringDocTest {
+
+	@Test
+	void transformed_index_with_oauth() throws Exception {
+        EntityExchangeResult<byte[]> getResult = webTestClient.get().uri("/webjars/swagger-ui/swagger-initializer.js")
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody().returnResult();
+
+        var responseContent = new String(getResult.getResponseBody());
+        assertFalse(responseContent.contains("https://petstore.swagger.io/v2/swagger.json"));
+        assertTrue(responseContent.contains("/v3/api-docs"));
+	}
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+
+}


### PR DESCRIPTION
fix path to register resource handler to work `SwaggerIndexPageTransformer` considering `/webjar` path prefix