### PR TITLE
docs(security): allow /v3/api-docs(.yaml) & Swagger UI when Spring Security is enabled (management port)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ This project is sponsored by
     - [Adding API Information and Security documentation](#adding-api-information-and-security-documentation)
     - [spring-webflux support with Annotated Controllers](#spring-webflux-support-with-annotated-controllers)
     - [Using a separate management port (Spring Boot 3)](#using-a-separate-management-port-spring-boot-3)
+    - [When Spring Security is enabled](#when-spring-security-is-enabled)
 - [Acknowledgements](#acknowledgements)
     - [Contributors](#contributors)
     - [Additional Support](#additional-support)
@@ -283,6 +284,28 @@ management:
 # springdoc is enabled by default with the starter;
 # endpoints remain on the application port.
 # (OpenAPI JSON = /v3/api-docs, Swagger UI = /swagger-ui/index.html)
+```
+
+### When Spring Security is enabled
+
+With Spring Boot 3, `/v3/api-docs` and Swagger UI are served on the **application port**, while Actuator runs on the **management port**.  
+If Spring Security is enabled, explicitly permit the docs paths on the **application port**:
+
+```java
+@Bean
+SecurityFilterChain api(HttpSecurity http) throws Exception {
+  http
+    .authorizeHttpRequests(auth -> auth
+      .requestMatchers(
+        "/v3/api-docs/**",   
+        "/v3/api-docs.yaml", 
+        "/swagger-ui/**",
+        "/swagger-ui.html"
+      ).permitAll()
+      .anyRequest().authenticated()
+    );
+  return http.build();
+}
 ```
 
 # Acknowledgements


### PR DESCRIPTION
### Summary
Adds a short note and minimal `SecurityFilterChain` example showing how to permit the OpenAPI and Swagger UI endpoints on the **application port** when Spring Security is enabled and Actuator runs on a separate **management port**.
Endpoints permitted: `/v3/api-docs/**`, `/v3/api-docs.yaml`, `/swagger-ui/**`, `/swagger-ui.html`.
_Actuator security remains on the management port; this snippet applies only to the application port._

### Why
With Spring Boot 3, OpenAPI endpoints and Swagger UI are served on the application port while Actuator runs on the management port. New users frequently see 404/401 for the docs when Spring Security is enabled unless these paths are explicitly permitted. This note removes that ambiguity.

### What changed
- **README:** under “Using a separate management port (Spring Boot 3)”
  - Added subsection **“When Spring Security is enabled”** with a minimal `SecurityFilterChain` snippet that permits:
    - `/v3/api-docs/**` (JSON endpoints)
    - `/v3/api-docs.yaml` (YAML root)
    - `/swagger-ui/**`
    - `/swagger-ui.html`
  - Added a **Table of Contents** entry pointing to the new subsection.

### Scope
Docs-only; no code changes. Backwards compatible.

### Related
Fixes #3149
