### PR TITLE
chore: act upon SonarQube warnings

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -82,6 +82,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.annotations.RouterOperations;
@@ -556,8 +557,9 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
                 .filter(clazz -> isPackageToScan(clazz.getPackage()))
                 .toArray(Class<?>[]::new);
         Webhooks[] webhooksAttr = openAPIService.getWebhooks(refinedClasses);
-        if (ArrayUtils.isEmpty(webhooksAttr))
+        if (ArrayUtils.isEmpty(webhooksAttr)) {
 			return;
+		}
 		var webhooks = Arrays.stream(webhooksAttr).map(Webhooks::value).flatMap(Arrays::stream).toArray(Webhook[]::new);
 		Arrays.stream(webhooks).forEach(webhook -> {
 			io.swagger.v3.oas.annotations.Operation apiOperation = webhook.operation();
@@ -683,7 +685,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			// allow for customisation
 			operation = customizeOperation(operation, components, handlerMethod);
 
-			if (StringUtils.contains(operationPath, "*")) {
+			if (Strings.CS.contains(operationPath, "*")) {
 				Matcher matcher = pathPattern.matcher(operationPath);
 				while (matcher.find()) {
 					String pathParam = matcher.group(1);
@@ -1297,7 +1299,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				if (ParameterIn.PATH.toString().equals(parameter.getIn())) {
 					// check it's present in the path
 					String name = parameter.getName();
-					if (!StringUtils.containsAny(operationPath, "{" + name + "}", "{*" + name + "}"))
+					if (!Strings.CS.containsAny(operationPath, "{" + name + "}", "{*" + name + "}"))
 						paramIt.remove();
 				}
 			}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/AdditionalModelsConverter.java
@@ -36,8 +36,6 @@ import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.oas.models.media.Schema;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springdoc.core.providers.ObjectMapperProvider;
 
 import static org.springdoc.core.utils.SpringDocUtils.cloneViaJson;
@@ -64,11 +62,6 @@ public class AdditionalModelsConverter implements ModelConverter {
 	 * The constant paramObjectReplacementMap.
 	 */
 	private static final Map<Class, Class> paramObjectReplacementMap = new HashMap<>();
-
-	/**
-	 * The constant LOGGER.
-	 */
-	private static final Logger LOGGER = LoggerFactory.getLogger(AdditionalModelsConverter.class);
 
 	/**
 	 * The Spring doc object mapper.

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PolymorphicModelConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PolymorphicModelConverter.java
@@ -203,9 +203,13 @@ public class PolymorphicModelConverter implements ModelConverter {
 	private Schema composePolymorphicSchema(AnnotatedType type, Schema schema, Collection<Schema> schemas) {
 		String ref = schema.get$ref();
 		List<Schema> composedSchemas = findComposedSchemas(ref, schemas);
-		if (composedSchemas.isEmpty()) return schema;
+		if (composedSchemas.isEmpty()) {
+			return schema;
+		}
         ComposedSchema result = new ComposedSchema();
-		if (isConcreteClass(type)) result.addOneOfItem(schema);
+		if (isConcreteClass(type)) {
+			result.addOneOfItem(schema);
+		}
 		JavaType javaType = springDocObjectMapper.jsonMapper().constructType(type.getType());
 		Class<?> clazz = javaType.getRawClass();
 		if (TYPES_TO_SKIP.stream().noneMatch(typeToSkip -> typeToSkip.equals(clazz.getSimpleName())))

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/QuerydslPredicateOperationCustomizer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/QuerydslPredicateOperationCustomizer.java
@@ -57,8 +57,6 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.querydsl.binding.QuerydslBindingsFactory;
 import org.springframework.data.querydsl.binding.QuerydslPredicate;
-import org.springframework.data.util.CastUtils;
-import org.springframework.data.util.ClassTypeInformation;
 import org.springframework.data.util.TypeInformation;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.method.HandlerMethod;
@@ -174,12 +172,12 @@ public class QuerydslPredicateOperationCustomizer implements GlobalOperationCust
 	 * @return the querydsl bindings
 	 */
 	private QuerydslBindings extractQdslBindings(QuerydslPredicate predicate) {
-		ClassTypeInformation<?> classTypeInformation = ClassTypeInformation.from(predicate.root());
-		TypeInformation<?> domainType = classTypeInformation.getRequiredActualType();
+		TypeInformation<?> typeInformation = TypeInformation.of(predicate.root());
+		TypeInformation<?> domainType = typeInformation.getRequiredActualType();
 
 		Optional<Class<? extends QuerydslBinderCustomizer<?>>> bindingsAnnotation = Optional.of(predicate)
 				.map(QuerydslPredicate::bindings)
-				.map(CastUtils::cast);
+				.map(binder -> (Class<? extends QuerydslBinderCustomizer<?>>) binder);
 
 		return bindingsAnnotation
 				.map(it -> querydslBindingsFactory.createBindingsFor(domainType, it))

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/models/MethodAttributes.java
@@ -445,8 +445,7 @@ public class MethodAttributes {
 				}
 				else {
 					String key = header.substring(0, neqIdx);
-					if (!this.headers.containsKey(key))
-						this.headers.put(key, StringUtils.EMPTY);
+					this.headers.putIfAbsent(key, StringUtils.EMPTY);
 				}
 			}
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericResponseService.java
@@ -760,8 +760,7 @@ public class GenericResponseService implements ApplicationContextAware {
 					}
 
 					if (addToGenericMap || exceptions.isEmpty()) {
-						methodAdviceInfo.getApiResponses().forEach((key, apiResponse) ->
-								genericApiResponseMap.putIfAbsent(key, apiResponse));
+						methodAdviceInfo.getApiResponses().forEach(genericApiResponseMap::putIfAbsent);
 					}
 				}
 			}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/RequestBodyService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/RequestBodyService.java
@@ -26,7 +26,6 @@
 
 package org.springdoc.core.service;
 
-import java.util.Arrays;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -256,7 +255,7 @@ public class RequestBodyService {
 	 */
 	public void calculateRequestBodyInfo(Components components, MethodAttributes methodAttributes,
 			ParameterInfo parameterInfo, RequestBodyInfo requestBodyInfo) {
-		RequestBody requestBody = requestBodyInfo.getRequestBody();
+		RequestBody requestBody;
 		MethodParameter methodParameter = parameterInfo.getMethodParameter();
 
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
@@ -492,7 +492,7 @@ public class SchemaUtils {
 					}
 				}
 			}
-		} catch (Throwable ignored) {
+		} catch (Exception ignored) {
 			// best-effort only
 		}
 		return false;
@@ -525,7 +525,7 @@ public class SchemaUtils {
 		try {
 			JsonProperty jp = p.getAnnotation(JsonProperty.class);
 			return jp != null && expected.equals(jp.value());
-		} catch (Throwable ignored) {
+		} catch (Exception ignored) {
 			return false;
 		}
 	}
@@ -545,7 +545,9 @@ public class SchemaUtils {
 		for (String m : names) {
 			try {
 				return f.getDeclaringClass().getMethod(m);
-			} catch (NoSuchMethodException ignored) {}
+			} catch (NoSuchMethodException ignored) {
+				// best-effort only
+			}
 		}
 		return null;
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocAnnotationsUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocAnnotationsUtils.java
@@ -544,9 +544,10 @@ public class SpringDocAnnotationsUtils extends AnnotationsUtils {
 	 * @param javadocProvider the javadoc provider
 	 */
 	public static void clearCache(JavadocProvider javadocProvider) {
-		if (javadocProvider != null)
+		if (javadocProvider != null) {
 			javadocProvider.clearCache();
-		MODEL_CONVERTER_CONTEXT_MAP.remove();;
+		}
+		MODEL_CONVERTER_CONTEXT_MAP.remove();
 	}
 	
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocKotlinUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocKotlinUtils.java
@@ -73,7 +73,9 @@ public class SpringDocKotlinUtils {
 					return p.getReturnType().isMarkedNullable();
 				}
 			}
-		} catch (Throwable ignored) {}
+		} catch (Exception ignored) {
+			// best-effort only
+		}
 		return null;
 	}
 
@@ -94,7 +96,9 @@ public class SpringDocKotlinUtils {
 					}
 				}
 			}
-		} catch (Throwable ignored) {}
+		} catch (Exception ignored) {
+			// best-effort only
+		}
 		return null;
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -231,7 +232,7 @@ public class SpringDocUtils {
 		if (schema == null || schema.getProperties() == null) {
 			return;
 		}
-		schema.getProperties().keySet().removeIf(key -> key == null);
+		schema.getProperties().keySet().removeIf(Objects::isNull);
 		schema.getProperties().values().forEach(SpringDocUtils::removeNullKeyProperties);
 	}
 

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWelcomeCommon.java
@@ -89,11 +89,6 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 		}
 	}
 
-	@Override
-	protected void calculateUiRootPath(SwaggerUiConfigParameters swaggerUiConfigParameters, StringBuilder... sbUrls) {
-		super.calculateUiRootPath(swaggerUiConfigParameters, sbUrls);
-	}
-
 	/**
 	 * Gets swagger ui config.
 	 *
@@ -104,6 +99,11 @@ public abstract class SwaggerWelcomeCommon extends AbstractSwaggerWelcome {
 		SwaggerUiConfigParameters swaggerUiConfigParameters = new SwaggerUiConfigParameters(swaggerUiConfig);
 		this.buildFromCurrentContextPath(swaggerUiConfigParameters, exchange);
 		return swaggerUiConfigParameters.getConfigParameters();
+	}
+
+	@Override
+	protected void calculateUiRootPath(SwaggerUiConfigParameters swaggerUiConfigParameters, StringBuilder... sbUrls) {
+		super.calculateUiRootPath(swaggerUiConfigParameters, sbUrls);
 	}
 
 	/**


### PR DESCRIPTION
The hope is that we can reduce the amount of warnings so that the pipeline starts showing green again.
<img width="935" height="493" alt="image" src="https://github.com/user-attachments/assets/a8c2b007-8164-407b-8a0e-c314ca3f52a0" />
But it might be that it will require some invalid warnings to be marked as "invalid/false-positive".