### PR TITLE
Add logs to notify when SpringDocs/Scalar is enabled because SpringDocs/Scalar is enabled by default (#3090) 

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocConfiguration.java
@@ -44,6 +44,8 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springdoc.api.ErrorMessage;
 import org.springdoc.api.OpenApiResourceNotFoundException;
 import org.springdoc.core.conditions.CacheOrGroupedOpenApiCondition;
@@ -101,6 +103,8 @@ import org.springdoc.core.service.SecurityService;
 import org.springdoc.core.utils.PropertyResolverUtils;
 import org.springdoc.core.utils.SchemaUtils;
 import org.springdoc.core.utils.SpringDocKotlinUtils;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import reactor.core.publisher.Flux;
 
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
@@ -151,6 +155,13 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnWebApplication
 public class SpringDocConfiguration {
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(SpringDocConfiguration.class);
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void init() {
+		LOGGER.warn("SpringDoc /api-docs endpoint is enabled by default. To disable it in production, set the property '{}=false' in your production profile configuration.", SPRINGDOC_ENABLED);
+	}
 
 	/**
 	 * The constant BINDRESULT_CLASS.

--- a/springdoc-openapi-starter-webflux-scalar/src/main/java/org/springdoc/webflux/scalar/ScalarConfiguration.java
+++ b/springdoc-openapi-starter-webflux-scalar/src/main/java/org/springdoc/webflux/scalar/ScalarConfiguration.java
@@ -27,6 +27,8 @@
 package org.springdoc.webflux.scalar;
 
 import com.scalar.maven.webjar.ScalarProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 
@@ -40,10 +42,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
 import org.springframework.web.server.adapter.ForwardedHeaderTransformer;
 
 import static org.springdoc.core.utils.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
@@ -62,6 +66,14 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_MANAGEMENT_PORT;
 @EnableConfigurationProperties(ScalarProperties.class)
 @ConditionalOnProperty(prefix = "scalar", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ScalarConfiguration {
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(ScalarConfiguration.class);
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void init() {
+		LOGGER.warn("SpringDoc Scalar is enabled by default. To disable it in production, set the property 'scalar.enabled=false' in your production profile configuration.");
+	}
+
 
 	/**
 	 * Scalar web mvc controller scalar web mvc controller.

--- a/springdoc-openapi-starter-webmvc-scalar/src/main/java/org/springdoc/webmvc/scalar/ScalarConfiguration.java
+++ b/springdoc-openapi-starter-webmvc-scalar/src/main/java/org/springdoc/webmvc/scalar/ScalarConfiguration.java
@@ -27,6 +27,8 @@
 package org.springdoc.webmvc.scalar;
 
 import com.scalar.maven.webjar.ScalarProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 
@@ -40,11 +42,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication.Type;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.EventListener;
 import org.springframework.web.filter.ForwardedHeaderFilter;
 
 import static org.springdoc.core.utils.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
@@ -63,6 +67,14 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_MANAGEMENT_PORT;
 @EnableConfigurationProperties(ScalarProperties.class)
 @ConditionalOnProperty(prefix = "scalar", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ScalarConfiguration {
+
+
+	protected static final Logger LOGGER = LoggerFactory.getLogger(ScalarConfiguration.class);
+
+	@EventListener(ApplicationReadyEvent.class)
+	public void init() {
+		 LOGGER.warn("SpringDoc Scalar is enabled by default. To disable it in production, set the property 'scalar.enabled=false' in your production profile configuration.");
+	}
 
 	/**
 	 * Scalar web mvc controller scalar web mvc controller.


### PR DESCRIPTION
Add logs to notify when SpringDocs/Scalar is enabled (#3090)

Since the SpringDoc team disagrees with disabling SpringDocs/Scalar by default #3090  (like Scalar does scalar/scalar#6781).
we can use an alternative approach to achieve the same result: notify developers who may be unaware about SpringDocs behavior.

Background: 

> @bnasslahsen
> 
> Making it disabled by default would be better. You could introduce a new property like `springdoc.scalar.enabled` to allow users to enable or disable it, rather than relying on `scalar.enabled`.
> 
> From previous experience, I've found that people typically disable SpringDoc via `springdoc.swagger-ui.enabled` only in production profiles, without realizing for several months that their other endpoints remain exposed to the internet through `/v3/api-docs`.
> 
> You might say this is a noob mistake, but in reality, the mistake is made by principal-level developers, and it passes both internal and external penetration testing. No one catches it for months in production, until a curious junior developer (me at one of my previous companies) discovers it by accident.
> 
> There may still be other systems/companies where this issue hasn't been discovered yet, so it's better to disable it by default and ensure users familiarize themselves with your library before enabling it.
> 
> Note that I sent the same concern to Scalar via email, and they accepted it: [scalar/scalar#6781](https://github.com/scalar/scalar/pull/6781) (Of course, I also sent the same concern to SpringDoc via email)
> 
> I agree with you that it may seem overkill, but when you look at it from the user's perspective, it makes sense.
> 
> Also, in 2024, the CVE board updated the CNA rules, including the following:
> 
> * 4.1.4 Insecure default configuration settings SHOULD be determined to be vulnerabilities
> 
> So what do you think?
> 
> Thank you for your effort in providing the Spring ecosystem with this library which makes our lives easier.


