### PR TITLE
docs: update dependency versions to 2.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Maven
    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-      <version>last-release-version</version>
+      <version>2.8.6</version>
    </dependency>
 ```
 
 Gradle
 
 ```groovy
-implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:latest'
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 ```
 
 * This step is optional: For custom path of the swagger documentation in HTML format, add
@@ -172,14 +172,14 @@ Maven
    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-      <version>last-release-version</version>
+      <version>2.8.6</version>
    </dependency>
 ```
 
 Gradle
 
 ```groovy
-implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:latest'
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:2.8.6'
 ```
 
 * This step is optional: For custom path of the OpenAPI documentation in Json format, add
@@ -225,14 +225,14 @@ Maven
    <dependency>
       <groupId>org.springdoc</groupId>
       <artifactId>springdoc-openapi-starter-webflux-ui</artifactId>
-      <version>last-release-version</version>
+      <version>2.8.6</version>
    </dependency>
 ```
 
 Gradle
 
 ```groovy
-implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:latest'
+implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
 ```
 
 * This step is optional: For custom path of the swagger documentation in HTML format, add

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Quality Gate](https://sonarcloud.io/api/project_badges/measure?project=springdoc_springdoc-openapi&metric=alert_status)](https://sonarcloud.io/dashboard?id=springdoc_springdoc-openapi)
 [![Known Vulnerabilities](https://snyk.io/test/github/springdoc/springdoc-openapi.git/badge.svg)](https://snyk.io/test/github/springdoc/springdoc-openapi.git)
 [![Stack Exchange questions](https://img.shields.io/stackexchange/stackoverflow/t/springdoc)](https://stackoverflow.com/questions/tagged/springdoc?tab=Votes)
+[![Maven Central](https://img.shields.io/maven-central/v/org.springdoc/springdoc-openapi-starter-webmvc-ui.svg)](https://central.sonatype.com/search?q=g:org.springdoc)
 
 IMPORTANT: ``springdoc-openapi v1.8.0`` is the latest Open Source release supporting
 Spring Boot 2.x and 1.x.


### PR DESCRIPTION
## What
Updated hardcoded placeholder versions (`last-release-version`, `latest`) 
in README.md to the current stable release version 2.8.6.

## Why
The README contained placeholder text instead of actual version numbers, 
which could confuse new users trying to add the dependency.