### PR TITLE
Fixes for Spring Boot 3.5.0 API

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
@@ -86,7 +86,7 @@ public class HateoasHalProvider {
 				.orElse(true);
 	}
 
-	private boolean isHalEnabled(@NonNull HateoasProperties hateoasProperties) {
+	private static boolean isHalEnabled(@NonNull HateoasProperties hateoasProperties) {
 		// In spring-boot 3.5, the method name was changed from getUseHalAsDefaultJsonMediaType to isUseHalAsDefaultJsonMediaType
 		var possibleMethodNames = List.of("isUseHalAsDefaultJsonMediaType", "getUseHalAsDefaultJsonMediaType");
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
@@ -82,7 +82,7 @@ public class HateoasHalProvider {
 	 */
 	public boolean isHalEnabled() {
 		return hateoasPropertiesOptional
-				.map(this::isHalEnabled)
+				.map(HateoasHalProvider ::isHalEnabled)
 				.orElse(true);
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
@@ -82,7 +82,7 @@ public class HateoasHalProvider {
 	 */
 	public boolean isHalEnabled() {
 		return hateoasPropertiesOptional
-				.map(HateoasHalProvider ::isHalEnabled)
+				.map(HateoasHalProvider::isHalEnabled)
 				.orElse(true);
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/HateoasHalProvider.java
@@ -94,8 +94,8 @@ public class HateoasHalProvider {
 			var method = ReflectionUtils.findMethod(HateoasProperties.class, methodName);
 			if (method != null) {
 				var result = ReflectionUtils.invokeMethod(method, hateoasProperties);
-				if (result instanceof Boolean) {
-					return (boolean) result;
+				if (result instanceof Boolean halEnabled) {
+					return halEnabled;
 				}
 
 				throw new IllegalStateException("Method " + methodName + " did not return a boolean value");


### PR DESCRIPTION
Spring Boot renamed the property methods to determine if HAL is enabled or not.  Use reflection to determine which method to call so we can support both versions

Another alternative would have been to merely bump the minimum supported version of spring boot to 3.5.0 and just use the new methods directly.  Not sure what is preferred here.  This does get it to start under 3.5 and 3.4 however.

Fixes #3005