### PR TITLE
feat: javadoc performance optimization

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -419,6 +419,10 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			return openAPI;
 		}
 		finally {
+            JavadocProvider javadocProvider = operationParser.getJavadocProvider();
+            if (javadocProvider != null) {
+                javadocProvider.clean();
+            }
 			this.reentrantLock.unlock();
 		}
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/JavadocProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/JavadocProvider.java
@@ -102,4 +102,9 @@ public interface JavadocProvider {
 	 * @return the first sentence based on javadoc guidelines
 	 */
 	String getFirstSentence(String text);
+
+    /**
+     * Clean the temp resources.
+     */
+    default void clean() {}
 }

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/SpringDocJavadocProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/SpringDocJavadocProvider.java
@@ -28,8 +28,7 @@ package org.springdoc.core.providers;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.github.therapi.runtimejavadoc.ClassJavadoc;
@@ -56,6 +55,11 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	private final CommentFormatter formatter = new CommentFormatter();
 
+    /**
+     * The Class javadoc cache.
+     */
+    private final Map<Class<?>, ClassJavadoc> classJavadocCache = new HashMap<>();
+
 
 	/**
 	 * Gets class description.
@@ -65,7 +69,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public String getClassJavadoc(Class<?> cl) {
-		ClassJavadoc classJavadoc = RuntimeJavadoc.getJavadoc(cl);
+		ClassJavadoc classJavadoc = getJavadoc(cl);
 		return formatter.format(classJavadoc.getComment());
 	}
 
@@ -77,7 +81,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public Map<String, String> getRecordClassParamJavadoc(Class<?> cl) {
-		ClassJavadoc classJavadoc = RuntimeJavadoc.getJavadoc(cl);
+		ClassJavadoc classJavadoc = getJavadoc(cl);
 		return classJavadoc.getRecordComponents().stream()
 				.collect(Collectors.toMap(ParamJavadoc::getName, recordClass -> formatter.format(recordClass.getComment())));
 	}
@@ -90,7 +94,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public String getMethodJavadocDescription(Method method) {
-		MethodJavadoc methodJavadoc = RuntimeJavadoc.getJavadoc(method);
+		MethodJavadoc methodJavadoc = getJavadoc(method);
 		return formatter.format(methodJavadoc.getComment());
 	}
 
@@ -102,7 +106,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public String getMethodJavadocReturn(Method method) {
-		MethodJavadoc methodJavadoc = RuntimeJavadoc.getJavadoc(method);
+		MethodJavadoc methodJavadoc = getJavadoc(method);
 		return formatter.format(methodJavadoc.getReturns());
 	}
 
@@ -113,7 +117,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 * @return the method throws (name-description map)
 	 */
 	public Map<String, String> getMethodJavadocThrows(Method method) {
-		return RuntimeJavadoc.getJavadoc(method)
+		return getJavadoc(method)
 				.getThrows()
 				.stream()
 				.collect(toMap(ThrowsJavadoc::getName, javadoc -> formatter.format(javadoc.getComment())));
@@ -128,7 +132,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public String getParamJavadoc(Method method, String name) {
-		MethodJavadoc methodJavadoc = RuntimeJavadoc.getJavadoc(method);
+		MethodJavadoc methodJavadoc = getJavadoc(method);
 		List<ParamJavadoc> paramsDoc = methodJavadoc.getParams();
 		return paramsDoc.stream().filter(paramJavadoc1 -> name.equals(paramJavadoc1.getName())).findAny()
 				.map(paramJavadoc1 -> formatter.format(paramJavadoc1.getComment())).orElse(null);
@@ -142,7 +146,7 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 	 */
 	@Override
 	public String getFieldJavadoc(Field field) {
-		FieldJavadoc fieldJavadoc = RuntimeJavadoc.getJavadoc(field);
+		FieldJavadoc fieldJavadoc = getJavadoc(field);
 		return formatter.format(fieldJavadoc.getComment());
 	}
 
@@ -173,4 +177,38 @@ public class SpringDocJavadocProvider implements JavadocProvider {
 		}
 		return text;
 	}
+
+    private ClassJavadoc getJavadoc(Class<?> cl) {
+        ClassJavadoc classJavadoc = classJavadocCache.get(cl);
+        if (classJavadoc != null) {
+            return classJavadoc;
+        }
+        classJavadoc = RuntimeJavadoc.getJavadoc(cl);
+        classJavadocCache.put(cl, classJavadoc);
+        return classJavadoc;
+    }
+
+    private MethodJavadoc getJavadoc(Method method) {
+        ClassJavadoc classJavadoc = getJavadoc(method.getDeclaringClass());
+        List<String> paramTypes = Arrays.stream(method.getParameterTypes())
+                .map(Class::getCanonicalName)
+                .toList();
+        return classJavadoc.getMethods()
+                .stream()
+                .filter(it -> Objects.equals(method.getName(), it.getName()) && Objects.equals(paramTypes, it.getParamTypes()))
+                .findFirst().orElseGet(() -> MethodJavadoc.createEmpty(method));
+    }
+
+    private FieldJavadoc getJavadoc(Field field) {
+        ClassJavadoc classJavadoc = getJavadoc(field.getDeclaringClass());
+        return classJavadoc.getFields()
+                .stream()
+                .filter(it -> Objects.equals(field.getName(), it.getName()))
+                .findFirst().orElseGet(() -> FieldJavadoc.createEmpty(field.getName()));
+    }
+
+    @Override
+    public void clean() {
+        classJavadocCache.clear();
+    }
 }


### PR DESCRIPTION
When generating API documentation with Javadoc, performance was poor due to multiple uses of reflection in SpringDocJavadocProvider. In this commit, a caching mechanism was introduced so that Javadoc retrieval no longer relies on reflection each time, improving performance.