### PR TITLE
Remove unused operations consumer from route builder methods

### DIFF
--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/fn/SpringdocRouteBuilder.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/fn/SpringdocRouteBuilder.java
@@ -552,12 +552,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 *
 	 * @param predicate              the predicate
 	 * @param routerFunctionSupplier the router function supplier
-	 * @param operationsConsumer     the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder nest(RequestPredicate predicate, Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.nest(predicate, routerFunctionSupplier).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder nest(RequestPredicate predicate, Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier) {
+		this.delegate.nest(predicate, routerFunctionSupplier);
 		return this;
 	}
 
@@ -567,12 +565,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 *
 	 * @param predicate          the predicate
 	 * @param builderConsumer    the builder consumer
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder nest(RequestPredicate predicate, Consumer<RouterFunctions.Builder> builderConsumer, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.nest(predicate, builderConsumer).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder nest(RequestPredicate predicate, Consumer<RouterFunctions.Builder> builderConsumer) {
+		this.delegate.nest(predicate, builderConsumer);
 		return this;
 	}
 
@@ -611,12 +607,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 * Filter springdoc route builder.
 	 *
 	 * @param filterFunction     the filter function
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder filter(HandlerFilterFunction<ServerResponse, ServerResponse> filterFunction, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.filter(filterFunction).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder filter(HandlerFilterFunction<ServerResponse, ServerResponse> filterFunction) {
+		this.delegate.filter(filterFunction);
 		return this;
 	}
 
@@ -624,13 +618,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	/**
 	 * Before springdoc route builder.
 	 *
-	 * @param requestProcessor   the request processor
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder before(UnaryOperator<ServerRequest> requestProcessor, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.before(requestProcessor).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder before(UnaryOperator<ServerRequest> requestProcessor) {
+		this.delegate.before(requestProcessor);
 		return this;
 	}
 
@@ -639,12 +630,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 * After springdoc route builder.
 	 *
 	 * @param responseProcessor  the response processor
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder after(BiFunction<ServerRequest, ServerResponse, ServerResponse> responseProcessor, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.after(responseProcessor).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder after(BiFunction<ServerRequest, ServerResponse, ServerResponse> responseProcessor) {
+		this.delegate.after(responseProcessor);
 		return this;
 	}
 

--- a/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v30/app150/HelloRouter.java
+++ b/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v30/app150/HelloRouter.java
@@ -26,10 +26,8 @@
 
 package test.org.springdoc.api.v30.app150;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.springdoc.core.fn.builders.operation.Builder;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 
 import org.springframework.context.annotation.Bean;
@@ -54,16 +52,13 @@ public class HelloRouter {
 
 						.POST("/titi", HANDLER_FUNCTION, builder -> builder.operationId("create-user-group-special")).build();
 
-		Consumer<Builder> operationsConsumer = builder -> {
-		};
-
-		return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
+        return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
 				SpringdocRouteBuilder.route()
 						.GET(HANDLER_FUNCTION, builder -> builder.operationId("get-users"))
 						.POST("/special", HANDLER_FUNCTION, builder -> builder.operationId("create-user-special"))
-						.nest(path("/groups"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/groups2"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier, operationsConsumer)
+						.nest(path("/groups"), routerFunctionSupplier)
+						.nest(path("/groups2"), routerFunctionSupplier)
+						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier)
 						.build())));
 
 	}

--- a/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v30/app151/HelloRouter.java
+++ b/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v30/app151/HelloRouter.java
@@ -26,10 +26,8 @@
 
 package test.org.springdoc.api.v30.app151;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.springdoc.core.fn.builders.operation.Builder;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 
 import org.springframework.context.annotation.Bean;
@@ -54,16 +52,13 @@ public class HelloRouter {
 
 						.POST("/titi", HANDLER_FUNCTION, builder -> builder.operationId("create-user-group-special")).build();
 
-		Consumer<Builder> operationsConsumer = builder -> {
-		};
-
-		return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
+        return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
 				SpringdocRouteBuilder.route()
 						.GET("", HANDLER_FUNCTION, builder -> builder.operationId("get-users"))
 						.POST("/special", HANDLER_FUNCTION, builder -> builder.operationId("create-user-special"))
-						.nest(path("/groups"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/groups2"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier, operationsConsumer)
+						.nest(path("/groups"), routerFunctionSupplier)
+						.nest(path("/groups2"), routerFunctionSupplier)
+						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier)
 						.build())));
 
 	}

--- a/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app150/HelloRouter.java
+++ b/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app150/HelloRouter.java
@@ -26,10 +26,8 @@
 
 package test.org.springdoc.api.v31.app150;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.springdoc.core.fn.builders.operation.Builder;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 
 import org.springframework.context.annotation.Bean;
@@ -54,16 +52,13 @@ public class HelloRouter {
 
 						.POST("/titi", HANDLER_FUNCTION, builder -> builder.operationId("create-user-group-special")).build();
 
-		Consumer<Builder> operationsConsumer = builder -> {
-		};
-
-		return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
+        return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
 				SpringdocRouteBuilder.route()
 						.GET(HANDLER_FUNCTION, builder -> builder.operationId("get-users"))
 						.POST("/special", HANDLER_FUNCTION, builder -> builder.operationId("create-user-special"))
-						.nest(path("/groups"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/groups2"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier, operationsConsumer)
+						.nest(path("/groups"), routerFunctionSupplier)
+						.nest(path("/groups2"), routerFunctionSupplier)
+						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier)
 						.build())));
 
 	}

--- a/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app151/HelloRouter.java
+++ b/springdoc-openapi-starter-webflux-api/src/test/java/test/org/springdoc/api/v31/app151/HelloRouter.java
@@ -26,10 +26,8 @@
 
 package test.org.springdoc.api.v31.app151;
 
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import org.springdoc.core.fn.builders.operation.Builder;
 import org.springdoc.webflux.core.fn.SpringdocRouteBuilder;
 
 import org.springframework.context.annotation.Bean;
@@ -54,16 +52,13 @@ public class HelloRouter {
 
 						.POST("/titi", HANDLER_FUNCTION, builder -> builder.operationId("create-user-group-special")).build();
 
-		Consumer<Builder> operationsConsumer = builder -> {
-		};
-
-		return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
+        return RouterFunctions.nest(RequestPredicates.path("/users"), nest(path("/test"), nest(path("/greeter"),
 				SpringdocRouteBuilder.route()
 						.GET("", HANDLER_FUNCTION, builder -> builder.operationId("get-users"))
 						.POST("/special", HANDLER_FUNCTION, builder -> builder.operationId("create-user-special"))
-						.nest(path("/groups"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/groups2"), routerFunctionSupplier, operationsConsumer)
-						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier, operationsConsumer)
+						.nest(path("/groups"), routerFunctionSupplier)
+						.nest(path("/groups2"), routerFunctionSupplier)
+						.nest(path("/greeter3").or(path("/greeter4")), routerFunctionSupplier)
 						.build())));
 
 	}

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/fn/SpringdocRouteBuilder.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/fn/SpringdocRouteBuilder.java
@@ -552,12 +552,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 *
 	 * @param predicate              the predicate
 	 * @param routerFunctionSupplier the router function supplier
-	 * @param operationsConsumer     the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder nest(RequestPredicate predicate, Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.nest(predicate, routerFunctionSupplier).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder nest(RequestPredicate predicate, Supplier<RouterFunction<ServerResponse>> routerFunctionSupplier) {
+		this.delegate.nest(predicate, routerFunctionSupplier);
 		return this;
 	}
 
@@ -567,12 +565,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 *
 	 * @param predicate          the predicate
 	 * @param builderConsumer    the builder consumer
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder nest(RequestPredicate predicate, Consumer<RouterFunctions.Builder> builderConsumer, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.nest(predicate, builderConsumer).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder nest(RequestPredicate predicate, Consumer<RouterFunctions.Builder> builderConsumer) {
+		this.delegate.nest(predicate, builderConsumer);
 		return this;
 	}
 
@@ -611,12 +607,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 * Filter springdoc route builder.
 	 *
 	 * @param filterFunction     the filter function
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder filter(HandlerFilterFunction<ServerResponse, ServerResponse> filterFunction, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.filter(filterFunction).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder filter(HandlerFilterFunction<ServerResponse, ServerResponse> filterFunction) {
+		this.delegate.filter(filterFunction);
 		return this;
 	}
 
@@ -625,12 +619,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 * Before springdoc route builder.
 	 *
 	 * @param requestProcessor   the request processor
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder before(UnaryOperator<ServerRequest> requestProcessor, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.before(requestProcessor).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder before(UnaryOperator<ServerRequest> requestProcessor) {
+		this.delegate.before(requestProcessor);
 		return this;
 	}
 
@@ -639,12 +631,10 @@ public class SpringdocRouteBuilder extends AbstractSpringdocRouteBuilder {
 	 * After springdoc route builder.
 	 *
 	 * @param responseProcessor  the response processor
-	 * @param operationsConsumer the operations consumer
 	 * @return the springdoc route builder
 	 */
-	public SpringdocRouteBuilder after(BiFunction<ServerRequest, ServerResponse, ServerResponse> responseProcessor, Consumer<Builder> operationsConsumer) {
-		Builder builder = getOperationBuilder(operationsConsumer);
-		this.delegate.after(responseProcessor).withAttribute(OPERATION_ATTRIBUTE, builder);
+	public SpringdocRouteBuilder after(BiFunction<ServerRequest, ServerResponse, ServerResponse> responseProcessor) {
+		this.delegate.after(responseProcessor);
 		return this;
 	}
 


### PR DESCRIPTION
`SpringdocRouteBuilder.before`, `SpringdocRouteBuilder.after` and `SpringdocRouteBuilder.filter` are overriding last route defined and `SpringdocRouteBuilder.nest` is unnecessary.

Fixes https://github.com/springdoc/springdoc-openapi/issues/1538

See https://github.com/springdoc/springdoc-openapi/commit/296af61ecd2791599266083f2fe5461147adb376 and https://github.com/springdoc/springdoc-openapi/issues/2399 for more.
