### PR TITLE
Upgrade swagger-core from version 2.2.47 to 2.2.48

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<central-publishing-maven-plugin.version>0.7.0
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
-		<swagger-api.version>2.2.47</swagger-api.version>
+		<swagger-api.version>2.2.48</swagger-api.version>
 		<swagger-ui.version>5.32.2</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocRequiredModule.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocRequiredModule.java
@@ -57,7 +57,7 @@ public class SpringDocRequiredModule extends SimpleModule {
 				if (schemaAnnotation.required() || requiredMode == Schema.RequiredMode.REQUIRED) {
 					return true;
 				}
-				else if (requiredMode == Schema.RequiredMode.NOT_REQUIRED || (StringUtils.isNotEmpty(schemaAnnotation.defaultValue()) && !Schema.DEFAULT_SENTINEL.equals(schemaAnnotation.defaultValue()))) {
+				else if (requiredMode == Schema.RequiredMode.NOT_REQUIRED || StringUtils.isNotEmpty(schemaAnnotation.defaultValue())) {
 					return false;
 				}
 			}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/DataRestDelegatingMethodParameterCustomizer.java
@@ -366,8 +366,7 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 
 						@Override
 						public String defaultValue() {
-							String defaultValue = getDefaultValue(parameterName, pageableDefault, parameterSchema.defaultValue());
-						return defaultValue != null ? defaultValue : io.swagger.v3.oas.annotations.media.Schema.DEFAULT_SENTINEL;
+							return getDefaultValue(parameterName, pageableDefault, parameterSchema.defaultValue());
 						}
 
 						@Override
@@ -758,8 +757,7 @@ public class DataRestDelegatingMethodParameterCustomizer implements DelegatingMe
 
 								@Override
 								public String defaultValue() {
-									String defaultValue = getArrayDefaultValue(parameterName, pageableDefault, sortDefault, schema.defaultValue());
-									return defaultValue != null ? defaultValue : io.swagger.v3.oas.annotations.media.Schema.DEFAULT_SENTINEL;
+									return getArrayDefaultValue(parameterName, pageableDefault, sortDefault, schema.defaultValue());
 								}
 
 								@Override

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/builders/schema/Builder.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/builders/schema/Builder.java
@@ -197,7 +197,7 @@ public class Builder {
 	/**
 	 * Provides a default value.
 	 */
-	private String defaultValue = Schema.DEFAULT_SENTINEL;
+	private String defaultValue = "";
 
 	/**
 	 * Provides a discriminator property value.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocAnnotationsUtils.java
@@ -504,7 +504,7 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 	 */
 	public static Object resolveDefaultValue(String defaultValueStr, ObjectMapper objectMapper) {
 		Object defaultValue = null;
-		if (StringUtils.isNotEmpty(defaultValueStr) && !io.swagger.v3.oas.annotations.media.Schema.DEFAULT_SENTINEL.equals(defaultValueStr)) {
+		if (StringUtils.isNotEmpty(defaultValueStr)) {
 			try {
 				defaultValue = objectMapper.readTree(defaultValueStr);
 			}

--- a/springdoc-openapi-tests/pom.xml
+++ b/springdoc-openapi-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modelVersion>4.0.0</modelVersion>

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-data-rest-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-groovy-tests</artifactId>
 	<name>${project.artifactId}</name>

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-hateoas-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webflux-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webmvc-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-security-tests</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
Changes are from [swagger-core reverting their change to the representation of an empty default value.](https://github.com/swagger-api/swagger-core/commit/935d6c4dd56899e7022d79381cdbfb9157bbba4a)