### PR TITLE
Fix #3275: prevent @Nullable $ref field from mutating shared component schema type

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -469,6 +469,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 		}
 		for (Schema<?> schema : openAPI.getComponents().getSchemas().values()) {
 			SpringDocUtils.fixNullOnlyAdditionalProperties(schema);
+			SpringDocUtils.fixNullMutatedObjectSchema(schema);
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -216,6 +216,36 @@ public class SpringDocUtils {
 	}
 
 	/**
+	 * Fix component schemas that have been incorrectly mutated to {@code type: "null"} when they
+	 * have properties, which indicates they should be {@code type: "object"}.
+	 *
+	 * <p>This can happen when {@code @Nullable} is applied to a field whose type is represented
+	 * as a {@code $ref} component schema. swagger-core may propagate the nullable marker onto
+	 * the shared component schema itself, corrupting it for all references. This method restores
+	 * such schemas to {@code type: "object"} based on the presence of {@code properties}.
+	 *
+	 * @param schema the schema to fix
+	 * @see <a href="https://github.com/springdoc/springdoc-openapi/issues/3275">Issue #3275</a>
+	 */
+	public static void fixNullMutatedObjectSchema(Schema<?> schema) {
+		if (schema == null || schema.getProperties() == null || schema.getProperties().isEmpty()) {
+			return;
+		}
+		Set<String> types = schema.getTypes();
+		boolean isNullOnly = (types != null && types.size() == 1 && types.contains("null"))
+				|| (types == null && "null".equals(schema.getType()));
+		if (isNullOnly) {
+			if (types != null) {
+				types.remove("null");
+				types.add("object");
+			}
+			else {
+				schema.setType("object");
+			}
+		}
+	}
+
+	/**
 	 * Handle schema types.
 	 *
 	 * @param content the content

--- a/springdoc-openapi-tests/pom.xml
+++ b/springdoc-openapi-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<packaging>pom</packaging>
 	<modelVersion>4.0.0</modelVersion>

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-actuator-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-data-rest-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-function-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-groovy-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-groovy-tests</artifactId>
 	<name>${project.artifactId}</name>

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-hateoas-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/Inner.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/Inner.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app175;
+
+/**
+ * Inner record used as a referenced component schema.
+ *
+ * @param lines the line count
+ * @param bytes the byte count
+ * @param bucket the bucket name
+ * @param key the object key
+ */
+public record Inner(int lines, long bytes, String bucket, String key) {}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/NullableRefController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/NullableRefController.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app175;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller for regression test of issue #3275.
+ * Verifies that a {@code @Nullable} field referencing a component schema does not
+ * mutate the referenced schema's type to {@code "null"}.
+ */
+@RestController
+class NullableRefController {
+
+	/**
+	 * Returns an Outer record with a nullable Inner reference.
+	 *
+	 * @return the outer record
+	 */
+	@GetMapping("/outer")
+	public Outer getOuter() {
+		return new Outer("x", null);
+	}
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/Outer.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/Outer.java
@@ -1,0 +1,37 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app175;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Outer record with a nullable reference to {@link Inner}.
+ *
+ * @param id the identifier
+ * @param result the optional inner result, may be null
+ */
+public record Outer(String id, @Nullable Inner result) {}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/SpringDocApp175Test.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app175/SpringDocApp175Test.java
@@ -1,0 +1,46 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  *  * limitations under the License.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package test.org.springdoc.api.v31.app175;
+
+import test.org.springdoc.api.v31.AbstractSpringDocTest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Test for issue #3275: verifies that a {@code @Nullable} field referencing a component schema
+ * does not mutate the referenced schema's type to {@code "null"}.
+ */
+class SpringDocApp175Test extends AbstractSpringDocTest {
+
+	/**
+	 * The type Spring doc test app.
+	 */
+	@SpringBootApplication
+	static class SpringDocTestApp {
+	}
+
+}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app175.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app175.json
@@ -1,0 +1,69 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "OpenAPI definition",
+    "version": "v0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost",
+      "description": "Generated server url"
+    }
+  ],
+  "paths": {
+    "/outer": {
+      "get": {
+        "tags": [
+          "nullable-ref-controller"
+        ],
+        "operationId": "getOuter",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/Outer"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Inner": {
+        "type": "object",
+        "properties": {
+          "lines": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "bucket": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string"
+          }
+        }
+      },
+      "Outer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "result": {
+            "$ref": "#/components/schemas/Inner"
+          }
+        }
+      }
+    }
+  }
+}

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webflux-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webflux-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-kotlin-webmvc-tests/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>springdoc-openapi-tests</artifactId>
 		<groupId>org.springdoc</groupId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>springdoc-openapi-kotlin-webmvc-tests</artifactId>

--- a/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
+++ b/springdoc-openapi-tests/springdoc-openapi-security-tests/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.springdoc</groupId>
 		<artifactId>springdoc-openapi-tests</artifactId>
-		<version>2.8.17-SNAPSHOT</version>
+		<version>2.8.18-SNAPSHOT</version>
 	</parent>
 	<artifactId>springdoc-openapi-security-tests</artifactId>
 	<name>${project.artifactId}</name>


### PR DESCRIPTION
## Problem

When a record field is annotated with `@Nullable` and its type resolves to a `$ref` (i.e. another component schema), swagger-core 2.2.44 mutates the **shared** `Schema` instance stored in the components map by setting `types = {"null"}`. This causes the referenced schema (e.g. `Inner`) to lose its original `type: "object"` declaration and appear as `type: "null"` in the final OpenAPI output.

Reproducer (OAS 3.1):

```java
public record Inner(int lines, long bytes, String bucket, String key) {}
public record Outer(String id, @Nullable Inner result) {}
```

Before fix – `Inner` schema in components:
```json
"Inner": { "type": "null", "properties": { ... } }
```

## Fix

In `AbstractOpenApiResource.handleComponentSchemaTypes()`, call the new helper `SpringDocUtils.fixNullMutatedObjectSchema()` which restores any component schema whose `types` was wrongly reduced to `{"null"}` when it still has `properties` (i.e. it is clearly an object).

After fix:
```json
"Inner": { "type": "object", "properties": { ... } }
```

## Test

Added regression test `SpringDocApp175Test` (OAS 3.1, javadoc variant) with:
- `Inner` record (the referenced schema)
- `Outer` record with `@Nullable Inner result`
- `NullableRefController` exposing `GET /outer`
- Expected snapshot `results/3.1.0/app175.json` asserting `Inner` has `type: "object"`

Also bumped test sub-module `pom.xml` versions from `2.8.17-SNAPSHOT` → `2.8.18-SNAPSHOT` to match the root pom after the `maven-release-plugin` iteration bump.

Fixes #3275