### PR TITLE
Fix: Property resolution for extensions within `@OpenAPIDefinition` Info object

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OpenAPIService.java
@@ -636,9 +636,11 @@ public class OpenAPIService implements ApplicationContextAware {
 	 */
 	private void buildOpenAPIWithOpenAPIDefinition(OpenAPI openAPI, OpenAPIDefinition apiDef, Locale locale) {
 		boolean isOpenapi3 = propertyResolverUtils.isOpenapi31();
-		Map<String, Object> extensions = AnnotationsUtils.getExtensions(isOpenapi3, apiDef.info().extensions());
 		// info
-		AnnotationsUtils.getInfo(apiDef.info(), true).map(info -> resolveProperties(info, extensions, locale)).ifPresent(openAPI::setInfo);
+		AnnotationsUtils.getInfo(apiDef.info(), true).map(info -> {
+			Map<String, Object> extensions = AnnotationsUtils.getExtensions(isOpenapi3, apiDef.info().extensions());
+			return resolveProperties(info, extensions, locale);
+		}).ifPresent(openAPI::setInfo);
 		// OpenApiDefinition security requirements
 		securityParser.getSecurityRequirements(apiDef.security()).ifPresent(openAPI::setSecurity);
 		// OpenApiDefinition external docs
@@ -702,7 +704,7 @@ public class OpenAPIService implements ApplicationContextAware {
 			resolveProperty(contact::getUrl, contact::url, propertyResolverUtils, locale);
 		}
 
-		if (propertyResolverUtils.isResolveExtensionsProperties() && extensions != null) {
+		if (extensions != null) {
 			Map<String, Object> extensionsResolved = propertyResolverUtils.resolveExtensions(locale, extensions);
 			if (propertyResolverUtils.isOpenapi31())
 				extensionsResolved.forEach(info::addExtension31);
@@ -712,7 +714,6 @@ public class OpenAPIService implements ApplicationContextAware {
 
 		return info;
 	}
-
 
 	/**
 	 * Resolve property.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
@@ -224,21 +224,27 @@ public class PropertyResolverUtils {
 			Map<String, Object> extensionsResolved = new HashMap<>();
 			extensions.forEach((key, value) -> {
 				String keyResolved = resolve(key, locale);
-				if (value instanceof HashMap<?, ?>) {
+				if (value instanceof HashMap<?, ?> valueAsMap) {
 					Map<String, Object> valueResolved = new HashMap<>();
-					((HashMap<?, ?>) value).forEach((key1, value1) -> {
+					valueAsMap.forEach((key1, value1) -> {
 						String key1Resolved = resolve(key1.toString(), locale);
 						String value1Resolved = resolve(value1.toString(), locale);
 						valueResolved.put(key1Resolved, value1Resolved);
 					});
 					extensionsResolved.put(keyResolved, valueResolved);
 				}
-				else
+				else if (value instanceof String valueAsString) {
+					String valueResolved = resolve(valueAsString, locale);
+					extensionsResolved.put(keyResolved, valueResolved);
+				}
+				else {
 					extensionsResolved.put(keyResolved, value);
+				}
 			});
 			return extensionsResolved;
 		}
-		else
+		else {
 			return extensions;
+		}
 	}
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app245/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app245/HelloController.java
@@ -1,0 +1,30 @@
+package test.org.springdoc.api.v31.app245;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.extensions.Extension;
+import io.swagger.v3.oas.annotations.extensions.ExtensionProperty;
+import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+@OpenAPIDefinition(
+    info = @Info(
+        title = "My App",
+        version = "${springdoc.version}",
+        extensions = {
+            @Extension(properties = {
+                @ExtensionProperty(name = "x-build-time", value = "${git.build.time}")
+            })
+        }
+    )
+)
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello")
+    public String hello() {
+        return "hello";
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app245/SpringDocApp245Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app245/SpringDocApp245Test.java
@@ -1,0 +1,31 @@
+package test.org.springdoc.api.v31.app245;
+
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "springdoc.version=v1",
+    "git.build.time=2025-07-08T12:00:00Z"
+})
+@AutoConfigureMockMvc
+class SpringDocApp245Test {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void SpringDocTestApp() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.info.version", is("v1")))
+            .andExpect(jsonPath("$.info.x-build-time", is("2025-07-08T12:00:00Z")));
+    }
+}


### PR DESCRIPTION
Fixes #3032 

**Problem:**
Property placeholders (`${...}`) were not being resolved within the `extensions` attribute of `@OpenAPIDefinition`'s `info` object. This was inconsistent, as placeholders in other `@Info` attributes, such as `title` and `version`, were resolving correctly.

**Example Code:**

```java
@OpenAPIDefinition(
    info = @Info(
          title = "OpenAPI Demo",
          version = "${springdoc.version}", // This value was resolved correctly
          extensions = @Extension(properties = @ExtensionProperty(name = "x-created-ts", value = "${git.build.time}")) // This value was NOT resolved
    ))
```

**Actual JSON Output:**

```java
{
  "info": {
    "title": "OpenAPI Demo",
    "version": "v1",
    "x-created-ts": "${git.build.time}" // Expected: "2024-07-08T12:00:00Z" (resolved value)
  },
  ...
}
```

**Root Cause:**
The root cause of this issue was two-fold, involving problems in both property resolution logic and its invocation:

1. **Incomplete Resolution in `PropertyResolverUtils`:**
The `resolveExtensions` method was not designed to resolve simple **String values** of top-level extension properties. It correctly handled the resolution of extension keys and the key-value pairs within nested maps, but it skipped the crucial step of resolving the extension's primary String value itself.

2. **Conditional Logic in `OpenAPIService`:**
The invocation of the property resolution logic for `@OpenAPIDefinition`'s `info` extensions was wrapped in a conditional check (`propertyResolverUtils.isResolveExtensionsProperties()`). This internal property defaults to `false`, which prevented the necessary resolution logic from being triggered in a standard configuration. This created an inconsistency with how other `@Info` attributes were handled, as their resolution was not similarly gated.

---

**Solution:**
This PR addresses both identified issues to ensure consistent and predictable behavior:

1. **Enhanced `PropertyResolverUtils`:**
The `resolveExtensions` method has been updated to properly resolve top-level String values within the extensions map. This was achieved by adding a specific check for String instances:

```java
else if (value instanceof String valueAsString) {
    String valueResolved = resolve(valueAsString, locale);
    extensionsResolved.put(keyResolved, valueResolved);
}
```

2. **Unconditional Resolution in `OpenAPIService`:**
The conditional check for `isResolveExtensionsProperties()` has been removed from the `resolveProperties(Info info, ...)` method. This ensures that property resolution for extensions is always applied, making the behavior consistent with all other `@Info` attributes.