### PR TITLE
ConditionalOnClass (HateoasProperties.class) in SpringDocHateoasConfiguration

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocHateoasConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocHateoasConfiguration.java
@@ -56,7 +56,7 @@ import org.springframework.hateoas.server.LinkRelationProvider;
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-hateoas:true}")
-@ConditionalOnClass(LinkRelationProvider.class)
+@ConditionalOnClass({LinkRelationProvider.class, HateoasProperties.class})
 @ConditionalOnWebApplication
 @ConditionalOnBean(SpringDocConfiguration.class)
 public class SpringDocHateoasConfiguration {


### PR DESCRIPTION
## Problem statement

`SpringDocHateoasConfiguration` auto-configurations fails in case of combination when `org.springframework.hateoas:spring-hateoas` is present in the classpath (checked via existing `@ConditionalOnClass(LinkRelationProvider.class)`), but `org.springframework.boot.hateoas.autoconfigure.HateoasProperties` from `org.springframework.boot:spring-boot-hateoas` (since 4.0.x) is not on the classpath.

The failure is
```
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 
'hateoasHalProvider' defined in class path resource [org/springdoc/core/configuration/SpringDocHateoasConfiguration.class]: 
Unexpected exception during bean creation
...
Caused by: java.lang.TypeNotPresentException: Type org.springframework.boot.hateoas.autoconfigure.HateoasProperties not present
...
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.hateoas.autoconfigure.HateoasProperties
```

## Proposed solution
Add missing `@ConditionalOnClass(HateoasProperties.class)`