### PR TITLE
fix:compatible with lower version of getOpenApi().

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -143,6 +143,7 @@ import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
  * @author hyeonisism
  * @author doljae
  * @author zdary
+ * @author Haotian Zhang
  */
 public abstract class AbstractOpenApiResource extends SpecFilter {
 
@@ -340,9 +341,20 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		this.getOpenApi(null, Locale.getDefault());
 	}
 
-	/**
-	 * Gets open api.
-	 *
+    /**
+     * Gets open api.
+     *
+     * @param locale the locale
+     * @return the open api
+     */
+    protected OpenAPI getOpenApi(Locale locale) {
+        return this.getOpenApi(null, locale);
+    }
+
+    /**
+     * Gets open api.
+     *
+     * @param serverBaseUrl the server base url
 	 * @param locale the locale
 	 * @return the open api
 	 */


### PR DESCRIPTION
The lower version of the getOpenApi method supports a single parameter, which needs to be compatible with this.