### PR TITLE
feat: add @Order to ApplicationReadyEvent listener (#3151)

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/events/SpringDocAppInitializer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/events/SpringDocAppInitializer.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 
 /**
  * The type Spring doc app initializer.
@@ -76,6 +77,7 @@ public class SpringDocAppInitializer {
 	 * Init.
 	 */
 	@EventListener(ApplicationReadyEvent.class)
+    @Order(0)
 	public void init() {
 		if(!this.springdocEnabled)
 			LOGGER.warn("SpringDoc {} endpoint is enabled by default. To disable it in production, set the property '{}=false'", endpoint, property);


### PR DESCRIPTION
Adresses #3151

Add `@Order` to the `ApplicationReadyEvent` listener introduced in 2.8.14. This allows consumers of the library to define in what order the listener is executed. Without this annotation, the listener is executed after all other listeners that do have the `@Order` annotation.

Note: The range of int signalling the Order is from `Integer.MIN_VALUE` to `Integer.MAX_VALUE` with a lower value meaning a higher priority, so 0 seems to be a sensible value for me