### PR TITLE
fix: add so that the type annotation is considered again if kotlin is not present

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
@@ -385,6 +385,8 @@ public class GenericParameterService {
 					type = restored;
 					typeAnnotations = ((Class<?>) type).getAnnotations();
 				}
+			} else {
+				typeAnnotations = methodParameter.getParameterType().getAnnotations();
 			}
 			Annotation[] mergedAnnotations =
 					Stream.concat(
@@ -394,7 +396,7 @@ public class GenericParameterService {
 			if (type instanceof Class && !((Class<?>) type).isEnum() && optionalWebConversionServiceProvider.isPresent()) {
 				WebConversionServiceProvider webConversionServiceProvider = optionalWebConversionServiceProvider.get();
 				if (!MethodParameterPojoExtractor.isSwaggerPrimitiveType((Class) type) && Arrays.stream(mergedAnnotations)
-								.noneMatch(a -> a.annotationType() == io.swagger.v3.oas.annotations.media.Schema.class)) {
+						.noneMatch(a -> a.annotationType() == io.swagger.v3.oas.annotations.media.Schema.class)) {
 					Class<?> springConvertedType = webConversionServiceProvider.getSpringConvertedType(methodParameter.getParameterType());
 					if (!(String.class.equals(springConvertedType) && ((Class<?>) type).isEnum()) && requestBodyInfo == null)
 						type = springConvertedType;

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/HelloController.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2025 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app248;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+public class HelloController {
+
+    @GetMapping(value = "/class-works/{regularSchema}")
+    public RegularSchema dataClass1(@PathVariable RegularSchema regularSchema) {
+        return null;
+    }
+
+    @GetMapping(value = "/class-works2/{pathSchema}")
+    public String dataClass2(@PathVariable PathSchema pathSchema) {
+        return null;
+    }
+
+    @GetMapping(value = "/class-works3/{itemId}")
+    public String dataClass3(@PathVariable ItemId itemId) {
+        return null;
+    }
+}
+
+@Schema(description = "regularSchema")
+record RegularSchema(String name, String value) {
+}
+
+@Schema(description = "pathSchema", example = "123")
+record PathSchema(UUID value) {
+}
+
+@Schema(
+        type = "uuid",
+        description = "Unique item identifier",
+        example = "9d9d46e5-d41c-4774-885d-8e9dbc67735c")
+record ItemId(UUID value) {
+
+    public static ItemId fromString(String uuid) {
+        return new ItemId(UUID.fromString(uuid));
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/ItemIdConverter.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/ItemIdConverter.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.v30.app248;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemIdConverter implements Converter<String, ItemId> {
+
+    @Override
+    public ItemId convert(String source) {
+        return ItemId.fromString(source);
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/SpringDocApp248Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app248/SpringDocApp248Test.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2025 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v30.app248;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v30.AbstractSpringDocV30Test;
+
+public class SpringDocApp248Test extends AbstractSpringDocV30Test {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/HelloController.java
@@ -1,0 +1,72 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2025 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *  
+ */
+
+package test.org.springdoc.api.v31.app248;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+public class HelloController {
+
+	@GetMapping(value = "/class-works/{regularSchema}")
+	public RegularSchema dataClass1(@PathVariable RegularSchema regularSchema) {
+		return null;
+	}
+
+	@GetMapping(value = "/class-works2/{pathSchema}")
+	public String dataClass2(@PathVariable PathSchema pathSchema) {
+		return null;
+	}
+
+	@GetMapping(value = "/class-works3/{itemId}")
+	public String dataClass3(@PathVariable ItemId itemId) {
+		return null;
+	}
+}
+
+@Schema(description = "regularSchema")
+record RegularSchema(String name, String value) {
+}
+
+@Schema(description = "pathSchema", example = "123")
+record PathSchema(UUID value) {
+}
+
+@Schema(
+		type = "uuid",
+		description = "Unique item identifier",
+		example = "9d9d46e5-d41c-4774-885d-8e9dbc67735c")
+record ItemId(UUID value) {
+
+	public static ItemId fromString(String uuid) {
+		return new ItemId(UUID.fromString(uuid));
+	}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/ItemIdConverter.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/ItemIdConverter.java
@@ -1,0 +1,13 @@
+package test.org.springdoc.api.v31.app248;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ItemIdConverter implements Converter<String, ItemId> {
+
+    @Override
+    public ItemId convert(String source) {
+        return ItemId.fromString(source);
+    }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/SpringDocApp248Test.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app248/SpringDocApp248Test.java
@@ -1,0 +1,10 @@
+package test.org.springdoc.api.v31.app248;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import test.org.springdoc.api.v31.AbstractSpringDocTest;
+
+public class SpringDocApp248Test extends AbstractSpringDocTest {
+
+	@SpringBootApplication
+	static class SpringDocTestApp {}
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app248.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app248.json
@@ -1,0 +1,121 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
+  },
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/class-works3/{itemId}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass3",
+        "parameters" : [ {
+          "name" : "itemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "format" : "uuid",
+            "description" : "Unique item identifier",
+            "example" : "9d9d46e5-d41c-4774-885d-8e9dbc67735c"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/class-works2/{pathSchema}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass2",
+        "parameters" : [ {
+          "name" : "pathSchema",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/PathSchema"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/class-works/{regularSchema}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass1",
+        "parameters" : [ {
+          "name" : "regularSchema",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/RegularSchema"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RegularSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "PathSchema" : {
+        "type" : "object",
+        "description" : "pathSchema",
+        "example" : 123,
+        "properties" : {
+          "value" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        }
+      },
+      "RegularSchema" : {
+        "type" : "object",
+        "description" : "regularSchema",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app248.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app248.json
@@ -1,0 +1,121 @@
+{
+  "openapi" : "3.1.0",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
+  },
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/class-works3/{itemId}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass3",
+        "parameters" : [ {
+          "name" : "itemId",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "format" : "uuid",
+            "description" : "Unique item identifier",
+            "example" : "9d9d46e5-d41c-4774-885d-8e9dbc67735c"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/class-works2/{pathSchema}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass2",
+        "parameters" : [ {
+          "name" : "pathSchema",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/PathSchema"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/class-works/{regularSchema}" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "dataClass1",
+        "parameters" : [ {
+          "name" : "regularSchema",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/components/schemas/RegularSchema"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/RegularSchema"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "PathSchema" : {
+        "type" : "object",
+        "description" : "pathSchema",
+        "example" : 123,
+        "properties" : {
+          "value" : {
+            "type" : "string",
+            "format" : "uuid"
+          }
+        }
+      },
+      "RegularSchema" : {
+        "type" : "object",
+        "description" : "regularSchema",
+        "properties" : {
+          "name" : {
+            "type" : "string"
+          },
+          "value" : {
+            "type" : "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #3213

The change in https://github.com/springdoc/springdoc-openapi/commit/0ed32afeeaa8f236a5a27ab50e4301b1eb39223a#diff-be80ed57071d5a58204a5cc398c2284ace48ff3e1c355f961e0fe9fcde987f94L372 from 
```java
(... && methodParameter.getParameterType().getAnnotation(io.swagger.v3.oas.annotations.media.Schema.class) == null) {
``` 
to 
```java
(... && Arrays.stream(mergedAnnotations)
    .noneMatch(a -> a.annotationType() == io.swagger.v3.oas.annotations.media.Schema.class)) {
```
Accidentally dropped the parameter type annotations when not using Kotlin (previously checked with `methodParameter.getParameterType()`). This PR reintroduce so that those annotations are also checked and considered again.