### PR TITLE
disable "/v3/api-docs", and "/swagger-ui.html" by default and upgrade to Scalar 0.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 		<spring-cloud-function.version>4.2.2</spring-cloud-function.version>
 		<spring-security-oauth2-authorization-server.version>1.4.3
 		</spring-security-oauth2-authorization-server.version>
-		<scalar.version>0.1.0</scalar.version>
+		<scalar.version>0.2.1</scalar.version>
 		<skipPublishing>false</skipPublishing>
 	</properties>
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
@@ -1434,7 +1434,7 @@ public class SpringDocConfigProperties {
 		/**
 		 * Whether to generate and serve an OpenAPI document.
 		 */
-		private boolean enabled = true;
+		private boolean enabled = false;
 
 		/**
 		 * The Resolve schema properties.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigProperties.java
@@ -96,7 +96,7 @@ public class SwaggerUiConfigProperties extends AbstractSwaggerUiConfigProperties
 	/**
 	 * Whether to generate and serve an OpenAPI document.
 	 */
-	private boolean enabled = true;
+	private boolean enabled = false;
 
 	/**
 	 * The Use root path.


### PR DESCRIPTION
Disable SpringDoc by default to maintain alignment with Scalar (scalar/scalar#6781) and ensure that the default configuration follows secure-by-default principles.