### PR TITLE
docs(management-port): add example for /v3/api-docs and Swagger UI (#…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ This project is sponsored by
     - [Error Handling for REST using @ControllerAdvice](#error-handling-for-rest-using-controlleradvice)
     - [Adding API Information and Security documentation](#adding-api-information-and-security-documentation)
     - [spring-webflux support with Annotated Controllers](#spring-webflux-support-with-annotated-controllers)
+    - [Using a separate management port (Spring Boot 3)](#using-a-separate-management-port-spring-boot-3)
 - [Acknowledgements](#acknowledgements)
     - [Contributors](#contributors)
     - [Additional Support](#additional-support)


### PR DESCRIPTION
### What
Add a short README section showing how /v3/api-docs and Swagger UI behave when Spring Boot 3 uses a separate management port.

### Why
Many users put Actuator on a different management port and are unsure which URLs to use. This adds a minimal config + verification commands.

### Notes
- Content placed above “Acknowledgements”.
- References issue #3147.
