### PR TITLE
Make WebProperties and WebMvcProperties optional in SwaggerConfig

### DIFF
--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
@@ -145,21 +145,24 @@ public class SwaggerConfig {
 	/**
 	 * Swagger web mvc configurer swagger web mvc configurer.
 	 *
-	 * @param swaggerUiConfigProperties the swagger ui calculated config
-	 * @param springWebProperties       the spring web config
-	 * @param springWebMvcProperties    the spring mvc config
-	 * @param swaggerIndexTransformer   the swagger index transformer
-	 * @param swaggerResourceResolver   the swagger resource resolver
-	 * @param swaggerWelcomeCommon   the swagger welcome common
+	 * @param swaggerUiConfigProperties         the swagger ui calculated config
+	 * @param springWebPropertiesProvider       the spring web config provider
+	 * @param springWebMvcPropertiesProvider    the spring mvc config provider
+	 * @param swaggerIndexTransformer           the swagger index transformer
+	 * @param swaggerResourceResolver           the swagger resource resolver
+	 * @param swaggerWelcomeCommon              the swagger welcome common
 	 * @return the swagger web mvc configurer
 	 */
 	@Bean
 	@ConditionalOnMissingBean
 	@Lazy(false)
 	SwaggerWebMvcConfigurer swaggerWebMvcConfigurer(SwaggerUiConfigProperties swaggerUiConfigProperties,
-			WebProperties springWebProperties, WebMvcProperties springWebMvcProperties,
+			ObjectProvider<WebProperties> springWebPropertiesProvider,
+			ObjectProvider<WebMvcProperties> springWebMvcPropertiesProvider,
 			SwaggerIndexTransformer swaggerIndexTransformer, SwaggerResourceResolver swaggerResourceResolver,
 			SwaggerWelcomeCommon swaggerWelcomeCommon) {
+		WebProperties springWebProperties = springWebPropertiesProvider.getIfAvailable(WebProperties::new);
+		WebMvcProperties springWebMvcProperties = springWebMvcPropertiesProvider.getIfAvailable(WebMvcProperties::new);
 		return new SwaggerWebMvcConfigurer(swaggerUiConfigProperties, springWebProperties, springWebMvcProperties, swaggerIndexTransformer, swaggerResourceResolver, swaggerWelcomeCommon);
 	}
 


### PR DESCRIPTION
Fixes #3288.

### Summary

The webmvc-ui starter's `SwaggerWebMvcConfigurer` bean has injected `WebProperties` and `WebMvcProperties` directly since 2.8.15 (commit f09afb9, which introduced the WebJar resource-handler refactor for #3146). Spring Boot's `WebMvcAutoConfiguration` normally publishes both beans, but applications that intentionally disable that auto-configuration (for example a plain Spring MVC app that configures the web layer manually) now fail to start with an `UnsatisfiedDependencyException` for the `swaggerWebMvcConfigurer` bean — exactly the upgrade regression from 2.8.14 to 2.8.16 reported in #3288.

### Change

`SwaggerConfig.swaggerWebMvcConfigurer(...)` now declares the two property beans as `ObjectProvider<WebProperties>` / `ObjectProvider<WebMvcProperties>` and falls back to default-constructed instances when the beans are absent:

- `WebProperties::new` — `addMappings` defaults to `true`, matching the path that `AbstractSwaggerConfigurer.getSwaggerWebjarHandlerConfigs()` takes when no resource bean exists.
- `WebMvcProperties::new` — `webjarsPathPattern` defaults to `/webjars/**`, which is what Spring Boot's autoconfigured bean exposes and what `SwaggerWebMvcConfigurer.getWebjarsPathPattern()` returned implicitly in 2.8.14.

Apps that do have Spring Boot autoconfiguration pick up the autoconfigured beans through the `ObjectProvider`, so existing behaviour is unchanged.

### Test plan

- [x] `mvn -B -f springdoc-openapi-starter-webmvc-ui/pom.xml test` — `Tests run: 75, Failures: 0, Errors: 0, Skipped: 0` on `main`-equivalent baseline and unchanged after the fix.

I did not add a dedicated regression test: the existing module relies on `@SpringBootTest` with `@SpringBootApplication` test apps, so a test that simulates the "no Spring Boot autoconfiguration" scenario would need a different harness (`WebApplicationContextRunner` or `@SpringBootApplication(exclude = WebMvcAutoConfiguration.class)`) than anything currently in this module. Happy to add one in the style maintainers prefer if useful.