### PR TITLE
feat: auto-set nullable: true for Kotlin nullable types in schema properties

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
@@ -28,6 +28,7 @@ package org.springdoc.core.configuration
 
 import org.springdoc.core.converters.KotlinInlineClassUnwrappingConverter
 import org.springdoc.core.customizers.KotlinDeprecatedPropertyCustomizer
+import org.springdoc.core.customizers.KotlinNullablePropertyCustomizer
 import org.springdoc.core.providers.ObjectMapperProvider
 import org.springdoc.core.utils.Constants
 import org.springdoc.core.utils.SpringDocKotlinUtils
@@ -75,6 +76,13 @@ class SpringDocKotlinConfiguration() {
 		@ConditionalOnMissingBean
 		fun kotlinDeprecatedPropertyCustomizer(objectMapperProvider: ObjectMapperProvider): KotlinDeprecatedPropertyCustomizer {
 			return KotlinDeprecatedPropertyCustomizer(objectMapperProvider)
+		}
+
+		@Bean
+		@Lazy(false)
+		@ConditionalOnMissingBean
+		fun kotlinNullablePropertyCustomizer(objectMapperProvider: ObjectMapperProvider): KotlinNullablePropertyCustomizer {
+			return KotlinNullablePropertyCustomizer(objectMapperProvider)
 		}
 
 		@Bean

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/KotlinNullablePropertyCustomizer.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/KotlinNullablePropertyCustomizer.kt
@@ -1,0 +1,92 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package org.springdoc.core.customizers
+
+import com.fasterxml.jackson.databind.JavaType
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverter
+import io.swagger.v3.core.converter.ModelConverterContext
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.media.Schema
+import org.springdoc.core.providers.ObjectMapperProvider
+import kotlin.reflect.full.memberProperties
+
+/**
+ * Sets `nullable: true` on schema properties for Kotlin data class fields
+ * whose return type is marked nullable (`Type?`).
+ *
+ * Springdoc already uses Kotlin nullability to determine the `required` list
+ * (via [org.springdoc.core.utils.SchemaUtils.fieldRequired]), but does not set
+ * `nullable: true` on the property schema itself. This causes OpenAPI client
+ * generators (e.g., fabrikt) to produce non-null types with null defaults,
+ * which fails compilation in Kotlin.
+ *
+ * See: https://github.com/springdoc/springdoc-openapi/issues/906
+ *
+ * @author Jeffrey Blayney
+ */
+class KotlinNullablePropertyCustomizer(
+	private val objectMapperProvider: ObjectMapperProvider
+) : ModelConverter {
+
+	override fun resolve(
+		type: AnnotatedType,
+		context: ModelConverterContext,
+		chain: Iterator<ModelConverter>
+	): Schema<*>? {
+		if (!chain.hasNext()) return null
+		val resolvedSchema = chain.next().resolve(type, context, chain)
+
+		val javaType: JavaType =
+			objectMapperProvider.jsonMapper().constructType(type.type)
+		if (javaType.rawClass.packageName.startsWith("java.")) {
+			return resolvedSchema
+		}
+
+		val kotlinClass = try {
+			javaType.rawClass.kotlin
+		} catch (_: Throwable) {
+			return resolvedSchema
+		}
+
+		for (prop in kotlinClass.memberProperties) {
+			if (prop.returnType.isMarkedNullable) {
+				val fieldName = prop.name
+				if (resolvedSchema != null && resolvedSchema.`$ref` != null) {
+					val schema =
+						context.getDefinedModels()[resolvedSchema.`$ref`.substring(
+							Components.COMPONENTS_SCHEMAS_REF.length
+						)]
+					schema?.properties?.get(fieldName)?.nullable = true
+				} else {
+					resolvedSchema?.properties?.get(fieldName)?.nullable = true
+				}
+			}
+		}
+		return resolvedSchema
+	}
+}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/KotlinNullablePropertyCustomizer.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/KotlinNullablePropertyCustomizer.kt
@@ -31,19 +31,20 @@ import io.swagger.v3.core.converter.AnnotatedType
 import io.swagger.v3.core.converter.ModelConverter
 import io.swagger.v3.core.converter.ModelConverterContext
 import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.SpecVersion
 import io.swagger.v3.oas.models.media.Schema
 import org.springdoc.core.providers.ObjectMapperProvider
 import kotlin.reflect.full.memberProperties
 
 /**
- * Sets `nullable: true` on schema properties for Kotlin data class fields
- * whose return type is marked nullable (`Type?`).
+ * Marks schema properties as nullable for Kotlin data class fields whose
+ * return type is marked nullable (`Type?`).
  *
- * Springdoc already uses Kotlin nullability to determine the `required` list
- * (via [org.springdoc.core.utils.SchemaUtils.fieldRequired]), but does not set
- * `nullable: true` on the property schema itself. This causes OpenAPI client
- * generators (e.g., fabrikt) to produce non-null types with null defaults,
- * which fails compilation in Kotlin.
+ * Handles both OAS 3.0 and OAS 3.1 nullable semantics:
+ * - **OAS 3.0**: Sets `nullable: true` on the property. For `$ref` properties,
+ *   wraps in `allOf` since `$ref` and `nullable` are mutually exclusive.
+ * - **OAS 3.1**: Adds `"null"` to the `type` array. For `$ref` properties,
+ *   wraps in `oneOf` with a `type: "null"` alternative.
  *
  * See: https://github.com/springdoc/springdoc-openapi/issues/906
  *
@@ -73,20 +74,68 @@ class KotlinNullablePropertyCustomizer(
 			return resolvedSchema
 		}
 
+		val targetSchema = if (resolvedSchema != null && resolvedSchema.`$ref` != null) {
+			context.getDefinedModels()[resolvedSchema.`$ref`.substring(Components.COMPONENTS_SCHEMAS_REF.length)]
+		} else {
+			resolvedSchema
+		}
+
+		if (targetSchema?.properties == null) return resolvedSchema
+
+		val specVersion = targetSchema.specVersion ?: SpecVersion.V30
+
+		val replacements = mutableMapOf<String, Schema<*>>()
 		for (prop in kotlinClass.memberProperties) {
-			if (prop.returnType.isMarkedNullable) {
-				val fieldName = prop.name
-				if (resolvedSchema != null && resolvedSchema.`$ref` != null) {
-					val schema =
-						context.getDefinedModels()[resolvedSchema.`$ref`.substring(
-							Components.COMPONENTS_SCHEMAS_REF.length
-						)]
-					schema?.properties?.get(fieldName)?.nullable = true
-				} else {
-					resolvedSchema?.properties?.get(fieldName)?.nullable = true
-				}
+			if (!prop.returnType.isMarkedNullable) continue
+			val fieldName = prop.name
+			val property = targetSchema.properties[fieldName] ?: continue
+
+			if (property.`$ref` != null) {
+				replacements[fieldName] = wrapRefNullable(property.`$ref`, specVersion)
+			} else {
+				markNullable(property, specVersion)
 			}
 		}
+
+		replacements.forEach { (name, wrapper) ->
+			targetSchema.properties[name] = wrapper
+		}
+
 		return resolvedSchema
+	}
+
+	/**
+	 * Marks a non-$ref property as nullable.
+	 * - OAS 3.0: `nullable: true`
+	 * - OAS 3.1: adds `"null"` to the `types` set
+	 */
+	private fun markNullable(property: Schema<*>, specVersion: SpecVersion) {
+		if (specVersion == SpecVersion.V31) {
+			val currentTypes = property.types ?: property.type?.let { setOf(it) } ?: emptySet()
+			if ("null" !in currentTypes) {
+				property.types = currentTypes + "null"
+			}
+		} else {
+			property.nullable = true
+		}
+	}
+
+	/**
+	 * Wraps a $ref in a nullable composite schema.
+	 * - OAS 3.0: `{ nullable: true, allOf: [{ $ref: "..." }] }`
+	 * - OAS 3.1: `{ oneOf: [{ $ref: "..." }, { type: "null" }] }`
+	 */
+	private fun wrapRefNullable(ref: String, specVersion: SpecVersion): Schema<*> {
+		val refSchema = Schema<Any>().apply { `$ref` = ref }
+		return if (specVersion == SpecVersion.V31) {
+			Schema<Any>().apply {
+				oneOf = listOf(refSchema, Schema<Any>().apply { addType("null") })
+			}
+		} else {
+			Schema<Any>().apply {
+				nullable = true
+				allOf = listOf(refSchema)
+			}
+		}
 	}
 }

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app18/NullableController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app18/NullableController.kt
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.v30.app18
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+data class NullableFieldsResponse(
+	val requiredField: String,
+	val nullableString: String? = null,
+	val nullableInt: Int? = null,
+	val nullableNested: NestedObject? = null,
+)
+
+data class NestedObject(
+	val name: String,
+	val description: String? = null,
+)
+
+@RestController
+class NullableController {
+	@GetMapping("/nullable")
+	fun getNullableFields(): NullableFieldsResponse =
+		NullableFieldsResponse(requiredField = "hello")
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app18/SpringDocApp18Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app18/SpringDocApp18Test.kt
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.v30.app18
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import test.org.springdoc.api.v30.AbstractKotlinSpringDocMVCTest
+
+class SpringDocApp18Test : AbstractKotlinSpringDocMVCTest() {
+
+	@SpringBootApplication
+	@ComponentScan(basePackages = ["org.springdoc", "test.org.springdoc.api.v30.app18"])
+	class DemoApplication
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app23/NullableController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app23/NullableController.kt
@@ -1,0 +1,23 @@
+package test.org.springdoc.api.v31.app23
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+data class NullableFieldsResponse(
+	val requiredField: String,
+	val nullableString: String? = null,
+	val nullableInt: Int? = null,
+	val nullableNested: NestedObject? = null,
+)
+
+data class NestedObject(
+	val name: String,
+	val description: String? = null,
+)
+
+@RestController
+class NullableController {
+	@GetMapping("/nullable")
+	fun getNullableFields(): NullableFieldsResponse =
+		NullableFieldsResponse(requiredField = "hello")
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app23/SpringDocApp23Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app23/SpringDocApp23Test.kt
@@ -1,0 +1,12 @@
+package test.org.springdoc.api.v31.app23
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import test.org.springdoc.api.v31.AbstractKotlinSpringDocMVCTest
+
+class SpringDocApp23Test : AbstractKotlinSpringDocMVCTest() {
+
+	@SpringBootApplication
+	@ComponentScan(basePackages = ["org.springdoc", "test.org.springdoc.api.v31.app23"])
+	class DemoApplication
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.0.1/app18.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.0.1/app18.json
@@ -1,0 +1,78 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/nullable": {
+      "get": {
+        "tags": [
+          "nullable-controller"
+        ],
+        "operationId": "getNullableFields",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NullableFieldsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NestedObject": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "NullableFieldsResponse": {
+        "required": [
+          "requiredField"
+        ],
+        "type": "object",
+        "properties": {
+          "requiredField": {
+            "type": "string"
+          },
+          "nullableString": {
+            "type": "string",
+            "nullable": true
+          },
+          "nullableInt": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "nullableNested": {
+            "nullable": true,
+            "$ref": "#/components/schemas/NestedObject"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.1.0/app23.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.1.0/app23.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "info": {
     "title": "OpenAPI definition",
     "version": "v0"
@@ -35,47 +35,55 @@
   "components": {
     "schemas": {
       "NestedObject": {
-        "required": [
-          "name"
-        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "description": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           }
-        }
+        },
+        "required": [
+          "name"
+        ]
       },
       "NullableFieldsResponse": {
-        "required": [
-          "requiredField"
-        ],
         "type": "object",
         "properties": {
           "requiredField": {
             "type": "string"
           },
           "nullableString": {
-            "type": "string",
-            "nullable": true
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "nullableInt": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
           },
           "nullableNested": {
-            "nullable": true,
-            "allOf": [
+            "oneOf": [
               {
                 "$ref": "#/components/schemas/NestedObject"
+              },
+              {
+                "type": "null"
               }
             ]
           }
-        }
+        },
+        "required": [
+          "requiredField"
+        ]
       }
     }
   }


### PR DESCRIPTION
## Problem

Springdoc correctly uses Kotlin reflection (`isMarkedNullable()` via `SpringDocKotlinUtils.kotlinNullability()`) to detect nullable types for the **required list** — nullable fields are excluded from `required` in `SchemaUtils.fieldRequired()`. However, it does **not** mark the property schema itself as nullable.

This causes OpenAPI client generators (e.g., [fabrikt](https://github.com/cjbooms/fabrikt), openapi-generator) to produce non-null types with null defaults when generating Kotlin clients, which fails compilation:

```kotlin
// Generated by fabrikt from a springdoc-produced spec:
data class MyModel(
    val optionalField: String = null  // ERROR: Null cannot be a value of a non-null type 'String'
)
```

## Solution

Adds `KotlinNullablePropertyCustomizer` — a `ModelConverter` that inspects Kotlin data class properties via `kotlin-reflect` and marks nullable properties in the schema.

Handles both OAS versions:

### OAS 3.0 (`nullable: true`)

Simple types:
```json
{ "type": "string", "nullable": true }
```

`$ref` types use `allOf` wrapper (since `$ref` and `nullable` are mutually exclusive siblings in OAS 3.0):
```json
{ "nullable": true, "allOf": [{ "$ref": "#/components/schemas/NestedObject" }] }
```

### OAS 3.1 (`type` arrays)

Simple types:
```json
{ "type": ["string", "null"] }
```

`$ref` types use `oneOf`:
```json
{ "oneOf": [{ "$ref": "#/components/schemas/NestedObject" }, { "type": "null" }] }
```

The `ModelConverter` detects the spec version from `schema.specVersion` and applies the correct strategy.

### Changes

| File | Change |
|------|--------|
| `KotlinNullablePropertyCustomizer.kt` | New — marks nullable Kotlin properties in schema, handles both OAS 3.0 and 3.1 |
| `SpringDocKotlinConfiguration.kt` | Registers `KotlinNullablePropertyCustomizer` bean |
| `v30/app18/` | OAS 3.0 test — controller with nullable fields, expected snapshot with `nullable: true` and `allOf` wrapping |
| `v31/app23/` | OAS 3.1 test — same controller, expected snapshot with `type` arrays and `oneOf` wrapping |

Auto-registered in `SpringDocKotlinConfiguration.KotlinReflectDependingConfiguration` when `kotlin-reflect` is on the classpath, following the same pattern as the existing `KotlinDeprecatedPropertyCustomizer`.

### Test

Tests verify that a controller returning a data class with nullable fields produces a spec where:
- Non-nullable fields (`requiredField: String`) are in the `required` list and NOT marked nullable
- Nullable primitive fields (`nullableString: String?`, `nullableInt: Int?`) are marked nullable
- Nullable `$ref` fields (`nullableNested: NestedObject?`) are wrapped appropriately for each OAS version

Fixes #906