### PR TITLE
Preserve YAML group URLs in Swagger UI

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerWelcome.java
@@ -107,8 +107,8 @@ public abstract class AbstractSwaggerWelcome {
 		if (StringUtils.isEmpty(swaggerUiConfig.getConfigUrl())) {
 			buildApiDocUrl(swaggerUiConfigParameters);
 			buildSwaggerConfigUrl(swaggerUiConfigParameters);
+			String swaggerUiUrl = swaggerUiConfig.getUrl();
 			if (CollectionUtils.isEmpty(swaggerUiConfigParameters.getUrls())) {
-				String swaggerUiUrl = swaggerUiConfig.getUrl();
 				if (StringUtils.isEmpty(swaggerUiUrl))
 					swaggerUiConfigParameters.setUrl(swaggerUiConfigParameters.getApiDocsUrl());
 				else if (swaggerUiConfigParameters.isValidUrl(swaggerUiUrl))
@@ -117,7 +117,7 @@ public abstract class AbstractSwaggerWelcome {
 					swaggerUiConfigParameters.setUrl(buildUrlWithContextPath(swaggerUiConfigParameters, swaggerUiUrl));
 			}
 			else
-				swaggerUiConfigParameters.addUrl(swaggerUiConfigParameters.getApiDocsUrl());
+				swaggerUiConfigParameters.addUrl(resolveGroupedApiDocsUrl(swaggerUiConfigParameters, swaggerUiUrl));
 			if (!CollectionUtils.isEmpty(swaggerUiConfig.getUrls())) {
 				swaggerUiConfig.cloneUrls()
 						.stream()
@@ -134,6 +134,16 @@ public abstract class AbstractSwaggerWelcome {
 			}
 		}
 		calculateOauth2RedirectUrl(swaggerUiConfigParameters, uriComponentsBuilder);
+	}
+
+	private String resolveGroupedApiDocsUrl(SwaggerUiConfigParameters swaggerUiConfigParameters, String swaggerUiUrl) {
+		if (StringUtils.isEmpty(swaggerUiUrl)) {
+			return swaggerUiConfigParameters.getApiDocsUrl();
+		}
+		if (swaggerUiConfigParameters.isValidUrl(swaggerUiUrl)) {
+			return swaggerUiUrl;
+		}
+		return buildUrlWithContextPath(swaggerUiConfigParameters, swaggerUiUrl);
 	}
 
 	/**

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app40/SpringDocApp40Test.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app40/SpringDocApp40Test.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2019-2026 the original author or authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package test.org.springdoc.ui.app40;
+
+import org.junit.jupiter.api.Test;
+import test.org.springdoc.ui.AbstractSpringDocTest;
+
+import org.springframework.test.context.TestPropertySource;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@TestPropertySource(properties = {
+		"springdoc.swagger-ui.url=/v3/api-docs.yaml",
+		"springdoc.swagger-ui.urlsPrimaryName=pets"
+})
+public class SpringDocApp40Test extends AbstractSpringDocTest {
+
+	@Test
+	void swagger_config_preserves_yaml_urls_for_multiple_groups() throws Exception {
+		mockMvc.perform(get("/v3/api-docs/swagger-config"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("configUrl", equalTo("/v3/api-docs/swagger-config")))
+				.andExpect(jsonPath("url", equalTo("/v3/api-docs.yaml")))
+				.andExpect(jsonPath("urls[0].url", equalTo("/v3/api-docs.yaml/stores")))
+				.andExpect(jsonPath("urls[0].name", equalTo("stores")))
+				.andExpect(jsonPath("urls[1].url", equalTo("/v3/api-docs.yaml/pets")))
+				.andExpect(jsonPath("urls[1].name", equalTo("zpets")))
+				.andExpect(jsonPath("$['urls.primaryName']", equalTo("pets")));
+	}
+}

--- a/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app40/SpringDocTestApp.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/test/java/test/org/springdoc/ui/app40/SpringDocTestApp.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.ui.app40;
+
+import org.springdoc.core.models.GroupedOpenApi;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+@SpringBootApplication
+public class SpringDocTestApp {
+
+	@Bean
+	public GroupedOpenApi storeOpenApi() {
+		return GroupedOpenApi.builder()
+				.group("stores")
+				.pathsToMatch("/store/**")
+				.build();
+	}
+
+	@Bean
+	public GroupedOpenApi groupOpenApi() {
+		return GroupedOpenApi.builder()
+				.group("pets")
+				.displayName("zpets")
+				.pathsToMatch("/pet/**")
+				.build();
+	}
+}


### PR DESCRIPTION
Fixes #3241

This preserves the resolved API docs path, including the `.yaml` suffix, when Springdoc builds grouped Swagger UI URLs.

It also adds a regression test covering `springdoc.api-docs.path=/v3/api-docs.yaml` with grouped endpoints.

Tests:
- `SpringDocApp40Test`
- `SpringDocApp4Test`
- `SpringDocApp8Test`
- `SpringDocSwaggerUiUrlPropertyTest`
- `SpringDocApp29Test`