### PR TITLE
Align test module parent versions with spring-boot-4 snapshot

### DIFF
--- a/springdoc-openapi-tests/pom.xml
+++ b/springdoc-openapi-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modelVersion>4.0.0</modelVersion>

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-data-rest-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-groovy-tests</artifactId>
 	<name>${project.artifactId}</name>

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-hateoas-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webflux-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webmvc-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>3.0.3-SNAPSHOT</version>
+		<version>3.0.4-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-security-tests</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
## Summary

Aligns the `springdoc-openapi-tests` reactor parent versions with the current `spring-boot-4` root snapshot version (`3.0.4-SNAPSHOT`).

## Background

The `spring-boot-4` root project now declares `3.0.4-SNAPSHOT`, but the test reactor modules still inherited `3.0.3-SNAPSHOT`. Since the Maven CI build activates the `ci` profile and includes `springdoc-openapi-tests`, Maven fails while reading the reactor before any tests can run.

This keeps the test modules on the same snapshot as the branch root so the local parent POM resolves correctly.

## Verification

- `mvn -B validate --file pom.xml`