### PR TITLE
Fix unexpected merging of media types

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
@@ -270,7 +270,11 @@ public class MethodAttributes {
 		RequestMapping reqMappingClass = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), RequestMapping.class);
 
 		if (reqMappingMethod != null && reqMappingClass != null) {
-			fillMethods(ArrayUtils.addAll(reqMappingMethod.produces(), reqMappingClass.produces()), ArrayUtils.addAll(reqMappingMethod.consumes(), reqMappingClass.consumes()), reqMappingMethod.headers());
+			fillMethods(
+					calculateMethodMediaTypes(reqMappingMethod.produces(), reqMappingClass.produces()),
+					calculateMethodMediaTypes(reqMappingMethod.consumes(), reqMappingClass.consumes()),
+					reqMappingMethod.headers()
+			);
 		}
 		else if (reqMappingMethod != null) {
 			fillMethods(reqMappingMethod.produces(), reqMappingMethod.consumes(), reqMappingMethod.headers());
@@ -311,6 +315,21 @@ public class MethodAttributes {
 		}
 
 		setHeaders(headers);
+	}
+
+	/**
+     * If there is any method type(s) present, then these will override the class type(s).
+     * See <a href="https://docs.spring.io/spring-framework/reference/web/webmvc/mvc-controller/ann-requestmapping.html#mvc-ann-requestmapping-consumes">...</a> for details
+	 *
+     * @param methodTypes the method types
+     * @param classTypes the class types
+     * @return the string [ ] containing the types that can be used for the method
+     */
+	private String[] calculateMethodMediaTypes(@Nullable String[] methodTypes, String[] classTypes) {
+		if (ArrayUtils.isNotEmpty(methodTypes)) {
+			return methodTypes;
+		}
+		return classTypes;
 	}
 
 	/**
@@ -478,7 +497,7 @@ public class MethodAttributes {
 	public void calculateHeadersForClass(Class<?> declaringClass) {
 		RequestMapping reqMappingClass = AnnotatedElementUtils.findMergedAnnotation(declaringClass, RequestMapping.class);
 		if (reqMappingClass != null) {
-			fillMethods(reqMappingClass.produces(), reqMappingClass.consumes(), reqMappingClass.headers());
+			setHeaders(reqMappingClass.headers());
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/RequestBodyService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/RequestBodyService.java
@@ -113,7 +113,7 @@ public class RequestBodyService {
 		}
 
 		if (requestBody.required()) {
-			requestBodyObject.setRequired(requestBody.required());
+			requestBodyObject.setRequired(true);
 			isEmpty = false;
 		}
 		if (requestBody.extensions().length > 0) {
@@ -128,7 +128,7 @@ public class RequestBodyService {
 		if (isEmpty)
 			return Optional.empty();
 
-		buildResquestBodyContent(requestBody, requestBodyOp, methodAttributes, components, jsonViewAnnotation, classConsumes, methodConsumes, requestBodyObject);
+		buildRequestBodyContent(requestBody, requestBodyOp, methodAttributes, components, jsonViewAnnotation, classConsumes, methodConsumes, requestBodyObject);
 
 		return Optional.of(requestBodyObject);
 	}
@@ -145,7 +145,10 @@ public class RequestBodyService {
 	 * @param methodConsumes     the method consumes
 	 * @param requestBodyObject  the request body object
 	 */
-	private void buildResquestBodyContent(io.swagger.v3.oas.annotations.parameters.RequestBody requestBody, RequestBody requestBodyOp, MethodAttributes methodAttributes, Components components, JsonView jsonViewAnnotation, String[] classConsumes, String[] methodConsumes, RequestBody requestBodyObject) {
+	private void buildRequestBodyContent(io.swagger.v3.oas.annotations.parameters.RequestBody requestBody,
+										 RequestBody requestBodyOp, MethodAttributes methodAttributes,
+										 Components components, JsonView jsonViewAnnotation, String[] classConsumes,
+										 String[] methodConsumes, RequestBody requestBodyObject) {
 		Optional<Content> optionalContent = SpringDocAnnotationsUtils
 				.getContent(requestBody.content(), getConsumes(classConsumes),
 						getConsumes(methodConsumes), null, components, jsonViewAnnotation, parameterBuilder.isOpenapi31());

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/model/MethodAttributesTest.java
@@ -1,70 +1,228 @@
 package org.springdoc.core.model;
 
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springdoc.core.models.MethodAttributes;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
+
 import java.lang.reflect.Method;
 import java.util.Locale;
 
-import org.junit.jupiter.api.Test;
-import org.springdoc.core.models.MethodAttributes;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.mockito.BDDMockito.given;
 
 public class MethodAttributesTest {
 
-	@Test
-	public void testMergeArrays() throws Exception {
-		MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+    private static final String APPLICATION_JSON = "application/json";
+    private static final String APPLICATION_XML = "application/xml";
+    private static final String APPLICATION_YAML = "application/yaml";
 
-		String[] array1 = { "application/json", "application/xml" };
-		String[] array2 = { "application/xml", "application/yaml" };
+    @Test
+    void testMergeArrays() throws Exception {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
 
-		String[] expected = { "application/json", "application/xml", "application/yaml" };
+        String[] array1 = {APPLICATION_JSON, APPLICATION_XML};
+        String[] array2 = {APPLICATION_XML, APPLICATION_YAML};
 
-		Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
-		mergeArraysMethod.setAccessible(true);
-		String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
+        String[] expected = {APPLICATION_JSON, APPLICATION_XML, APPLICATION_YAML};
 
-		assertArrayEquals(expected, result);
-	}
+        Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
+        mergeArraysMethod.setAccessible(true);
+        String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
 
-	@Test
-	public void testMergeArraysWithNullArray1() throws Exception {
-		MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+        assertArrayEquals(expected, result);
+    }
 
-		String[] array1 = null;
-		String[] array2 = { "application/xml", "application/yaml" };
+    @Test
+    void testMergeArraysWithNullArray1() throws Exception {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
 
-		String[] expected = { "application/xml", "application/yaml" };
+        String[] array1 = null;
+        String[] array2 = {APPLICATION_XML, APPLICATION_YAML};
 
-		Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
-		mergeArraysMethod.setAccessible(true);
-		String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
+        String[] expected = {APPLICATION_XML, APPLICATION_YAML};
 
-		assertArrayEquals(expected, result);
-	}
+        Method mergeArraysMethod = MethodAttributes.class.getDeclaredMethod("mergeArrays", String[].class, String[].class);
+        mergeArraysMethod.setAccessible(true);
+        String[] result = (String[]) mergeArraysMethod.invoke(methodAttributes, (Object) array1, (Object) array2);
 
-	@Test
-	public void testDefaultProducesMediaType() {
-		MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+        assertArrayEquals(expected, result);
+    }
 
-		Method method = this.getClass().getDeclaredMethods()[0];
-		methodAttributes.calculateConsumesProduces(method);
+    @Test
+    void testDefaultProducesMediaType() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
 
-		String[] expectedProduces = { "application/xml" };
-		String[] resultProduces = methodAttributes.getMethodProduces();
+        Method method = this.getClass().getDeclaredMethods()[0];
+        methodAttributes.calculateConsumesProduces(method);
 
-		assertArrayEquals(expectedProduces, resultProduces);
-	}
+        String[] expectedProduces = {APPLICATION_XML};
+        String[] resultProduces = methodAttributes.getMethodProduces();
 
-	@Test
-	public void testDefaultConsumesMediaType() {
-		MethodAttributes methodAttributes = new MethodAttributes("application/json", "application/xml", Locale.ENGLISH);
+        assertArrayEquals(expectedProduces, resultProduces);
+    }
 
-		Method method = this.getClass().getDeclaredMethods()[0];
-		methodAttributes.calculateConsumesProduces(method);
+    @Test
+    void testDefaultConsumesMediaType() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
 
-		String[] expectedConsumes = { "application/json" };
-		String[] resultConsumes = methodAttributes.getMethodConsumes();
+        Method method = this.getClass().getDeclaredMethods()[0];
+        methodAttributes.calculateConsumesProduces(method);
 
-		assertArrayEquals(expectedConsumes, resultConsumes);
-	}
+        String[] expectedConsumes = {APPLICATION_JSON};
+        String[] resultConsumes = methodAttributes.getMethodConsumes();
+
+        assertArrayEquals(expectedConsumes, resultConsumes);
+    }
+
+    @Test
+    void methodConsumesOverridesClassConsumes() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{APPLICATION_JSON, APPLICATION_XML},
+                new String[]{APPLICATION_JSON, APPLICATION_XML}
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+
+            methodAttributes.setClassConsumes(new String[]{APPLICATION_YAML});
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] expectedConsumes = {APPLICATION_JSON, APPLICATION_XML};
+            String[] resultConsumes = methodAttributes.getMethodConsumes();
+
+            assertArrayEquals(expectedConsumes, resultConsumes);
+        }
+    }
+
+    @Test
+    void methodProducesOverridesClassProduces() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{APPLICATION_JSON, APPLICATION_XML},
+                new String[]{APPLICATION_JSON, APPLICATION_XML}
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+
+            methodAttributes.setClassProduces(new String[]{APPLICATION_YAML});
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] expectedProduces = {APPLICATION_JSON, APPLICATION_XML};
+            String[] resultProduces = methodAttributes.getMethodProduces();
+
+            assertArrayEquals(expectedProduces, resultProduces);
+        }
+    }
+
+    @Test
+    void methodConsumesIsSetToClassConsumesIfNoMethodConsumesIsDefined() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{APPLICATION_JSON, APPLICATION_XML},
+                new String[]{}
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+
+            String[] classConsumes = new String[]{APPLICATION_YAML};
+            methodAttributes.setClassConsumes(classConsumes);
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] resultConsumes = methodAttributes.getMethodConsumes();
+
+            assertArrayEquals(classConsumes, resultConsumes);
+        }
+    }
+
+    @Test
+    void methodProducesIsSetToClassProducesIfNoMethodProducesIsDefined() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{},
+                new String[]{APPLICATION_JSON, APPLICATION_XML}
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+
+            String[] classProduces = new String[]{APPLICATION_YAML};
+            methodAttributes.setClassProduces(classProduces);
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] resultProduces = methodAttributes.getMethodProduces();
+
+            assertArrayEquals(classProduces, resultProduces);
+        }
+    }
+
+    @Test
+    void methodConsumesIsSetToClassConsumesIfNoMethodConsumesIsDefinedAndClassConsumesNotSet() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        String[] classConsumes = new String[]{APPLICATION_YAML};
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{APPLICATION_JSON, APPLICATION_XML},
+                new String[]{}
+        );
+        RequestMapping classMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{},
+                classConsumes
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), RequestMapping.class))
+                    .thenReturn(classMapping);
+
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] resultConsumes = methodAttributes.getMethodConsumes();
+
+            assertArrayEquals(classConsumes, resultConsumes);
+        }
+    }
+
+    @Test
+    void methodProducesIsSetToClassProducesIfNoMethodProducesIsDefinedAndClassProducesNotSet() {
+        MethodAttributes methodAttributes = new MethodAttributes(APPLICATION_JSON, APPLICATION_XML, Locale.ENGLISH);
+        String[] classProduces = new String[]{APPLICATION_YAML};
+        RequestMapping requestMapping = givenAnnotationHasMediaTypeAnnotations(
+                new String[]{},
+                new String[]{APPLICATION_JSON, APPLICATION_XML}
+        );
+        RequestMapping classMapping = givenAnnotationHasMediaTypeAnnotations(
+                classProduces,
+                new String[]{}
+        );
+        Method method = this.getClass().getDeclaredMethods()[0];
+        try (MockedStatic<AnnotatedElementUtils> annotatedElementUtils = Mockito.mockStatic(AnnotatedElementUtils.class)) {
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method, RequestMapping.class))
+                    .thenReturn(requestMapping);
+            annotatedElementUtils.when(() -> AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), RequestMapping.class))
+                    .thenReturn(classMapping);
+
+            methodAttributes.calculateConsumesProduces(method);
+
+            String[] resultProduces = methodAttributes.getMethodProduces();
+
+            assertArrayEquals(classProduces, resultProduces);
+        }
+    }
+
+    private RequestMapping givenAnnotationHasMediaTypeAnnotations(String[] produces, String[] consumes) {
+        RequestMapping requestMapping = Mockito.mock(RequestMapping.class);
+        given(requestMapping.produces()).willReturn(produces);
+        given(requestMapping.consumes()).willReturn(consumes);
+        return requestMapping;
+    }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app219/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app219/HelloController.java
@@ -31,12 +31,27 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping(value = "/api", produces = { "application/xml" }, consumes = { "application/json" })
+@RequestMapping(value = "/api", produces = {"application/xml"}, consumes = {"application/json"})
 public class HelloController {
 
-	@RequestMapping(value = "/testpost", method = RequestMethod.POST, produces = { "application/json" },
-			consumes = { "application/json;charset=UTF-8", "application/json; charset=UTF-8" })
-	public ResponseEntity<TestObject> testpost(@RequestBody TestObject dto) {
-		return ResponseEntity.ok(dto);
-	}
+    @RequestMapping(value = "/testpost", method = RequestMethod.POST, produces = {"application/json"},
+            consumes = {"application/json;charset=UTF-8", "application/json; charset=UTF-8"})
+    public ResponseEntity<TestObject> postWithProducesAndConsumes(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost2", method = RequestMethod.POST, consumes = {"application/json;charset=UTF-8"})
+    public ResponseEntity<TestObject> postWithConsumes(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost3", method = RequestMethod.POST, produces = {"application/json"})
+    public ResponseEntity<TestObject> postWithProduces(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost4", method = RequestMethod.POST)
+    public ResponseEntity<TestObject> post(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app219/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app219/HelloController.java
@@ -29,14 +29,30 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+import test.org.springdoc.api.v30.app219.TestObject;
 
 @RestController
-@RequestMapping(value = "/api", produces = { "application/xml" }, consumes = { "application/json" })
+@RequestMapping(value = "/api", produces = {"application/xml"}, consumes = {"application/json"})
 public class HelloController {
 
-	@RequestMapping(value = "/testpost", method = RequestMethod.POST, produces = { "application/json" },
-			consumes = { "application/json;charset=UTF-8", "application/json; charset=UTF-8" })
-	public ResponseEntity<TestObject> testpost(@RequestBody TestObject dto) {
-		return ResponseEntity.ok(dto);
-	}
+    @RequestMapping(value = "/testpost", method = RequestMethod.POST, produces = {"application/json"},
+            consumes = {"application/json;charset=UTF-8", "application/json; charset=UTF-8"})
+    public ResponseEntity<TestObject> postWithProducesAndConsumes(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost2", method = RequestMethod.POST, consumes = {"application/json;charset=UTF-8"})
+    public ResponseEntity<TestObject> postWithConsumes(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost3", method = RequestMethod.POST, produces = {"application/json"})
+    public ResponseEntity<TestObject> postWithProduces(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
+
+    @RequestMapping(value = "/testpost4", method = RequestMethod.POST)
+    public ResponseEntity<TestObject> post(@RequestBody TestObject dto) {
+        return ResponseEntity.ok(dto);
+    }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app219.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app219.json
@@ -16,14 +16,9 @@
         "tags": [
           "hello-controller"
         ],
-        "operationId": "testpost",
+        "operationId": "postWithProducesAndConsumes",
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestObject"
-              }
-            },
             "application/json;charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/TestObject"
@@ -41,12 +36,97 @@
           "200": {
             "description": "OK",
             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost2": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "postWithConsumes",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
               "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/TestObject"
                 }
-              },
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost3": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "postWithProduces",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost4": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/TestObject"
                 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app219.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app219.json
@@ -16,14 +16,9 @@
         "tags": [
           "hello-controller"
         ],
-        "operationId": "testpost",
+        "operationId": "postWithProducesAndConsumes",
         "requestBody": {
           "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/TestObject"
-              }
-            },
             "application/json;charset=UTF-8": {
               "schema": {
                 "$ref": "#/components/schemas/TestObject"
@@ -41,12 +36,97 @@
           "200": {
             "description": "OK",
             "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost2": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "postWithConsumes",
+        "requestBody": {
+          "content": {
+            "application/json;charset=UTF-8": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
               "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/TestObject"
                 }
-              },
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost3": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "postWithProduces",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestObject"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/testpost4": {
+      "post": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TestObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/xml": {
                 "schema": {
                   "$ref": "#/components/schemas/TestObject"
                 }


### PR DESCRIPTION
Fixes #3023

A minimal suggested fix. Given the description provided in the issue, I do not see how [mergeArrays](https://github.com/springdoc/springdoc-openapi/pull/2600/files#diff-60dbe5350c24bb6f53b8fd8216bd7668923262bf47d2f61a3317774d6b6d6a8aR308-R311) should ever be involved with any media type processing, since the media type documentation states that they should override rather than join the types. But due to the lack of descriptive testing together with values being set upon class instantiation and then later changed with a method invocation, I am hesitant to do too much of a change.

Feel free to use and contribute with the unit tests in this PR if you implement a change, since they add a lot of information with regard to what is an implicit/explicit behavior.

