### PR TITLE
fix: PropertyResolverUtils retains a JsonNode when reading an ExtensionProperty annotation

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/PropertyResolverUtils.java
@@ -234,7 +234,12 @@ public class PropertyResolverUtils {
 					Map<String, Object> valueResolved = new HashMap<>();
 					valueAsMap.forEach((key1, value1) -> {
 						String key1Resolved = resolve(key1.toString(), locale);
-						String value1Resolved = resolve(value1.toString(), locale);
+						Object value1Resolved;
+						if (value1 instanceof String valueAsString) {
+							value1Resolved = resolve(valueAsString, locale);
+						} else {
+							value1Resolved = value1;
+						}
 						valueResolved.put(key1Resolved, value1Resolved);
 					});
 					extensionsResolved.put(keyResolved, valueResolved);

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app213/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app213/HelloController.java
@@ -31,8 +31,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 										name = "uri",
 										value = "${api.extensions.properties.uri}/testcontroller/getTest"),
 								@ExtensionProperty(name = "passthroughBehavior", value = "${api.extensions.properties.passthroughBehavior}"),
-								@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}") }) },
-
+								@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}")
+						})
+				},
 				title = "${api.info.title}",
 				version = "${api.info.version}",
 				description = "${api.info.description}",
@@ -57,7 +58,10 @@ public class HelloController {
 									name = "uri",
 									value = "${api.extensions.properties.uri}/testcontroller/getTest"),
 							@ExtensionProperty(name = "passthroughBehavior", value = "${api.extensions.properties.passthroughBehavior}"),
-							@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}") }) })
+							@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}") ,
+							@ExtensionProperty(name = "jsonProperty", parseValue = true, value = "{ \"key\": \"value\", \"key2\": \"value2\" }")
+					})
+			})
 
 	public PersonDTO queryMyDto() {
 		// This return a PageImpl with the data, the method parameter 'query' is a pojo containg filter properties

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app213/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app213/HelloController.java
@@ -31,8 +31,9 @@ import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 										name = "uri",
 										value = "${api.extensions.properties.uri}/testcontroller/getTest"),
 								@ExtensionProperty(name = "passthroughBehavior", value = "${api.extensions.properties.passthroughBehavior}"),
-								@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}") }) },
-
+								@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}")
+						})
+				},
 				title = "${api.info.title}",
 				version = "${api.info.version}",
 				description = "${api.info.description}",
@@ -57,7 +58,10 @@ public class HelloController {
 									name = "uri",
 									value = "${api.extensions.properties.uri}/testcontroller/getTest"),
 							@ExtensionProperty(name = "passthroughBehavior", value = "${api.extensions.properties.passthroughBehavior}"),
-							@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}") }) })
+							@ExtensionProperty(name = "connectionType", value = "${api.extensions.properties.connectionType}"),
+							@ExtensionProperty(name = "jsonProperty", parseValue = true, value = "{ \"key\": \"value\", \"key2\": \"value2\" }")
+					})
+			})
 
 	public PersonDTO queryMyDto() {
 		// This return a PageImpl with the data, the method parameter 'query' is a pojo containg filter properties

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app213.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app213.json
@@ -53,7 +53,11 @@
           "type": "http_proxy",
           "httpMethod": "GET",
           "uri": "http://my-vpc/nlb-link/testcontroller/getTest",
-          "connectionType": "VPC_LINK"
+          "connectionType": "VPC_LINK",
+          "jsonProperty" : {
+            "key" : "value",
+            "key2" : "value2"
+          }
         }
       }
     }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app213.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app213.json
@@ -53,7 +53,11 @@
           "type": "http_proxy",
           "httpMethod": "GET",
           "uri": "http://my-vpc/nlb-link/testcontroller/getTest",
-          "connectionType": "VPC_LINK"
+          "connectionType": "VPC_LINK",
+          "jsonProperty" : {
+            "key" : "value",
+            "key2" : "value2"
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes #3234 as per the suggestion provided in the issue.