### PR TITLE
fix: skip url param when urls already populated to fix BaseLayout + GroupedOpenApi break (fixes #3243)

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigParameters.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigParameters.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.springdoc.core.utils.SpringDocPropertiesUtils;
 import org.springframework.util.CollectionUtils;
 
 import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
@@ -289,7 +290,8 @@ public class SwaggerUiConfigParameters extends AbstractSwaggerUiConfigProperties
 		if (supportedSubmitMethods != null)
 			org.springdoc.core.utils.SpringDocPropertiesUtils.put("supportedSubmitMethods", supportedSubmitMethods, params);
 		org.springdoc.core.utils.SpringDocPropertiesUtils.put(OAUTH2_REDIRECT_URL_PROPERTY, oauth2RedirectUrl, params);
-		org.springdoc.core.utils.SpringDocPropertiesUtils.put(URL_PROPERTY, url, params);
+		if (CollectionUtils.isEmpty(urls))
+			org.springdoc.core.utils.SpringDocPropertiesUtils.put(URL_PROPERTY, url, params);
 		put(URLS_PROPERTY, urls, params);
 		org.springdoc.core.utils.SpringDocPropertiesUtils.put("urls.primaryName", urlsPrimaryName, params);
 		org.springdoc.core.utils.SpringDocPropertiesUtils.put(TRY_IT_ENABLED_PROPERTY, tryItOutEnabled, params);


### PR DESCRIPTION
## Description

When `springdoc.swagger-ui.layout=BaseLayout` is set alongside `GroupedOpenApi` beans, swagger-ui renders "No API definition provided."

### Root cause

In `SwaggerUiConfigParameters#getConfigParameters()`, the single `url` property is unconditionally written into the config params map even when the `urls` array is already populated by group definitions. swagger-ui treats a non-null `url` as the primary source and ignores `urls`, so no API definition is found.

### Fix

Guard the `URL_PROPERTY` write behind a `CollectionUtils.isEmpty(urls)` check so it is only emitted when no grouped URLs are present. This restores correct behaviour for both single-api (url) and multi-group (urls) setups regardless of the `layout` property.

Fixes #3243

## Changes made
- `SwaggerUiConfigParameters.java`: wrap `SpringDocPropertiesUtils.put(URL_PROPERTY, ...)` in an `if (CollectionUtils.isEmpty(urls))` guard

## How has this been tested?
- Reproduced the bug locally with `springdoc.swagger-ui.layout=BaseLayout` + two `GroupedOpenApi` beans
- Confirmed swagger-ui loads correctly after the fix
- Confirmed single-API setup (no groups, layout=BaseLayout) still works — url is still emitted
- Ran `./mvnw verify` — all existing tests pass

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code so it is easy to understand
- [x] My changes generate no new warnings
- [x] No new dependencies introduced