### PR TITLE
Add mechanism to disable nullable for Kotlin properties

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
@@ -81,6 +81,7 @@ class SpringDocKotlinConfiguration() {
 		@Bean
 		@Lazy(false)
 		@ConditionalOnMissingBean
+		@ConditionalOnProperty(name = [Constants.SPRINGDOC_KOTLIN_NULLABLE_PROPERTY_CUSTOMIZER_ENABLED], matchIfMissing = true)
 		fun kotlinNullablePropertyCustomizer(objectMapperProvider: ObjectMapperProvider): KotlinNullablePropertyCustomizer {
 			return KotlinNullablePropertyCustomizer(objectMapperProvider)
 		}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/Constants.java
@@ -107,6 +107,11 @@ public final class Constants {
 	public static final String SPRINGDOC_POLYMORPHIC_CONVERTER_ENABLED = "springdoc.model-converters.polymorphic-converter.enabled";
 
 	/**
+	 * The constant SPRINGDOC_KOTLIN_NULLABLE_PROPERTY_CUSTOMIZER_ENABLED.
+	 */
+	public static final String SPRINGDOC_KOTLIN_NULLABLE_PROPERTY_CUSTOMIZER_ENABLED = "springdoc.model-converters.kotlin-nullable-property-customizer.enabled";
+
+	/**
 	 * The constant SPRINGDOC_SCHEMA_RESOLVE_PROPERTIES.
 	 */
 	public static final String SPRINGDOC_SCHEMA_RESOLVE_PROPERTIES = "springdoc.api-docs.resolve-schema-properties";

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app19/NullableController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app19/NullableController.kt
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.v30.app19
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+data class NullableFieldsResponse(
+    val requiredField: String,
+    val nullableString: String? = null,
+    val nullableInt: Int? = null,
+    val nullableNested: NestedObject? = null,
+)
+
+data class NestedObject(
+    val name: String,
+    val description: String? = null,
+)
+
+@RestController
+class NullableController {
+    @GetMapping("/nullable")
+    fun getNullableFields(): NullableFieldsResponse = NullableFieldsResponse(requiredField = "hello")
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app19/SpringDocApp19Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v30/app19/SpringDocApp19Test.kt
@@ -1,0 +1,31 @@
+package test.org.springdoc.api.v30.app19
+
+import io.swagger.v3.core.converter.ModelConverters
+import org.springdoc.core.customizers.KotlinNullablePropertyCustomizer
+import org.springdoc.core.utils.Constants
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.test.context.TestPropertySource
+import test.org.springdoc.api.v30.AbstractKotlinSpringDocMVCTest
+
+@TestPropertySource(
+    properties = [
+        "springdoc.api-docs.version=openapi_3_0", Constants.SPRINGDOC_KOTLIN_NULLABLE_PROPERTY_CUSTOMIZER_ENABLED +
+            "=false",
+    ],
+)
+class SpringDocApp19Test : AbstractKotlinSpringDocMVCTest() {
+    companion object {
+        init {
+            ModelConverters
+                .getInstance(false)
+                .getConverters()
+                .filterIsInstance<KotlinNullablePropertyCustomizer>()
+                .forEach { ModelConverters.getInstance(false).removeConverter(it) }
+        }
+    }
+
+    @SpringBootApplication
+    @ComponentScan(basePackages = ["org.springdoc", "test.org.springdoc.api.v30.app19"])
+    class DemoApplication
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app24/NullableController.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app24/NullableController.kt
@@ -1,0 +1,22 @@
+package test.org.springdoc.api.v31.app24
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+data class NullableFieldsResponse(
+    val requiredField: String,
+    val nullableString: String? = null,
+    val nullableInt: Int? = null,
+    val nullableNested: NestedObject? = null,
+)
+
+data class NestedObject(
+    val name: String,
+    val description: String? = null,
+)
+
+@RestController
+class NullableController {
+    @GetMapping("/nullable")
+    fun getNullableFields(): NullableFieldsResponse = NullableFieldsResponse(requiredField = "hello")
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app24/SpringDocApp24Test.kt
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/kotlin/test/org/springdoc/api/v31/app24/SpringDocApp24Test.kt
@@ -1,0 +1,26 @@
+package test.org.springdoc.api.v31.app24
+
+import io.swagger.v3.core.converter.ModelConverters
+import org.springdoc.core.customizers.KotlinNullablePropertyCustomizer
+import org.springdoc.core.utils.Constants
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.test.context.TestPropertySource
+import test.org.springdoc.api.v31.AbstractKotlinSpringDocMVCTest
+
+@TestPropertySource(properties = [Constants.SPRINGDOC_KOTLIN_NULLABLE_PROPERTY_CUSTOMIZER_ENABLED + "=false"])
+class SpringDocApp24Test : AbstractKotlinSpringDocMVCTest() {
+    companion object {
+        init {
+            ModelConverters
+                .getInstance(true)
+                .getConverters()
+                .filterIsInstance<KotlinNullablePropertyCustomizer>()
+                .forEach { ModelConverters.getInstance(true).removeConverter(it) }
+        }
+    }
+
+    @SpringBootApplication
+    @ComponentScan(basePackages = ["org.springdoc", "test.org.springdoc.api.v31.app24"])
+    class DemoApplication
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.0.1/app19.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.0.1/app19.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/nullable": {
+      "get": {
+        "tags": [
+          "nullable-controller"
+        ],
+        "operationId": "getNullableFields",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NullableFieldsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NestedObject": {
+        "required": [
+          "name"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "NullableFieldsResponse": {
+        "required": [
+          "requiredField"
+        ],
+        "type": "object",
+        "properties": {
+          "requiredField": {
+            "type": "string"
+          },
+          "nullableString": {
+            "type": "string"
+          },
+          "nullableInt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "nullableNested": {
+            "$ref": "#/components/schemas/NestedObject"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.1.0/app24.json
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/src/test/resources/results/3.1.0/app24.json
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/nullable": {
+      "get": {
+        "tags": [
+          "nullable-controller"
+        ],
+        "operationId": "getNullableFields",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/NullableFieldsResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "NestedObject": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ]
+      },
+      "NullableFieldsResponse": {
+        "type": "object",
+        "properties": {
+          "requiredField": {
+            "type": "string"
+          },
+          "nullableString": {
+            "type": "string"
+          },
+          "nullableInt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "nullableNested": {
+            "$ref": "#/components/schemas/NestedObject"
+          }
+        },
+        "required": [
+          "requiredField"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The newly-added `KotlinNullablePropertyCustomizer` results in Kotlin nullable properties being always marked as non-required *and* nullable. Sometimes that may not be a desirable output.

The Java/Kotlin+Jackson ecosystem does not generally or easily support undefined *and* null properties at the same time. Usually, Kotlin properties with a null value are either serialized as `"property": null` or they are left out (making them undefined). In our backend we leave them out via `@JsonInclude` `non_null/non_absent` and we document them as non-required in our OpenAPI spec. The understanding is that they may be missing from the payload, but if they are present, they are never null.

Our frontend then generates TypeScript types with optional properties, as in `property?: TheType`. In this setup, marking these properties as nullable in the OpenAPI spec results in optional *and* nullable TypeScript properties, as in `property?: TheType | null`. This brings no additional value and is actually detrimental, as the frontend developers now need to handle null values that never occur in practice.

I propose the introduction of a new property `springdoc.model-converters.kotlin-nullable-property-customizer.enabled` (defaulted to true) that would allow disabling `KotlinNullablePropertyCustomizer` on demand.
