### PR TITLE
Support externalDocs configure on SpecPropertiesCustomizer

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
@@ -32,12 +32,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import io.swagger.v3.oas.models.Components;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Operation;
-import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.*;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
-import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
@@ -90,6 +86,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Anton Tkachenko tkachenkoas@gmail.com
  * @author bnasslahsen
+ * @author Hujin Hong
  */
 public class SpecPropertiesCustomizer implements GlobalOpenApiCustomizer {
 
@@ -148,6 +145,27 @@ public class SpecPropertiesCustomizer implements GlobalOpenApiCustomizer {
 			if (!CollectionUtils.isEmpty(openApiProperties.getServers())) {
 				openApi.setServers(new ArrayList<>(openApiProperties.getServers()));
 			}
+
+			ExternalDocumentation externalDocumentationProperties = openApiProperties.getExternalDocs();
+			if (externalDocumentationProperties != null) {
+				customizeExternalDocs(openApi, externalDocumentationProperties);
+			}
+		}
+	}
+
+	/**
+	 * Customized external docs.
+	 *
+	 * @param openApi the open api
+	 * @param externalDocumentationProperties the external documentation
+	 */
+	private void customizeExternalDocs(OpenAPI openApi, ExternalDocumentation externalDocumentationProperties) {
+		ExternalDocumentation externalDocumentation = openApi.getExternalDocs();
+		if (externalDocumentation != null) {
+			resolveString(externalDocumentation::description, externalDocumentationProperties::getDescription);
+			resolveString(externalDocumentation::url, externalDocumentationProperties::getUrl);
+		} else {
+			openApi.externalDocs(externalDocumentationProperties);
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
@@ -32,8 +32,13 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import io.swagger.v3.oas.models.*;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.PathItem.HttpMethod;
+import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
@@ -170,7 +170,7 @@ public class SpecPropertiesCustomizer implements GlobalOpenApiCustomizer {
 			resolveString(externalDocumentation::description, externalDocumentationProperties::getDescription);
 			resolveString(externalDocumentation::url, externalDocumentationProperties::getUrl);
 		} else {
-			openApi.externalDocs(externalDocumentationProperties);
+			openApi.setExternalDocs(externalDocumentationProperties);
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpecPropertiesCustomizer.java
@@ -91,7 +91,7 @@ import org.springframework.util.CollectionUtils;
  *
  * @author Anton Tkachenko tkachenkoas@gmail.com
  * @author bnasslahsen
- * @author Hujin Hong
+ * @author Huijin Hong
  */
 public class SpecPropertiesCustomizer implements GlobalOpenApiCustomizer {
 

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/application-212.yml
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/application-212.yml
@@ -36,7 +36,10 @@ springdoc:
             - hello
           summary: Summary of Get operationId 'persons'
           description: Description of Get operationId 'persons'
-  
+    external-docs:
+      description: External docs description
+      url: "https://example.com/external-docs"
+
   group-configs:
     - group: apiGroupName
       open-api:
@@ -52,10 +55,13 @@ springdoc:
                 name:
                   description: Description for 'name' property in ApiGroupName
                   example: Example value for 'name' property in ApiGroupName
-        
+
         paths:
           /persons2:
             get:
               summary: Summary of operationId 'persons' in ApiGroupName
               description: Description of operationId 'persons' in ApiGroupName
+        external-docs:
+          description: External docs description for ApiGroupName
+          url: "https://example.com/apiGroupName-external-docs"
 

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/application-217.yml
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/application-217.yml
@@ -22,6 +22,9 @@ springdoc:
               type: http
               scheme: bearer
               bearer-format: JWT
+        external-docs:
+          description: Example External Docs demo
+          url: "https://example.com/external-docs-demo"
     - group: user
       display-name: User Interfaces
       packages-to-scan:
@@ -46,6 +49,9 @@ springdoc:
                 name:
                   description: Description for 'name' property
                   example: Example value for 'name' property
+        external-docs:
+          description: Example External Docs user
+          url: "https://example.com/external-docs-user"
   open-api:
     servers:
       - url: "https://api.example.com"

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app212-grouped.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app212-grouped.json
@@ -127,5 +127,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "External docs description for ApiGroupName",
+    "url": "https://example.com/apiGroupName-external-docs"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app212.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app212.json
@@ -125,5 +125,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "External docs description",
+    "url": "https://example.com/external-docs"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app217-1.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app217-1.json
@@ -58,5 +58,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "Example External Docs demo",
+    "url": "https://example.com/external-docs-demo"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app217-2.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app217-2.json
@@ -51,5 +51,9 @@
         "description": "Description for PersonDTO component"
       }
     }
+  },
+  "externalDocs": {
+    "description": "Example External Docs user",
+    "url": "https://example.com/external-docs-user"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app212-grouped.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app212-grouped.json
@@ -127,5 +127,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "External docs description for ApiGroupName",
+    "url": "https://example.com/apiGroupName-external-docs"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app212.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app212.json
@@ -125,5 +125,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "External docs description",
+    "url": "https://example.com/external-docs"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app217-1.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app217-1.json
@@ -58,5 +58,9 @@
         "bearerFormat": "JWT"
       }
     }
+  },
+  "externalDocs": {
+    "description": "Example External Docs demo",
+    "url": "https://example.com/external-docs-demo"
   }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app217-2.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app217-2.json
@@ -51,5 +51,9 @@
         }
       }
     }
+  },
+  "externalDocs": {
+    "description": "Example External Docs user",
+    "url": "https://example.com/external-docs-user"
   }
 }


### PR DESCRIPTION
Fixes #3028 

Added support for `externalDocs` property reflect to open API object.

The detail suggestion is described on this issue. Please refer it.

Thanks!