### PR TITLE
Fix #3282: preserve nest() version predicate across all routes in nest

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,9 +9,6 @@
 name: Java CI with Maven
 
 on:
-  push:
-    branches:
-      - spring-boot-4
   pull_request:
 
 jobs:

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/AbstractRouterFunctionVisitor.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/fn/AbstractRouterFunctionVisitor.java
@@ -77,6 +77,12 @@ public class AbstractRouterFunctionVisitor {
 	protected Map<Integer, List<String>> nestedPaths = new LinkedHashMap<>();
 
 	/**
+	 * The Nested versions, keyed by nesting level, set by {@code version(...)} predicates
+	 * declared on {@code nest(...)} calls. Sticky for all routes within the nest level.
+	 */
+	protected Map<Integer, String> nestedVersions = new LinkedHashMap<>();
+
+	/**
 	 * The Is or.
 	 */
 	protected boolean isOr;
@@ -189,7 +195,16 @@ public class AbstractRouterFunctionVisitor {
 	 * @param version the version
 	 */
 	public void version(String version) {
-		this.version = version;
+		// When visited as a nest(...) predicate, currentRouterFunctionDatas is null
+		// (cleared by commonStartNested) and the version must apply to every route in the
+		// nested block. When visited as a per-route predicate, currentRouterFunctionDatas
+		// has been freshly initialized by route(...) and the version is one-shot.
+		if (this.currentRouterFunctionDatas == null && this.level > 0) {
+			this.nestedVersions.put(this.level, version);
+		}
+		else {
+			this.version = version;
+		}
 	}
 
 	/**
@@ -281,6 +296,7 @@ public class AbstractRouterFunctionVisitor {
 	 */
 	protected void commonEndNested() {
 		nestedPaths.remove(this.level);
+		nestedVersions.remove(this.level);
 		this.level--;
 	}
 
@@ -296,7 +312,7 @@ public class AbstractRouterFunctionVisitor {
 	 * Common route.
 	 */
 	protected void commonRoute() {
-		String currentVersion = this.version;
+		String currentVersion = (this.version != null) ? this.version : currentNestedVersion();
 		this.version = null;
 		this.routerFunctionDatas.addAll(currentRouterFunctionDatas);
 		currentRouterFunctionDatas.forEach(routerFunctionData -> {
@@ -306,6 +322,15 @@ public class AbstractRouterFunctionVisitor {
 			}
 		});
 		this.attributes = new HashMap<>();
+	}
+
+	private String currentNestedVersion() {
+		if (nestedVersions.isEmpty()) {
+			return null;
+		}
+		// Innermost nest wins
+		int innermost = nestedVersions.keySet().stream().mapToInt(Integer::intValue).max().orElse(-1);
+		return nestedVersions.get(innermost);
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/fn/AbstractRouterFunctionVisitorTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/fn/AbstractRouterFunctionVisitorTest.java
@@ -1,0 +1,159 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  *
+ *  *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *  *
+ *  *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *  *
+ *  *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *  *
+ *  *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  *
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package org.springdoc.core.fn;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AbstractRouterFunctionVisitor}.
+ *
+ * @author oss-bot
+ */
+class AbstractRouterFunctionVisitorTest {
+
+	@Test
+	void versionFromNestPredicateAppliesToEveryRouteInTheNest() {
+		TestVisitor visitor = new TestVisitor();
+
+		// nest(version("v1"), route(GET "/foo").and(route(GET "/bar")))
+		visitor.commonStartNestedPublic();
+		visitor.version("v1");
+		visitor.routePublic(() -> visitor.path("/foo"));
+		visitor.routePublic(() -> visitor.path("/bar"));
+		visitor.commonEndNestedPublic();
+
+		List<RouterFunctionData> routes = visitor.getRouterFunctionDatas();
+		assertThat(routes).hasSize(2);
+		assertThat(routes).extracting(RouterFunctionData::getPath).containsExactly("/foo", "/bar");
+		assertThat(routes).extracting(RouterFunctionData::getVersion).containsExactly("v1", "v1");
+	}
+
+	@Test
+	void versionFromAndNestPredicateAppliesToEveryRouteInItsOwnNest() {
+		TestVisitor visitor = new TestVisitor();
+
+		// nest(version("v1"), routes).andNest(version("v2"), routes)
+		visitor.commonStartNestedPublic();
+		visitor.version("v1");
+		visitor.routePublic(() -> visitor.path("/foo"));
+		visitor.routePublic(() -> visitor.path("/bar"));
+		visitor.commonEndNestedPublic();
+
+		visitor.commonStartNestedPublic();
+		visitor.version("v2");
+		visitor.routePublic(() -> visitor.path("/foo"));
+		visitor.routePublic(() -> visitor.path("/bar"));
+		visitor.commonEndNestedPublic();
+
+		List<RouterFunctionData> routes = visitor.getRouterFunctionDatas();
+		assertThat(routes).hasSize(4);
+		assertThat(routes).extracting(RouterFunctionData::getVersion)
+				.containsExactly("v1", "v1", "v2", "v2");
+	}
+
+	@Test
+	void perRouteVersionRemainsOneShotInsideNest() {
+		TestVisitor visitor = new TestVisitor();
+
+		// nest(path("/api"), route().version("v1").GET("/foo").and(route().GET("/bar")))
+		visitor.commonStartNestedPublic();
+		visitor.path("/api");
+
+		visitor.routePublic(() -> {
+			visitor.version("v1");
+			visitor.path("/foo");
+		});
+		visitor.routePublic(() -> visitor.path("/bar"));
+
+		visitor.commonEndNestedPublic();
+
+		List<RouterFunctionData> routes = visitor.getRouterFunctionDatas();
+		assertThat(routes).hasSize(2);
+		assertThat(routes).extracting(RouterFunctionData::getVersion).containsExactly("v1", null);
+	}
+
+	@Test
+	void innerNestVersionOverridesOuterNestVersion() {
+		TestVisitor visitor = new TestVisitor();
+
+		// nest(version("v1"), nest(version("v2"), route))
+		visitor.commonStartNestedPublic();
+		visitor.version("v1");
+
+		visitor.commonStartNestedPublic();
+		visitor.version("v2");
+		visitor.routePublic(() -> visitor.path("/foo"));
+		visitor.commonEndNestedPublic();
+
+		// After the inner nest ends, the outer version applies again
+		visitor.routePublic(() -> visitor.path("/bar"));
+		visitor.commonEndNestedPublic();
+
+		List<RouterFunctionData> routes = visitor.getRouterFunctionDatas();
+		assertThat(routes).extracting(RouterFunctionData::getPath).containsExactly("/foo", "/bar");
+		assertThat(routes).extracting(RouterFunctionData::getVersion).containsExactly("v2", "v1");
+	}
+
+	@Test
+	void topLevelPerRouteVersionRemainsOneShot() {
+		TestVisitor visitor = new TestVisitor();
+
+		// route().version("v0").GET("/top") followed by route().GET("/plain")
+		visitor.routePublic(() -> {
+			visitor.version("v0");
+			visitor.path("/top");
+		});
+		visitor.routePublic(() -> visitor.path("/plain"));
+
+		List<RouterFunctionData> routes = visitor.getRouterFunctionDatas();
+		assertThat(routes).extracting(RouterFunctionData::getVersion).containsExactly("v0", null);
+	}
+
+	/**
+	 * Exposes the relevant {@code protected} hooks so tests can simulate the call order a
+	 * real {@code RouterFunctions.Visitor} produces.
+	 */
+	private static class TestVisitor extends AbstractRouterFunctionVisitor {
+
+		void commonStartNestedPublic() {
+			commonStartNested();
+		}
+
+		void commonEndNestedPublic() {
+			commonEndNested();
+		}
+
+		void routePublic(Runnable predicateVisits) {
+			this.currentRouterFunctionDatas = new ArrayList<>();
+			predicateVisits.run();
+			commonRoute();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3282.

`AbstractRouterFunctionVisitor.commonRoute` unconditionally nullified `this.version` after the first route, so when `RequestPredicates.version(...)` was declared on a `RouterFunctions.nest(...)`, only the first route in the nested block received the version. The reporter's repro:

```java
RouterFunctions.nest(path("/api/{version}"),
    RouterFunctions.nest(version("v1"),
        route().GET("/foo", h).build()
        .and(route().GET("/bar", h).build()))
    .andNest(version("v2"),
        route().GET("/foo", h).build()
        .and(route().GET("/bar", h).build())));
```

produced only the *first* route of each nest with its version; the second route was emitted at `/api/{version}/bar` because the version had been silently nulled.

## Change

The fix distinguishes the two visit paths for `version(...)`:

- as a `nest(...)` **predicate** — `currentRouterFunctionDatas` is `null` (cleared by `commonStartNested`); the version is stored per nesting level in a new `nestedVersions` map and applies to every route in that level. Inner nests override outer ones. The level entry is cleared on `commonEndNested`, restoring symmetry with how `nestedPaths` is handled.
- as a per-route predicate — `currentRouterFunctionDatas` is the freshly-initialized list from `route(...)`; the version stays in `this.version` and is consumed by `commonRoute` exactly as before, preserving existing per-route one-shot behavior.

`commonRoute` falls back to the innermost `nestedVersions` entry when no per-route version was set, so the existing per-route override still wins inside a nest.

## Test plan

- [x] New `AbstractRouterFunctionVisitorTest` (5 cases) covering: nest predicate sticky, `andNest` chain, per-route inside nest stays one-shot, inner nest overrides outer, top-level per-route stays one-shot.
- [x] `mvn test` in `springdoc-openapi-starter-common` — all 34 tests pass with no regressions.

Verification done: (1) `gh pr list` for matching keywords — no in-flight PR; (2) issue has no claim or comments; (3) fix touches `.java` files only; (4) confirmed `commonRoute` on `upstream/spring-boot-4` still has `this.version = null;`; (5) no parent epic.

## Note on the workflow file

The OAuth token used to push this branch does not have `workflow` scope, so the branch keeps `.github/workflows/maven.yml` matching the version on `main` instead of `spring-boot-4`. The 3-line `push:` trigger you added on `spring-boot-4` will reappear in the diff against this PR — feel free to drop that hunk on merge.