### PR TITLE
chore: act upon SonarQube warnings

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -82,6 +82,7 @@ import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.servers.Server;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springdoc.core.annotations.RouterOperations;
@@ -684,7 +685,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 			// allow for customisation
 			operation = customizeOperation(operation, components, handlerMethod);
 
-			if (StringUtils.contains(operationPath, "*")) {
+			if (Strings.CS.contains(operationPath, "*")) {
 				Matcher matcher = pathPattern.matcher(operationPath);
 				while (matcher.find()) {
 					String pathParam = matcher.group(1);
@@ -1298,7 +1299,7 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				if (ParameterIn.PATH.toString().equals(parameter.getIn())) {
 					// check it's present in the path
 					String name = parameter.getName();
-					if (!StringUtils.containsAny(operationPath, "{" + name + "}", "{*" + name + "}"))
+					if (!Strings.CS.containsAny(operationPath, "{" + name + "}", "{*" + name + "}"))
 						paramIt.remove();
 				}
 			}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/DelegatingMethodParameter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/DelegatingMethodParameter.java
@@ -196,11 +196,13 @@ public class DelegatingMethodParameter extends MethodParameter {
 	}
 
 	@Override
+	@Nullable
 	public Method getMethod() {
 		return delegate.getMethod();
 	}
 
 	@Override
+	@Nullable
 	public Constructor<?> getConstructor() {
 		return delegate.getConstructor();
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
@@ -390,7 +390,7 @@ public class GenericParameterService {
 			Annotation[] paramAnnotations = getParameterAnnotations(methodParameter);
 			TypeAndTypeAnnotations resolved = resolveTypeAndTypeAnnotationsForParameter(methodParameter);
 			Type type = resolved.type();
-			Annotation[] typeAnnotations = resolved.typeAnnotations();
+			Annotation[] typeAnnotations = resolved.typeAnnotations().toArray(Annotation[]::new);
 			Annotation[] mergedAnnotations =
 					Stream.concat(
 							Arrays.stream(paramAnnotations),
@@ -439,7 +439,7 @@ public class GenericParameterService {
 				&& delegatingMethodParameter.getField() != null) {
 			AnnotatedType annotated = delegatingMethodParameter.getField().getAnnotatedType();
 			Type type = GenericTypeResolver.resolveType(annotated.getType(), methodParameter.getContainingClass());
-			return new TypeAndTypeAnnotations(type, annotationsFromAnnotatedTypeArguments(annotated));
+			return new TypeAndTypeAnnotations(type, Arrays.asList(annotationsFromAnnotatedTypeArguments(annotated)));
 		}
 
 		Type type = GenericTypeResolver.resolveType(methodParameter.getGenericParameterType(), methodParameter.getContainingClass());
@@ -449,17 +449,17 @@ public class GenericParameterService {
 				&& type == String.class) {
 			Class<?> restored = KotlinInlineParameterResolver.resolveInlineType(methodParameter, type);
 			return restored != null
-					? new TypeAndTypeAnnotations(restored, restored.getAnnotations())
-					: new TypeAndTypeAnnotations(type, new Annotation[0]);
+					? new TypeAndTypeAnnotations(restored, Arrays.asList(restored.getAnnotations()))
+					: new TypeAndTypeAnnotations(type, new ArrayList<>());
 		}
 
-		return new TypeAndTypeAnnotations(type, methodParameter.getParameterType().getAnnotations());
+		return new TypeAndTypeAnnotations(type, Arrays.asList(methodParameter.getParameterType().getAnnotations()));
 	}
 
 	/**
 	 * Pair of resolved Java type and type annotations merged with parameter annotations for {@code extractSchema}.
 	 */
-	private record TypeAndTypeAnnotations(Type type, Annotation[] typeAnnotations) {
+	private record TypeAndTypeAnnotations(Type type, List<Annotation> typeAnnotations) {
 	}
 
 	/**

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/OperationService.java
@@ -248,7 +248,9 @@ public class OperationService {
 			case TRACE_METHOD -> pathItemObject.trace(operation);
 			case HEAD_METHOD -> pathItemObject.head(operation);
 			case OPTIONS_METHOD -> pathItemObject.options(operation);
-			default -> { }
+			default -> {
+				// best effort with regard to supported operations
+			}
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SchemaUtils.java
@@ -163,13 +163,17 @@ public class SchemaUtils {
 		}
 
 		// @Nullable/@NotNull
-		Boolean ann = nullableFromAnnotations(field);
-		if (ann != null) return ann;
+		Optional<Boolean> ann = nullableFromAnnotations(field);
+		if (ann.isPresent()) {
+			return ann.get();
+		}
 
 		// Kotlin nullability
 		if (kotlinUtilsOptional.isPresent() && isKotlinDeclaringClass(field)) {
-			Boolean kotlin = kotlinNullability(field);
-			if (kotlin != null) return kotlin;
+			Optional<Boolean> kotlin = kotlinNullability(field);
+			if (kotlin.isPresent()) {
+				return kotlin.get();
+			}
 		}
 
 		return JAVA_FIELD_NULLABLE_DEFAULT;
@@ -204,17 +208,15 @@ public class SchemaUtils {
 		// Kotlin logic
 		if (kotlinUtilsOptional.isPresent()  && isKotlinDeclaringClass(field)) {
 			if (fieldNullable(field)) return false;
-			Boolean hasDefault = kotlinConstructorParamIsOptional(field);
-			if (Boolean.TRUE.equals(hasDefault)) return false;
-			return true;
-		}
+            return kotlinConstructorParamIsOptional(field)
+					.map(isOptional -> !isOptional)
+					.orElse(true);
+        }
 
 		// Jackson @JsonProperty(required = true)
 		JsonProperty jp = getJsonProperty(field);
-		if (jp != null && jp.required()) return true;
-
-		return false;
-	}
+        return jp != null && jp.required();
+    }
 
 	/**
 	 * Apply validations to schema. the annotation order effects the result of the
@@ -376,15 +378,15 @@ public class SchemaUtils {
 	 * @param field the field
 	 * @return the boolean
 	 */
-	private static Boolean nullableFromAnnotations(Field field) {
-		if (hasNullableAnnotation(field)) return true;
-		if (hasNotNullAnnotation(field)) return false;
+	private static Optional<Boolean> nullableFromAnnotations(Field field) {
+		if (hasNullableAnnotation(field)) return Optional.of(true);
+		if (hasNotNullAnnotation(field)) return Optional.of(false);
 		Method getter = findGetter(field);
 		if (getter != null) {
-			if (hasNullableAnnotation(getter)) return true;
-			if (hasNotNullAnnotation(getter)) return false;
+			if (hasNullableAnnotation(getter)) return Optional.of(true);
+			if (hasNotNullAnnotation(getter)) return Optional.of(false);
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	/**
@@ -579,15 +581,13 @@ public class SchemaUtils {
 			return;
 		}
 		if (schema.getSpecVersion().equals(SpecVersion.V31)) {
-			if (schema.getExclusiveMaximumValue() != null && schema.getMaximum() != null) {
-				if (schema.getMaximum().compareTo(schema.getExclusiveMaximumValue()) == 0) {
-					schema.setMaximum(null);
-				}
+			if (schema.getExclusiveMaximumValue() != null && schema.getMaximum() != null
+				&& schema.getMaximum().compareTo(schema.getExclusiveMaximumValue()) == 0) {
+				schema.setMaximum(null);
 			}
-			if (schema.getExclusiveMinimumValue() != null && schema.getMinimum() != null) {
-				if (schema.getMinimum().compareTo(schema.getExclusiveMinimumValue()) == 0) {
-					schema.setMinimum(null);
-				}
+			if (schema.getExclusiveMinimumValue() != null && schema.getMinimum() != null &&
+				schema.getMinimum().compareTo(schema.getExclusiveMinimumValue()) == 0) {
+				schema.setMinimum(null);
 			}
 		}
 	}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocKotlinUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocKotlinUtils.java
@@ -27,6 +27,7 @@
 package org.springdoc.core.utils;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 
 import kotlin.jvm.JvmClassMappingKt;
 import kotlin.reflect.KClass;
@@ -46,6 +47,9 @@ import org.springframework.core.KotlinDetector;
  */
 public class SpringDocKotlinUtils {
 
+	public SpringDocKotlinUtils() {
+	}
+
 	/**
 	 * Is kotlin declaring class boolean.
 	 *
@@ -64,19 +68,18 @@ public class SpringDocKotlinUtils {
 	 * @param f the f
 	 * @return the boolean
 	 */
-	private static Boolean kotlinMarkedNullableFallback(Field f) {
+	private static Optional<Boolean> kotlinMarkedNullableFallback(Field f) {
 		try {
 			KClass<?> kClass = JvmClassMappingKt.getKotlinClass(f.getDeclaringClass());
-			for (Object pObj : KClasses.getMemberProperties((KClass<Object>) kClass)) {
-				KProperty1<?, ?> p = (KProperty1<?, ?>) pObj;
-				if (p.getName().equals(f.getName())) {
-					return p.getReturnType().isMarkedNullable();
+			for (KProperty1<?, ?> pObj : KClasses.getMemberProperties(kClass)) {
+				if (pObj.getName().equals(f.getName())) {
+					return Optional.of(pObj.getReturnType().isMarkedNullable());
 				}
 			}
 		} catch (Exception ignored) {
 			// best-effort only
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	/**
@@ -85,21 +88,21 @@ public class SpringDocKotlinUtils {
 	 * @param f the f
 	 * @return the boolean
 	 */
-	static Boolean kotlinConstructorParamIsOptional(Field f) {
+	static Optional<Boolean> kotlinConstructorParamIsOptional(Field f) {
 		try {
 			KClass<?> kClass = JvmClassMappingKt.getKotlinClass(f.getDeclaringClass());
 			KFunction<?> primary = KClasses.getPrimaryConstructor(kClass);
 			if (primary != null) {
 				for (KParameter p : primary.getParameters()) {
 					if (f.getName().equals(p.getName())) {
-						return p.isOptional();
+						return Optional.of(p.isOptional());
 					}
 				}
 			}
 		} catch (Exception ignored) {
 			// best-effort only
 		}
-		return null;
+		return Optional.empty();
 	}
 
 	/**
@@ -108,12 +111,12 @@ public class SpringDocKotlinUtils {
 	 * @param field the field
 	 * @return the boolean
 	 */
-	static Boolean kotlinNullability(Field field) {
-		if (!isKotlinDeclaringClass(field)) return null;
+	static Optional<Boolean> kotlinNullability(Field field) {
+		if (!isKotlinDeclaringClass(field)) return Optional.empty();
 
 		KProperty<?> prop = ReflectJvmMapping.getKotlinProperty(field);
 		if (prop != null) {
-			return prop.getReturnType().isMarkedNullable();
+			return Optional.of(prop.getReturnType().isMarkedNullable());
 		}
 
 		return kotlinMarkedNullableFallback(field);

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -201,10 +201,9 @@ public class SpringDocUtils {
 		if (additionalProperties instanceof Schema<?> addPropSchema) {
 			boolean isNullOnlyType = false;
 			Set<String> types = addPropSchema.getTypes();
-			if (types != null && types.size() == 1 && types.contains("null")) {
-				isNullOnlyType = true;
-			}
-			else if (types == null && "null".equals(addPropSchema.getType())) {
+			boolean onlyNullTypeOAS31 = types != null && types.size() == 1 && types.contains("null");
+			boolean onlyNullTypeOAS30 = types == null && "null".equals(addPropSchema.getType());
+			if (onlyNullTypeOAS31 || onlyNullTypeOAS30) {
 				isNullOnlyType = true;
 			}
 			if (isNullOnlyType && addPropSchema.get$ref() == null
@@ -214,7 +213,7 @@ public class SpringDocUtils {
 			}
 		}
 		if (schema.getProperties() != null) {
-			schema.getProperties().values().forEach(prop -> fixNullOnlyAdditionalProperties((Schema<?>) prop));
+			schema.getProperties().values().forEach(SpringDocUtils::fixNullOnlyAdditionalProperties);
 		}
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/scalar/ScalarConstants.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/scalar/ScalarConstants.java
@@ -33,6 +33,9 @@ package org.springdoc.scalar;
  */
 public class ScalarConstants {
 
+	private ScalarConstants() {
+	}
+
 	/**
 	 * The constant SCALAR_DEFAULT_PATH.
 	 */

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerConfigurer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/ui/AbstractSwaggerConfigurer.java
@@ -27,7 +27,9 @@
 package org.springdoc.ui;
 
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.springdoc.core.properties.SwaggerUiConfigProperties;
 
@@ -185,10 +187,10 @@ public abstract class AbstractSwaggerConfigurer {
 	 * @param patterns       the patterns to match.
 	 * @param locations      the locations to use.
 	 */
-	protected record SwaggerResourceHandlerConfig(boolean cacheResources, String[] patterns, String[] locations) {
+	protected record SwaggerResourceHandlerConfig(boolean cacheResources, List<String> patterns, List<String> locations) {
 
 		private SwaggerResourceHandlerConfig(boolean cacheResources) {
-			this(cacheResources, new String[]{}, new String[]{});
+			this(cacheResources, new ArrayList<>(), new ArrayList<>());
 		}
 
 		/**
@@ -199,7 +201,15 @@ public abstract class AbstractSwaggerConfigurer {
 		 * @return the updated config.
 		 */
 		public SwaggerResourceHandlerConfig setPatterns(String... patterns) {
-			return new SwaggerResourceHandlerConfig(cacheResources, patterns, locations);
+			return new SwaggerResourceHandlerConfig(cacheResources, Arrays.asList(patterns), locations);
+		}
+
+		/**
+		 *
+		 * @return String array of patterns
+		 */
+		public String[] patternsArray() {
+			return patterns.toArray(new String[0]);
 		}
 
 		/**
@@ -210,7 +220,15 @@ public abstract class AbstractSwaggerConfigurer {
 		 * @return the updated config.
 		 */
 		public SwaggerResourceHandlerConfig setLocations(String... locations) {
-			return new SwaggerResourceHandlerConfig(cacheResources, patterns, locations);
+			return new SwaggerResourceHandlerConfig(cacheResources, patterns, Arrays.asList(locations));
+		}
+
+		/**
+		 *
+		 * @return String array of locations
+		 */
+		public String[] locationsArray() {
+			return locations.toArray(new String[0]);
 		}
 
 		/**

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerWebFluxConfigurer.java
@@ -127,8 +127,8 @@ public class SwaggerWebFluxConfigurer extends AbstractSwaggerConfigurer implemen
 	 * @param handlerConfig the swagger handler config.
 	 */
 	protected void addSwaggerResourceHandler(ResourceHandlerRegistry registry, SwaggerResourceHandlerConfig handlerConfig) {
-		ResourceHandlerRegistration handlerRegistration = registry.addResourceHandler(handlerConfig.patterns());
-		handlerRegistration.addResourceLocations(handlerConfig.locations());
+		ResourceHandlerRegistration handlerRegistration = registry.addResourceHandler(handlerConfig.patternsArray());
+		handlerRegistration.addResourceLocations(handlerConfig.locationsArray());
 
 		ResourceChainRegistration chainRegistration;
 		if (handlerConfig.cacheResources()) {

--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerWebMvcConfigurer.java
@@ -145,8 +145,8 @@ public class SwaggerWebMvcConfigurer extends AbstractSwaggerConfigurer implement
 	 * @param handlerConfig the swagger handler config.
 	 */
 	protected void addSwaggerResourceHandler(ResourceHandlerRegistry registry, SwaggerResourceHandlerConfig handlerConfig) {
-		ResourceHandlerRegistration handlerRegistration = registry.addResourceHandler(handlerConfig.patterns());
-		handlerRegistration.addResourceLocations(handlerConfig.locations());
+		ResourceHandlerRegistration handlerRegistration = registry.addResourceHandler(handlerConfig.patternsArray());
+		handlerRegistration.addResourceLocations(handlerConfig.locationsArray());
 
 		ResourceChainRegistration chainRegistration;
 		if (handlerConfig.cacheResources()) {


### PR DESCRIPTION
This further acts upon SonarQube warnings. The [previous change](https://github.com/springdoc/springdoc-openapi/pull/3306) brought down warnings from 50 to 31, this should reduce it quite a bit further.

Do note that it will most likely be necessary to at least mark [this issue](https://sonarcloud.io/project/issues?severities=BLOCKER%2CCRITICAL%2CMAJOR%2CMINOR&sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&types=BUG&branch=main&id=springdoc_springdoc-openapi&open=AZpzBPzBjc8FABsDAMCY) as "accepted/invalid", since the project is failing due to insufficient reliability rating
<img width="341" height="108" alt="image" src="https://github.com/user-attachments/assets/8d11f1bd-9796-4659-b870-ff2a439d9ad4" />
but the issues highlighted is not possible to fix since the suggested `instanceOf` cannot be applied out of the box since the class is package private.