### PR TITLE
chore: remove intermediate fix methods for OAS31 exclusive constraints and null-only additional properties

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
-import io.swagger.v3.oas.models.SpecVersion;
 import io.swagger.v3.oas.models.media.Schema;
 import jakarta.validation.OverridesAttribute;
 import jakarta.validation.constraints.DecimalMax;
@@ -296,7 +295,6 @@ public class SchemaUtils {
 				schema.setMaximum(BigDecimal.valueOf(((Range) anno).max()));
 			}
 		});
-		fixOAS31ExclusiveConstraints(schema);
 		if (schema!=null && annotatedNotNull(annotations)) {
 			String specVersion = schema.getSpecVersion().name();
 			if (!"V30".equals(specVersion)) {
@@ -562,31 +560,5 @@ public class SchemaUtils {
 		Method g = findGetter(f);
 		if (g != null) return g.getAnnotation(JsonProperty.class);
 		return null;
-	}
-
-	/**
-	 * Swagger-core 2.2.49 introduced so that {@link Positive} and {@link Negative} are introspected.
-	 * It does not correctly use the fact that exclusiveMinimum/exclusiveMaximum are values in OAS31.
-	 * <p>
-	 * Tracked under <a href="https://github.com/swagger-api/swagger-core/issues/5170">swagger-core#5170</a>.
-	 *
-	 * @param schema the schema to fix
-	 */
-	public static void fixOAS31ExclusiveConstraints(Schema<?> schema) {
-		if (schema == null) {
-			return;
-		}
-		if (schema.getSpecVersion().equals(SpecVersion.V31)) {
-			if (schema.getExclusiveMaximumValue() != null && schema.getMaximum() != null) {
-				if (schema.getMaximum().compareTo(schema.getExclusiveMaximumValue()) == 0) {
-					schema.setMaximum(null);
-				}
-			}
-			if (schema.getExclusiveMinimumValue() != null && schema.getMinimum() != null) {
-				if (schema.getMinimum().compareTo(schema.getExclusiveMinimumValue()) == 0) {
-					schema.setMinimum(null);
-				}
-			}
-		}
 	}
 }

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -180,40 +179,6 @@ public class SpringDocUtils {
 			if (schema.getProperties() != null) {
 				schema.getProperties().forEach((key, value) -> handleSchemaTypes(value));
 			}
-			fixNullOnlyAdditionalProperties(schema);
-		}
-	}
-
-	/**
-	 * Fix additionalProperties incorrectly set to {"type": "null"} when @Nullable
-	 * propagates from a Map field to its Object value type (resolved as "any type" = {}).
-	 * <p>
-	 * Tracked under <a href="https://github.com/swagger-api/swagger-core/issues/5115">swagger-core#5115</a>.
-	 *
-	 * @param schema the schema to fix
-	 */
-	public static void fixNullOnlyAdditionalProperties(Schema<?> schema) {
-		if (schema == null) {
-			return;
-		}
-		Object additionalProperties = schema.getAdditionalProperties();
-		if (additionalProperties instanceof Schema<?> addPropSchema) {
-			boolean isNullOnlyType = false;
-			Set<String> types = addPropSchema.getTypes();
-			if (types != null && types.size() == 1 && types.contains("null")) {
-				isNullOnlyType = true;
-			}
-			else if (types == null && "null".equals(addPropSchema.getType())) {
-				isNullOnlyType = true;
-			}
-			if (isNullOnlyType && addPropSchema.get$ref() == null
-					&& addPropSchema.getProperties() == null && addPropSchema.getFormat() == null) {
-				addPropSchema.setTypes(null);
-				addPropSchema.setType(null);
-			}
-		}
-		if (schema.getProperties() != null) {
-			schema.getProperties().values().forEach(prop -> fixNullOnlyAdditionalProperties((Schema<?>) prop));
 		}
 	}
 


### PR DESCRIPTION
Removes temporary methods that were introduced to handle swagger-core bugs. The issues have been fixed upstream and are present with coming swagger-core 2.2.53, so they should no longer be needed locally.

See:
https://github.com/swagger-api/swagger-core/issues/5170
https://github.com/swagger-api/swagger-core/issues/5115