### PR TITLE
Upgrade swagger-core from version 2.2.41 to 2.2.42

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<central-publishing-maven-plugin.version>0.7.0
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
-		<swagger-api.version>2.2.41</swagger-api.version>
+		<swagger-api.version>2.2.42</swagger-api.version>
 		<swagger-ui.version>5.31.0</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>

--- a/springdoc-openapi-starter-webflux-api/src/test/resources/results/3.0.1/app102.json
+++ b/springdoc-openapi-starter-webflux-api/src/test/resources/results/3.0.1/app102.json
@@ -32,6 +32,7 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           },

--- a/springdoc-openapi-starter-webflux-api/src/test/resources/results/3.1.0/app102.json
+++ b/springdoc-openapi-starter-webflux-api/src/test/resources/results/3.1.0/app102.json
@@ -32,7 +32,8 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app102.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app102.json
@@ -32,6 +32,7 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           },

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app105-4.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app105-4.json
@@ -35,6 +35,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app121.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app121.json
@@ -32,6 +32,7 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           },

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app14.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app14.json
@@ -50,6 +50,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-en-GB.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-en-GB.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-en-US.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-en-US.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-fr-FR.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app171-fr-FR.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app18.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app18.json
@@ -23,6 +23,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -54,6 +55,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -149,6 +151,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -180,6 +183,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app19.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app19.json
@@ -52,6 +52,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "minLength": 1,
                 "type": "string"
               }
             }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app209.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app209.json
@@ -23,6 +23,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -54,6 +55,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -149,6 +151,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -180,6 +183,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -201,3 +205,4 @@
   },
   "components": {}
 }
+ 

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app21.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app21.json
@@ -24,6 +24,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app23.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app23.json
@@ -24,6 +24,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-en-US.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-en-US.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-fr-CA.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-fr-CA.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-zh-CN.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app238-zh-CN.json
@@ -49,6 +49,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app24.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app24.json
@@ -30,6 +30,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app102.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app102.json
@@ -32,7 +32,8 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app105-4.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app105-4.json
@@ -35,7 +35,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app121.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app121.json
@@ -32,7 +32,8 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app14.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app14.json
@@ -50,7 +50,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-en-GB.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-en-GB.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-en-US.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-en-US.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-fr-FR.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app171-fr-FR.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app18.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app18.json
@@ -23,7 +23,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -54,7 +55,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -149,7 +151,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -180,7 +183,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app19.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app19.json
@@ -52,7 +52,8 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           },

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app209.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app209.json
@@ -23,7 +23,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -54,7 +55,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -149,7 +151,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -180,7 +183,8 @@
             "description": "persons name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app21.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app21.json
@@ -24,7 +24,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app23.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app23.json
@@ -24,7 +24,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-en-US.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-en-US.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-fr-CA.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-fr-CA.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-zh-CN.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app238-zh-CN.json
@@ -49,7 +49,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app24.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app24.json
@@ -30,7 +30,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/resources/results/3.0.1/app68-4.json
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/resources/results/3.0.1/app68-4.json
@@ -35,6 +35,7 @@
             "in": "query",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/resources/results/3.1.0/app68-4.json
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/src/test/resources/results/3.1.0/app68-4.json
@@ -35,7 +35,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.0.1/app18.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.0.1/app18.json
@@ -25,6 +25,7 @@
             "description": "Description for abc",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             },
             "example": "def"
@@ -69,6 +70,7 @@
             "description": "Description for abc",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             },
             "example": "def"

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app18.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app18.json
@@ -25,7 +25,8 @@
             "description": "Description for abc",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "example": "def"
           },
@@ -69,7 +70,8 @@
             "description": "Description for abc",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "example": "def"
           },

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/src/test/groovy/test/org/springdoc/api/v30/app2/CarController.groovy
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/src/test/groovy/test/org/springdoc/api/v30/app2/CarController.groovy
@@ -42,7 +42,7 @@ class CarController {
 	}
 
 	@GetMapping(path = '/cars')
-	List<test.org.springdoc.api.v30.app2.Car> getCars(@ParameterObject CarsFilter filter) {
+	List<Car> getCars(@ParameterObject CarsFilter filter) {
 		return carService.getCars()
 	}
 

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/src/test/groovy/test/org/springdoc/api/v31/app2/CarController.groovy
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/src/test/groovy/test/org/springdoc/api/v31/app2/CarController.groovy
@@ -35,14 +35,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 class CarController {
 
-	test.org.springdoc.api.v31.app2.CarService carService
+	CarService carService
 
-	CarController(test.org.springdoc.api.v31.app2.CarService carService) {
+	CarController(CarService carService) {
 		this.carService = carService
 	}
 
 	@GetMapping(path = '/cars')
-	List<test.org.springdoc.api.v31.app2.Car> getCars(@ParameterObject CarsFilter filter) {
+	List<Car> getCars(@ParameterObject CarsFilter filter) {
 		return carService.getCars()
 	}
 
@@ -51,7 +51,7 @@ class CarController {
 	}
 
 	@GetMapping(path = 'cars/{carId}')
-	test.org.springdoc.api.v31.app2.Car getCar(@PathVariable(value = 'carId') Long carId) {
+    Car getCar(@PathVariable(value = 'carId') Long carId) {
 		return carService.getCar(carId)
 	}
 }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app102.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app102.json
@@ -41,6 +41,7 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           },

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app105-4.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app105-4.json
@@ -38,6 +38,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app121.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app121.json
@@ -41,6 +41,7 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           },

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app14.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app14.json
@@ -54,6 +54,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app18.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app18.json
@@ -32,6 +32,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -50,80 +51,14 @@
         }
       }
     },
-    "/persons2": {
+    "/persons7": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 2 string.",
-        "description": "Persons 2 string.",
-        "operationId": "persons2",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "persons name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "the string",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/persons3": {
-      "get": {
-        "tags": [
-          "hello-controller"
-        ],
-        "summary": "Persons 3 string.",
-        "description": "Persons 3 string.",
-        "operationId": "persons3",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "persons name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "the string",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/persons4": {
-      "get": {
-        "tags": [
-          "hello-controller"
-        ],
-        "summary": "Persons 4 string.",
-        "description": "Persons 4 string.",
-        "operationId": "persons4",
+        "summary": "Persons 7 string.",
+        "description": "Persons 7 string.",
+        "operationId": "persons7",
         "parameters": [
           {
             "name": "age",
@@ -132,8 +67,43 @@
             "required": true,
             "schema": {
               "minimum": 0,
+              "exclusiveMinimum": true,
               "type": "integer",
               "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the string",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/persons6": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "Persons 6 string.",
+        "description": "Persons 6 string.",
+        "operationId": "persons6",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "persons name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "type": "string"
             }
           }
         ],
@@ -186,14 +156,49 @@
         }
       }
     },
-    "/persons6": {
+    "/persons4": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 6 string.",
-        "description": "Persons 6 string.",
-        "operationId": "persons6",
+        "summary": "Persons 4 string.",
+        "description": "Persons 4 string.",
+        "operationId": "persons4",
+        "parameters": [
+          {
+            "name": "age",
+            "in": "query",
+            "description": "the age",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the string",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/persons3": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "Persons 3 string.",
+        "description": "Persons 3 string.",
+        "operationId": "persons3",
         "parameters": [
           {
             "name": "name",
@@ -201,6 +206,7 @@
             "description": "persons name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }
@@ -219,25 +225,23 @@
         }
       }
     },
-    "/persons7": {
+    "/persons2": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 7 string.",
-        "description": "Persons 7 string.",
-        "operationId": "persons7",
+        "summary": "Persons 2 string.",
+        "description": "Persons 2 string.",
+        "operationId": "persons2",
         "parameters": [
           {
-            "name": "age",
+            "name": "name",
             "in": "query",
-            "description": "the age",
+            "description": "persons name",
             "required": true,
             "schema": {
-              "minimum": 0,
-              "exclusiveMinimum": true,
-              "type": "integer",
-              "format": "int32"
+              "minLength": 1,
+              "type": "string"
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app19.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app19.json
@@ -94,6 +94,7 @@
           "content": {
             "application/json": {
               "schema": {
+                "minLength": 1,
                 "type": "string"
               }
             }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app21.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app21.json
@@ -26,6 +26,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app23.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app23.json
@@ -32,6 +32,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app24.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app24.json
@@ -38,6 +38,7 @@
             "description": "the name",
             "required": true,
             "schema": {
+              "minLength": 1,
               "type": "string"
             }
           }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app102.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app102.json
@@ -41,7 +41,8 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app105-4.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app105-4.json
@@ -38,7 +38,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app121.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app121.json
@@ -41,7 +41,8 @@
             "description": "parameter from child of RequestParams",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           {

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app14.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app14.json
@@ -32,7 +32,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app18.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app18.json
@@ -32,7 +32,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -50,80 +51,14 @@
         }
       }
     },
-    "/persons2": {
+    "/persons7": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 2 string.",
-        "description": "Persons 2 string.",
-        "operationId": "persons2",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "persons name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "the string",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/persons3": {
-      "get": {
-        "tags": [
-          "hello-controller"
-        ],
-        "summary": "Persons 3 string.",
-        "description": "Persons 3 string.",
-        "operationId": "persons3",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "query",
-            "description": "persons name",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "the string",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/persons4": {
-      "get": {
-        "tags": [
-          "hello-controller"
-        ],
-        "summary": "Persons 4 string.",
-        "description": "Persons 4 string.",
-        "operationId": "persons4",
+        "summary": "Persons 7 string.",
+        "description": "Persons 7 string.",
+        "operationId": "persons7",
         "parameters": [
           {
             "name": "age",
@@ -133,7 +68,41 @@
             "schema": {
               "type": "integer",
               "format": "int32",
-              "minimum": 0
+              "exclusiveMinimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the string",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/persons6": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "Persons 6 string.",
+        "description": "Persons 6 string.",
+        "operationId": "persons6",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "persons name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
             }
           }
         ],
@@ -186,22 +155,24 @@
         }
       }
     },
-    "/persons6": {
+    "/persons4": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 6 string.",
-        "description": "Persons 6 string.",
-        "operationId": "persons6",
+        "summary": "Persons 4 string.",
+        "description": "Persons 4 string.",
+        "operationId": "persons4",
         "parameters": [
           {
-            "name": "name",
+            "name": "age",
             "in": "query",
-            "description": "persons name",
+            "description": "the age",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
             }
           }
         ],
@@ -219,24 +190,57 @@
         }
       }
     },
-    "/persons7": {
+    "/persons3": {
       "get": {
         "tags": [
           "hello-controller"
         ],
-        "summary": "Persons 7 string.",
-        "description": "Persons 7 string.",
-        "operationId": "persons7",
+        "summary": "Persons 3 string.",
+        "description": "Persons 3 string.",
+        "operationId": "persons3",
         "parameters": [
           {
-            "name": "age",
+            "name": "name",
             "in": "query",
-            "description": "the age",
+            "description": "persons name",
             "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "exclusiveMinimum": 0
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "the string",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/persons2": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "summary": "Persons 2 string.",
+        "description": "Persons 2 string.",
+        "operationId": "persons2",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "description": "persons name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app19.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app19.json
@@ -94,7 +94,8 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "string"
+                "type": "string",
+                "minLength": 1
               }
             }
           },

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app21.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app21.json
@@ -26,7 +26,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app23.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app23.json
@@ -32,7 +32,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app24.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app24.json
@@ -38,7 +38,8 @@
             "description": "the name",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           }
         ],


### PR DESCRIPTION
Upgrades swagger-core from version 2.2.41 to 2.2.42 to utilize the [fix](https://github.com/swagger-api/swagger-core/pull/5033) for reported issue https://github.com/springdoc/springdoc-openapi/issues/3191.