### PR TITLE
Upgrade swagger-core from version 2.2.48 to 2.2.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<central-publishing-maven-plugin.version>0.7.0
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
-		<swagger-api.version>2.2.48</swagger-api.version>
+		<swagger-api.version>2.2.49</swagger-api.version>
 		<swagger-ui.version>5.32.2</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -385,9 +385,6 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				}
 				getPaths(mappingsMap, finalLocale, openAPI);
 
-				if (OpenApiVersion.OPENAPI_3_1 == springDocConfigProperties.getApiDocs().getVersion())
-					handleComponentSchemaTypes(openAPI);
-
 				if (springDocConfigProperties.isTrimKotlinIndent())
 					this.trimIndent(openAPI);
 
@@ -456,20 +453,6 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	private void trimIndent(OpenAPI openAPI) {
 		trimComponents(openAPI);
 		trimPaths(openAPI);
-	}
-
-	/**
-	 * Fix component schemas for OAS 3.1 post-processing.
-	 *
-	 * @param openAPI the open api
-	 */
-	private static void handleComponentSchemaTypes(OpenAPI openAPI) {
-		if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
-			return;
-		}
-		for (Schema<?> schema : openAPI.getComponents().getSchemas().values()) {
-			SpringDocUtils.fixNullOnlyAdditionalProperties(schema);
-		}
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
@@ -35,7 +35,6 @@ import io.swagger.v3.core.util.ObjectMapperFactory;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.core.util.PrimitiveType;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.mixins.SortedOpenAPIMixin;
 import org.springdoc.core.mixins.SortedOpenAPIMixin31;
@@ -81,14 +80,10 @@ public class ObjectMapperProvider extends ObjectMapperFactory {
 			if (springDocConfigProperties.isExplicitObjectSchema()) {
 				System.setProperty(Schema.EXPLICIT_OBJECT_SCHEMA_PROPERTY, "true");
 			}
-			else {
-				PrimitiveType.explicitObjectType = false;
-			}
 		}
 		else {
 			jsonMapper = Json.mapper();
 			yamlMapper = Yaml.mapper();
-			PrimitiveType.explicitObjectType = null;
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
@@ -12,8 +12,8 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.media.Schema;
-import jakarta.validation.Constraint;
 import jakarta.validation.OverridesAttribute;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
@@ -296,6 +296,7 @@ public class SchemaUtils {
 				schema.setMaximum(BigDecimal.valueOf(((Range) anno).max()));
 			}
 		});
+		fixOAS31ExclusiveConstraints(schema);
 		if (schema!=null && annotatedNotNull(annotations)) {
 			String specVersion = schema.getSpecVersion().name();
 			if (!"V30".equals(specVersion)) {
@@ -540,5 +541,31 @@ public class SchemaUtils {
 		Method g = findGetter(f);
 		if (g != null) return g.getAnnotation(JsonProperty.class);
 		return null;
+	}
+
+	/**
+	 * Swagger-core 2.2.49 introduced so that {@link Positive} and {@link Negative} are introspected.
+	 * It does not correctly use the fact that exclusiveMinimum/exclusiveMaximum are values in OAS31.
+	 * <p>
+	 * Tracked under <a href="https://github.com/swagger-api/swagger-core/issues/5170">swagger-core#5170</a>.
+	 *
+	 * @param schema the schema to fix
+	 */
+	public static void fixOAS31ExclusiveConstraints(Schema<?> schema) {
+		if (schema == null) {
+			return;
+		}
+		if (schema.getSpecVersion().equals(SpecVersion.V31)) {
+			if (schema.getExclusiveMaximumValue() != null && schema.getMaximum() != null) {
+				if (schema.getMaximum().compareTo(schema.getExclusiveMaximumValue()) == 0) {
+					schema.setMaximum(null);
+				}
+			}
+			if (schema.getExclusiveMinimumValue() != null && schema.getMinimum() != null) {
+				if (schema.getMinimum().compareTo(schema.getExclusiveMinimumValue()) == 0) {
+					schema.setMinimum(null);
+				}
+			}
+		}
 	}
 }

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -187,6 +187,8 @@ public class SpringDocUtils {
 	/**
 	 * Fix additionalProperties incorrectly set to {"type": "null"} when @Nullable
 	 * propagates from a Map field to its Object value type (resolved as "any type" = {}).
+	 * <p>
+	 * Tracked under <a href="https://github.com/swagger-api/swagger-core/issues/5115">swagger-core#5115</a>.
 	 *
 	 * @param schema the schema to fix
 	 */


### PR DESCRIPTION
Swagger-core 2.2.49 includes [a fix](https://github.com/swagger-api/swagger-core/pull/5112) for the resolving of additionalProperties being `type: object` rather than `{}`. Thus that logic within this repo has been removed.

Swagger-core has also introduced their own interpretation of `@Positive`, which does not separate OAS 3.0 and OAS 3.1. It has been reported in https://github.com/swagger-api/swagger-core/issues/5170.