### PR TITLE
Direction enum:  fixed visibility scope of group order so that setGroupsOrder method can be used

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/AbstractSwaggerUiConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/AbstractSwaggerUiConfigProperties.java
@@ -698,7 +698,7 @@ public abstract class AbstractSwaggerUiConfigProperties {
 	/**
 	 * The enum Direction.
 	 */
-	enum Direction {
+	public enum Direction {
 		/**
 		 * Asc direction.
 		 */


### PR DESCRIPTION
Make Direction Enum **public**, so we can change group direction programmatically.
Direction is not visible outside the package **org.springdoc.core.properties**