### PR TITLE
Change so useReturnTypeSchema is considered on an http code level

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
@@ -134,7 +134,7 @@ public class MethodAttributes {
 	/**
 	 * The Use return type schema.
 	 */
-	private boolean useReturnTypeSchema;
+	private final Map<String, Boolean> useReturnTypeSchema = new LinkedHashMap<>();
 
 	/**
 	 * Instantiates a new Method attributes.
@@ -529,20 +529,21 @@ public class MethodAttributes {
 	}
 
 	/**
-	 * Is use return type schema boolean.
+	 * Gets use return type schema.
 	 *
-	 * @return the boolean
+	 * @return the use return type schema
 	 */
-	public boolean isUseReturnTypeSchema() {
+	public Map<String, Boolean> getUseReturnTypeSchema() {
 		return useReturnTypeSchema;
 	}
 
 	/**
-	 * Sets use return type schema.
+	 * Put use return type schema.
 	 *
+	 * @param responseCode the response code
 	 * @param useReturnTypeSchema the use return type schema
 	 */
-	public void setUseReturnTypeSchema(boolean useReturnTypeSchema) {
-		this.useReturnTypeSchema = useReturnTypeSchema;
+	public void putUseReturnTypeSchema(String responseCode, boolean useReturnTypeSchema) {
+        this.useReturnTypeSchema.put(responseCode, useReturnTypeSchema);
 	}
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app226/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app226/HelloController.java
@@ -4,8 +4,10 @@ import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,20 +19,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 public class HelloController {
 
+	public record Error(String message) {
+
+	}
+
 	@PostMapping("/testBoolean")
-	@ApiResponse(
-			useReturnTypeSchema = true,
-			responseCode = "200",
-			description = "OK",
-			content = {
-					@Content(
-							mediaType = "*/*",
-							examples =
-							@ExampleObject(
-									name = "success",
-									value = "..."))
-			}
-	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					useReturnTypeSchema = true,
+					responseCode = "200",
+					description = "OK",
+					content = {
+							@Content(
+									mediaType = "*/*",
+									examples =
+									@ExampleObject(
+											name = "success",
+											value = "..."))
+					}
+			),
+			@ApiResponse(
+					responseCode = "400",
+					description = "OK",
+					content = {
+							@Content(
+									mediaType = "*/*",
+									schema = @Schema(implementation = Error.class))
+					}
+			)
+	})
 	public Map<String, String> HelloController() {
 		return null;
 	}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app226/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app226/HelloController.java
@@ -4,8 +4,10 @@ import java.util.Map;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,20 +19,35 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping
 public class HelloController {
 
+	public record Error(String message) {
+
+	}
+
 	@PostMapping("/testBoolean")
-	@ApiResponse(
-			useReturnTypeSchema = true,
-			responseCode = "200",
-			description = "OK",
-			content = {
-					@Content(
-							mediaType = "*/*",
-							examples =
-							@ExampleObject(
-									name = "success",
-									value = "..."))
-			}
-	)
+	@ApiResponses(value = {
+			@ApiResponse(
+					useReturnTypeSchema = true,
+					responseCode = "200",
+					description = "OK",
+					content = {
+							@Content(
+									mediaType = "*/*",
+									examples =
+									@ExampleObject(
+											name = "success",
+											value = "..."))
+					}
+			),
+			@ApiResponse(
+					responseCode = "400",
+					description = "OK",
+					content = {
+							@Content(
+									mediaType = "*/*",
+									schema = @Schema(implementation = Error.class))
+					}
+			)
+	})
 	public Map<String, String> HelloController() {
 		return null;
 	}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app226.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app226.json
@@ -36,10 +36,31 @@
                 }
               }
             }
+          },
+          "400" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Error"
+                }
+              }
+            }
           }
         }
       }
     }
   },
-  "components": {}
+  "components": {
+    "schemas" : {
+      "Error" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app226.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app226.json
@@ -1,38 +1,44 @@
 {
-  "openapi": "3.1.0",
-  "info": {
-    "title": "OpenAPI definition",
-    "version": "v0"
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "paths": {
-    "/testBoolean": {
-      "post": {
-        "tags": [
-          "hello-controller"
-        ],
-        "operationId": "HelloController",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/testBoolean" : {
+      "post" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "HelloController",
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "object",
+                  "additionalProperties" : {
+                    "type" : "string"
                   }
                 },
-                "examples": {
-                  "success": {
-                    "description": "success",
-                    "value": "..."
+                "examples" : {
+                  "success" : {
+                    "description" : "success",
+                    "value" : "..."
                   }
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/Error"
                 }
               }
             }
@@ -41,5 +47,16 @@
       }
     }
   },
-  "components": {}
+  "components" : {
+    "schemas" : {
+      "Error" : {
+        "type" : "object",
+        "properties" : {
+          "message" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes #3137

The issue reported stem from the fact the the `useReturnTypeSchema` currently is considered on a method level rather than on an http code level. This means that if several `@ApiResponse` are defined, then the last annotation determines whether the `useReturnTypeSchema` is triggered or not. This will then in turn lead to either all responses calculating the response type or none or them.

This change allows the definition to be tied to individual http code definitions, so that for example only the 200 response derives its response type, while any 4xx or 5xx definition can retain strictly an explicit schema implementation.