### PR TITLE
fix: Add a type deserializer to allow for JSON cloning of a JsonSchema object

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/deserializers/TypeSetDeserializer.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/deserializers/TypeSetDeserializer.java
@@ -1,0 +1,41 @@
+package org.springdoc.core.deserializers;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Reads an OpenAPI 3.1 schema "type" that swagger-core serializes as a scalar
+ * {@code "type": "integer"} back into the Set<String> field, while still supporting
+ * the array form {@code "type": ["string","null"]}.
+ * <p>
+ * Reported upstream with <a href="https://github.com/swagger-api/swagger-core/issues/5264">swagger-core issue 5264</a>
+ */
+public class TypeSetDeserializer extends JsonDeserializer<Set<String>> {
+
+    @Override
+    public Set<String> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonNode node = ctxt.readTree(p);
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        Set<String> types = new LinkedHashSet<>();
+        if (node.isArray()) {
+            node.forEach(n -> {
+                if (!n.isNull()) {
+                    types.add(n.asText());
+                }
+            });
+        }
+        else {
+            types.add(node.asText());
+        }
+        return types.isEmpty() ? null : types;
+    }
+
+}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/mixins/SchemaTypeMixin.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/mixins/SchemaTypeMixin.java
@@ -1,0 +1,15 @@
+package org.springdoc.core.mixins;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.springdoc.core.deserializers.TypeSetDeserializer;
+
+import java.util.Set;
+
+public interface SchemaTypeMixin {
+
+    @JsonProperty("type")
+    @JsonDeserialize(using = TypeSetDeserializer.class)
+    void setTypes(Set<String> types);
+
+}

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/providers/ObjectMapperProvider.java
@@ -35,11 +35,13 @@ import io.swagger.v3.core.util.ObjectMapperFactory;
 import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.JsonSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.mixins.SortedOpenAPIMixin;
 import org.springdoc.core.mixins.SortedOpenAPIMixin31;
 import org.springdoc.core.mixins.SortedSchemaMixin;
 import org.springdoc.core.mixins.SortedSchemaMixin31;
+import org.springdoc.core.mixins.SchemaTypeMixin;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SpringDocConfigProperties.ApiDocs.OpenApiVersion;
 
@@ -74,6 +76,7 @@ public class ObjectMapperProvider extends ObjectMapperFactory {
 		if (openApiVersion == OpenApiVersion.OPENAPI_3_1) {
 			jsonMapper = Json31.mapper();
 			yamlMapper = Yaml31.mapper();
+			jsonMapper.addMixIn(JsonSchema.class, SchemaTypeMixin.class);
 			if (springDocConfigProperties.isUseArbitrarySchemas()) {
 				System.setProperty(Schema.USE_ARBITRARY_SCHEMA_PROPERTY, "true");
 			}

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/utils/SpringDocUtilsTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/utils/SpringDocUtilsTest.java
@@ -1,0 +1,64 @@
+package org.springdoc.core.utils;
+
+import io.swagger.v3.oas.models.media.JsonSchema;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.properties.SpringDocConfigProperties;
+import org.springdoc.core.providers.ObjectMapperProvider;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpringDocUtilsTest {
+
+    @Test
+    void singleTypeForJsonSchemaJsonCloning() {
+        SpringDocConfigProperties props = new SpringDocConfigProperties();
+        props.getApiDocs().setVersion(SpringDocConfigProperties.ApiDocs.OpenApiVersion.OPENAPI_3_1);
+        ObjectMapperProvider provider = new ObjectMapperProvider(props);
+
+        JsonSchema jsonSchema = new JsonSchema();
+        jsonSchema.setTypes(Set.of("integer"));
+
+        JsonSchema cloned = SpringDocUtils.cloneViaJson(jsonSchema, JsonSchema.class, provider.jsonMapper());
+
+        // The object is cloned properly, we do not get the type cast fallback
+        assertNotSame(jsonSchema, cloned);
+        assertNotNull(cloned);
+        assertEquals(Set.of("integer"), cloned.getTypes());
+    }
+
+    @Test
+    void nullTypeBecomesNullTypesForJsonSchemaJsonCloning() {
+        SpringDocConfigProperties props = new SpringDocConfigProperties();
+        props.getApiDocs().setVersion(SpringDocConfigProperties.ApiDocs.OpenApiVersion.OPENAPI_3_1);
+        ObjectMapperProvider provider = new ObjectMapperProvider(props);
+
+        JsonSchema jsonSchema = new JsonSchema();
+
+        JsonSchema cloned = SpringDocUtils.cloneViaJson(jsonSchema, JsonSchema.class, provider.jsonMapper());
+
+        // The object is cloned properly, we do not get the type cast fallback
+        assertNotSame(jsonSchema, cloned);
+        assertNotNull(cloned);
+        assertNull(cloned.getTypes());
+    }
+
+    @Test
+    void typeArrayIsRetainedForJsonSchemaJsonCloning() {
+        SpringDocConfigProperties props = new SpringDocConfigProperties();
+        props.getApiDocs().setVersion(SpringDocConfigProperties.ApiDocs.OpenApiVersion.OPENAPI_3_1);
+        ObjectMapperProvider provider = new ObjectMapperProvider(props);
+
+        JsonSchema jsonSchema = new JsonSchema();
+        jsonSchema.setTypes(Set.of("integer", "null"));
+
+        JsonSchema cloned = SpringDocUtils.cloneViaJson(jsonSchema, JsonSchema.class, provider.jsonMapper());
+
+        // The object is cloned properly, we do not get the type cast fallback
+        assertNotSame(jsonSchema, cloned);
+        assertNotNull(cloned);
+        assertEquals(Set.of("integer", "null"), cloned.getTypes());
+    }
+
+}


### PR DESCRIPTION
Change https://github.com/springdoc/springdoc-openapi/commit/47002081dde26868d36b43a2ec1577ac408cd01b introduced logic that involved cloning a schema with `schema = cloneViaJson(schema, schema.getClass(), parameterBuilder.getObjectMapperProvider().jsonMapper());`. This logic will fail for an OAS 3.1 specification, since the `JsonSchema` from swagger-core is not symmetric with regard to the `type(s)` field when doing back and forth de/serialization. See [serialization configuration](https://github.com/swagger-api/swagger-core/blob/master/modules/swagger-core/src/main/java/io/swagger/v3/core/jackson/mixin/Schema31Mixin.java#L65).

This means that `types: [integer]` becomes `type: integer`, which then cannot be deserialized back into `JsonSchema`.

This PR adjusts for that issue by adding a `JsonSchema` `Mixin` that forwards the `type` field into `types`.

Fixes https://github.com/springdoc/springdoc-openapi/issues/3314