### PR TITLE
Fix version mismatch in springdoc-openapi-tests: update sub-modules to 2.8.18-SNAPSHOT

### DIFF
--- a/springdoc-openapi-tests/pom.xml
+++ b/springdoc-openapi-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modelVersion>4.0.0</modelVersion>

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-data-rest-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-groovy-tests</artifactId>
 	<name>${project.artifactId}</name>

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-hateoas-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webflux-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webmvc-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-security-tests</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
## Summary

Fixes #3261

The `springdoc-openapi-tests` module and all its sub-modules (11 total) were 
still referencing `2.8.17-SNAPSHOT` as their parent POM version after the 
root was bumped to `2.8.18-SNAPSHOT`. This caused the entire build to fail 
immediately for anyone cloning the repo fresh.

## Changes

Updated the `<version>` tag inside `<parent>` block from `2.8.17-SNAPSHOT` 
to `2.8.18-SNAPSHOT` in all affected modules under `springdoc-openapi-tests/`.

## Testing

Verified full build passes after fix:

mvn clean install -DskipTests
[INFO] BUILD SUCCESS — 21 modules built in 22s

## Affected Files

- springdoc-openapi-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
- springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
