### PR TITLE
Use adaptFromForwardedHeaders instead of deprecated fromHttpRequest

### DIFF
--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
@@ -34,6 +34,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SwaggerUiConfigParameters;
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 import org.springdoc.ui.AbstractSwaggerWelcome;
+import org.springframework.web.util.ForwardedHeaderUtils;
 import reactor.core.publisher.Mono;
 
 import org.springframework.http.HttpStatus;
@@ -123,7 +124,7 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 	void buildFromCurrentContextPath(SwaggerUiConfigParameters swaggerUiConfigParameters, ServerHttpRequest request) {
 		super.init(swaggerUiConfigParameters);
 		swaggerUiConfigParameters.setContextPath(request.getPath().contextPath().value());
-		String url = UriComponentsBuilder.fromHttpRequest(request).toUriString();
+		String url = ForwardedHeaderUtils.adaptFromForwardedHeaders(request.getURI(), request.getHeaders()).toUriString();
 		String target = UriComponentsBuilder.fromPath(request.getPath().contextPath().value()).toUriString();
 		int endIndex = url.indexOf(target) + target.length();
 		if (endIndex > 0) {


### PR DESCRIPTION
Use adaptFromForwardedHeaders instead of deprecated fromHttpRequest method. 
FromHttpRequest has been removed in Spring 7.0.0-M7/Spring Boot 4.0.0-M1.

Please note: This PR proposes the same fix as #3027, but since I could not get the CI to run and this was not my fork/PR, I decided to create my own pull request. I hope that's ok.