### PR TITLE
Use Swagger BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<maven-release-plugin.version>2.5.3</maven-release-plugin.version>
 		<central-publishing-maven-plugin.version>0.7.0
 		</central-publishing-maven-plugin.version>
-		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
+		<flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
 		<swagger-api.version>2.2.47</swagger-api.version>
 		<swagger-ui.version>5.32.2</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
@@ -70,8 +70,10 @@
 			<!-- swagger dependencies -->
 			<dependency>
 				<groupId>io.swagger.core.v3</groupId>
-				<artifactId>swagger-core-jakarta</artifactId>
+				<artifactId>swagger-bom</artifactId>
 				<version>${swagger-api.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 			<!-- swagger ui -->
 			<dependency>

--- a/springdoc-openapi-bom/pom.xml
+++ b/springdoc-openapi-bom/pom.xml
@@ -45,6 +45,13 @@
 				<artifactId>springdoc-openapi-starter-webflux-scalar</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-bom</artifactId>
+				<version>${swagger-api.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -69,7 +76,7 @@
 							<pomElements>
 								<properties>remove</properties>
 								<distributionManagement>remove</distributionManagement>
-								<dependencyManagement>keep</dependencyManagement>
+								<dependencyManagement>extended_interpolate</dependencyManagement>
 								<repositories>remove</repositories>
 								<issueManagement>remove</issueManagement>
 							</pomElements>


### PR DESCRIPTION
This PR assumes that:
1. Springdoc release is compatible with `<swagger-api.version>`
2. Every application which use Springdoc wants compatible Swagger version and does not want risk incompatible Swagger version which may win automatic version resolution.

Additional bonus for Maven multi module application is that with given BOM one module may take dependency to `io.swagger.core.v3:swagger-annotations` and other module may take dependency to `org.springdoc:springdoc-openapi-starter-webmvc-ui` without version managements, because versions are managed by Springdoc BOM