### PR TITLE
Disable creation of a blank GitHub issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,13 @@ assignees: ''
 
 ---
 
+<!--
+**If the issue is NOT a bug**
+
+- We use GitHub issues to track bugs and enhancements. If you have a general usage question please ask on [Stack Overflow](https://stackoverflow.com/). 
+- The springdoc-openapi team and the broader community monitor the [springdoc](https://stackoverflow.com/tags/springdoc) tag.
+-->
+
 **Describe the bug**
 
 - If you are reporting a bug, please help to speed up problem diagnosis by providing as

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,13 @@ assignees: ''
 
 ---
 
+<!--
+**If the issue is NOT a feature request**
+
+- We use GitHub issues to track bugs and enhancements. If you have a general usage question please ask on [Stack Overflow](https://stackoverflow.com/).
+- The springdoc-openapi team and the broader community monitor the [springdoc](https://stackoverflow.com/tags/springdoc) tag.
+-->
+
 **Is your feature request related to a problem? Please describe.**
 
 - A clear and concise description of what the problem is. Ex. I'm always frustrated


### PR DESCRIPTION
Based on the information provided [here](https://github.com/springdoc/springdoc-openapi/issues/3180#issuecomment-3692486229) I believe it could be of interest to disable the creation of blank GitHub issues. This could guide the user better towards using the correct forum for the correct type of issue.

My change is taken from the [GitHub template guide](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).

To consider:
- The added starting `If the issue is NOT...` section could be considered superfluous/annoying, i.e., subject to removal
- `contact_links` from the template guide could potentially be used to convey the Stack Overflow information