### PR TITLE
Upgrade swagger-core to version 2.2.38

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<central-publishing-maven-plugin.version>0.7.0
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
-		<swagger-api.version>2.2.36</swagger-api.version>
+		<swagger-api.version>2.2.38</swagger-api.version>
 		<swagger-ui.version>5.28.1</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app26/MyModel.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app26/MyModel.java
@@ -28,7 +28,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public class MyModel {
 
-	@Schema(description = "Hello", type = "object", oneOf = { Foo.class, Bar.class })
+	@Schema(description = "Hello", types = "object", oneOf = { Foo.class, Bar.class })
 	private Object thing;
 
 	public Object getThing() {

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app29/TrackerData.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app29/TrackerData.java
@@ -40,7 +40,7 @@ public class TrackerData {
 	@JsonProperty("timestamp")
 	Instant timestamp;
 
-	@Schema(name = "value", type = "number", format = "double", description = "The data value", required = true, example = "19.0")
+	@Schema(name = "value", types = "number", format = "double", description = "The data value", required = true, example = "19.0")
 	@JsonProperty("value")
 	Double value;
 

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app4/TrackerData.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app4/TrackerData.java
@@ -39,7 +39,7 @@ public class TrackerData {
 	@JsonProperty("timestamp")
 	Instant timestamp;
 
-	@Schema(name = "value", type = "number", format = "double", description = "The data value", required = true, example = "19.0")
+	@Schema(name = "value", types = "number", format = "double", description = "The data value", required = true, example = "19.0")
 	@JsonProperty("value")
 	Double value;
 

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app164.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app164.json
@@ -49,10 +49,12 @@
           "booleanValueAsFourthParameter": {
             "type": "boolean"
           },
-          "listBlah": {
-            "type": "array",
-            "items": {
-              "description": "test"
+          "listBlah" : {
+            "type" : "array",
+            "description" : "test",
+            "items" : {
+              "type" : "string",
+              "description" : "test"
             }
           }
         }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app26.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app26.json
@@ -64,14 +64,9 @@
         "type": "object",
         "properties": {
           "thing": {
+            "type" : "object",
             "description": "Hello",
             "oneOf": [
-              {
-                "$ref": "#/components/schemas/Foo"
-              },
-              {
-                "$ref": "#/components/schemas/Bar"
-              },
               {
                 "$ref": "#/components/schemas/Foo"
               },

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app26/MyModel.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app26/MyModel.java
@@ -36,7 +36,7 @@ class MyModel {
 	/**
 	 * The Thing.
 	 */
-	@Schema(description = "Hello", type = "object", oneOf = { Foo.class, Bar.class })
+	@Schema(description = "Hello", types = "object", oneOf = { Foo.class, Bar.class })
 	private Object thing;
 
 	/**

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app29/TrackerData.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app29/TrackerData.java
@@ -54,7 +54,7 @@ class TrackerData {
 	/**
 	 * The Value.
 	 */
-	@Schema(name = "value", type = "number", format = "double", description = "The data value", required = true, example = "19.0")
+	@Schema(name = "value", types = "number", format = "double", description = "The data value", required = true, example = "19.0")
 	@JsonProperty("value")
 	Double value;
 

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app4/TrackerData.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app4/TrackerData.java
@@ -53,7 +53,7 @@ class TrackerData {
 	/**
 	 * The Value.
 	 */
-	@Schema(name = "value", type = "number", format = "double", description = "The data value", required = true, example = "19.0")
+	@Schema(name = "value", types = "number", format = "double", description = "The data value", required = true, example = "19.0")
 	@JsonProperty("value")
 	Double value;
 

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app26.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app26.json
@@ -78,14 +78,9 @@
         "description": "The type My model.",
         "properties": {
           "thing": {
+            "type": "object",
             "description": "Hello",
             "oneOf": [
-              {
-                "$ref": "#/components/schemas/Foo"
-              },
-              {
-                "$ref": "#/components/schemas/Bar"
-              },
               {
                 "$ref": "#/components/schemas/Foo"
               },


### PR DESCRIPTION
Upgrades swagger-core from 2.2.36 to 2.2.38. 

Note that the schema type overriding for the 3.1 specification resolver seems to have had some minor regression, as it now seems to require the 3.1 `types` to be set rather than the old 3.0 `type`. This has previously been highlighted as issues by consumers, so might be necessary to investigate if a fallback is possible.

This should also close https://github.com/swagger-api/swagger-core/issues/4822, since the duplicated `oneOf` issue seems to have been resolved.