### PR TITLE
SpringDocWebMvcConfiguration relies on unspecified autoconfiguration ordering. Fixes #3313

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocDataRestConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocDataRestConfiguration.java
@@ -47,6 +47,7 @@ import org.springdoc.core.service.OperationService;
 import org.springdoc.core.utils.SpringDocDataRestUtils;
 import tools.jackson.databind.ObjectMapper;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -77,6 +78,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-data-rest:true}")
 @ConditionalOnClass(RepositoryRestConfiguration.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocFunctionCatalogConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocFunctionCatalogConfiguration.java
@@ -32,6 +32,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.CloudFunctionProvider;
 import org.springdoc.core.providers.SpringCloudFunctionProvider;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -50,6 +51,7 @@ import org.springframework.context.annotation.Lazy;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.show-spring-cloud-functions:true}")
 @ConditionalOnClass(FunctionEndpointInitializer.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocGroovyConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocGroovyConfiguration.java
@@ -32,6 +32,7 @@ import org.springdoc.core.converters.JavaTypeToIgnoreConverter;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.utils.SpringDocUtils;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -47,6 +48,7 @@ import org.springframework.context.annotation.Lazy;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-groovy:true}")
 @ConditionalOnClass(MetaClass.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocHateoasConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocHateoasConfiguration.java
@@ -37,6 +37,7 @@ import org.springdoc.core.providers.HateoasHalProvider;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.utils.Constants;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -55,6 +56,7 @@ import org.springframework.hateoas.server.LinkRelationProvider;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-hateoas:true}")
 @ConditionalOnClass({LinkRelationProvider.class, HateoasProperties.class})
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocJacksonKotlinModuleConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocJacksonKotlinModuleConfiguration.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.module.kotlin.KotlinModule;
 import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.providers.ObjectMapperProvider;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -46,6 +47,7 @@ import org.springframework.context.annotation.Primary;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnClass(KotlinModule.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-kotlin:true}")
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocJavadocConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocJavadocConfiguration.java
@@ -32,6 +32,7 @@ import org.springdoc.core.providers.JavadocProvider;
 import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.providers.SpringDocJavadocProvider;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -50,6 +51,7 @@ import org.springframework.core.annotation.Order;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-javadoc:true}")
 @ConditionalOnClass(CommentFormatter.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinConfiguration.kt
@@ -33,6 +33,7 @@ import org.springdoc.core.providers.ObjectMapperProvider
 import org.springdoc.core.utils.Constants
 import org.springdoc.core.utils.SpringDocKotlinUtils
 import org.springdoc.core.utils.SpringDocUtils
+import org.springframework.boot.autoconfigure.AutoConfigureAfter
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression
@@ -50,6 +51,7 @@ import kotlin.coroutines.Continuation
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration::class)
 @ConditionalOnProperty(name = [Constants.SPRINGDOC_ENABLED], matchIfMissing = true)
 @ConditionalOnExpression("\${springdoc.api-docs.enabled:true} and \${springdoc.enable-kotlin:true}")
 @ConditionalOnClass(Continuation::class)

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinxConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocKotlinxConfiguration.java
@@ -28,6 +28,7 @@ package org.springdoc.core.configuration;
 
 import kotlinx.coroutines.flow.Flow;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -44,6 +45,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-kotlin:true}")
 @ConditionalOnClass(Flow.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocPageableConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocPageableConfiguration.java
@@ -35,6 +35,7 @@ import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.providers.RepositoryRestConfigurationProvider;
 import org.springdoc.core.providers.SpringDataWebPropertiesProvider;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -59,6 +60,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnClass(Pageable.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSecurityConfiguration.java
@@ -46,6 +46,7 @@ import org.springdoc.core.configuration.hints.SpringDocSecurityHints;
 import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -81,6 +82,7 @@ import static org.springdoc.core.utils.SpringSecurityUtils.getPath;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnExpression("${springdoc.api-docs.enabled:true} and ${springdoc.enable-spring-security:true}")
 @ConditionalOnClass(SecurityFilterChain.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSortConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSortConfiguration.java
@@ -34,6 +34,7 @@ import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springdoc.core.providers.RepositoryRestConfigurationProvider;
 import org.springdoc.core.providers.SpringDataWebPropertiesProvider;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -55,6 +56,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnClass(Sort.class)
 @ConditionalOnWebApplication

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSpecPropertiesConfiguration.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/configuration/SpringDocSpecPropertiesConfiguration.java
@@ -36,6 +36,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springdoc.core.properties.SpringDocConfigProperties.GroupConfig;
 
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -51,6 +52,7 @@ import org.springframework.context.annotation.Lazy;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnBean(SpringDocConfiguration.class)
 @Conditional(SpecPropertiesCondition.class)
 public class SpringDocSpecPropertiesConfiguration {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SpringDocConfigProperties.java
@@ -38,6 +38,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties.ApiDocs.OpenApiVe
 import org.springdoc.core.utils.Constants;
 
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -55,6 +56,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_ENABLED;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConfigurationProperties(prefix = Constants.SPRINGDOC_PREFIX)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiConfigProperties.java
@@ -37,6 +37,7 @@ import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.utils.Constants;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -58,6 +59,7 @@ import static org.springframework.util.AntPathMatcher.DEFAULT_PATH_SEPARATOR;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConfigurationProperties(prefix = SPRINGDOC_SWAGGER_PREFIX)
 @ConditionalOnProperty(name = SPRINGDOC_SWAGGER_UI_ENABLED, matchIfMissing = true)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiOAuthProperties.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/properties/SwaggerUiOAuthProperties.java
@@ -34,6 +34,7 @@ import java.util.TreeMap;
 import org.springdoc.core.configuration.SpringDocConfiguration;
 import org.springdoc.core.utils.SpringDocPropertiesUtils;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -52,6 +53,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_SWAGGER_UI_ENABLED;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConfigurationProperties(prefix = "springdoc.swagger-ui.oauth")
 @ConditionalOnProperty(name = SPRINGDOC_SWAGGER_UI_ENABLED, matchIfMissing = true)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/configuration/MultipleOpenApiSupportConfiguration.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/configuration/MultipleOpenApiSupportConfiguration.java
@@ -44,6 +44,7 @@ import org.springdoc.webflux.api.MultipleOpenApiWebFluxResource;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -66,6 +67,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_MANAGEMENT_PORT;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @Conditional(MultipleOpenApiSupportCondition.class)

--- a/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/configuration/SpringDocWebFluxConfiguration.java
+++ b/springdoc-openapi-starter-webflux-api/src/main/java/org/springdoc/webflux/core/configuration/SpringDocWebFluxConfiguration.java
@@ -61,6 +61,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointPr
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -83,6 +84,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_ENABLED;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webflux-scalar/src/main/java/org/springdoc/webflux/scalar/ScalarConfiguration.java
+++ b/springdoc-openapi-starter-webflux-scalar/src/main/java/org/springdoc/webflux/scalar/ScalarConfiguration.java
@@ -34,6 +34,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -58,6 +59,7 @@ import static org.springdoc.scalar.ScalarConstants.DEFAULT_SCALAR_ACTUATOR_PATH;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SCALAR_ENABLED, matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.REACTIVE)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
+++ b/springdoc-openapi-starter-webflux-ui/src/main/java/org/springdoc/webflux/ui/SwaggerConfig.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -69,6 +70,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_ROOT_PATH;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SPRINGDOC_SWAGGER_UI_ENABLED, matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.REACTIVE)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/configuration/SpringDocWebMvcConfiguration.java
+++ b/springdoc-openapi-starter-webmvc-api/src/main/java/org/springdoc/webmvc/core/configuration/SpringDocWebMvcConfiguration.java
@@ -62,6 +62,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointPr
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -88,6 +89,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getConfig;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnProperty(name = SPRINGDOC_ENABLED, matchIfMissing = true)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/org/springdoc/autoconfigure/SpringDocAutoConfigurationOrderTest.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/org/springdoc/autoconfigure/SpringDocAutoConfigurationOrderTest.java
@@ -1,0 +1,146 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package org.springdoc.autoconfigure;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.configuration.SpringDocConfiguration;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.classreading.MetadataReaderFactory;
+import org.springframework.core.type.classreading.SimpleMetadataReaderFactory;
+import org.springframework.util.StringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An auto-configuration that is only registered when {@link SpringDocConfiguration} already
+ * contributed its beans has to declare that order, otherwise the {@code @ConditionalOnBean} match
+ * depends on where the class name happens to sort in Spring Boot's auto-configuration sort. A
+ * third-party auto-configuration that sorts earlier and orders itself around a springdoc
+ * auto-configuration is then enough to move that class ahead of {@link SpringDocConfiguration},
+ * which silently drops it (gh-3313).
+ *
+ * @author kdelay
+ */
+class SpringDocAutoConfigurationOrderTest {
+
+	private static final String IMPORTS_RESOURCE = "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports";
+
+	private final MetadataReaderFactory metadataReaderFactory = new SimpleMetadataReaderFactory();
+
+	@Test
+	void auto_configurations_conditional_on_spring_doc_configuration_declare_their_order() throws IOException {
+		List<String> gatedWithoutDeclaredOrder = new ArrayList<>();
+		for (String candidate : autoConfigurationImports()) {
+			AnnotationMetadata metadata = annotationMetadata(candidate);
+			if (isConditionalOnSpringDocConfiguration(metadata) && !declaresOrderAfterSpringDocConfiguration(metadata)) {
+				gatedWithoutDeclaredOrder.add(candidate);
+			}
+		}
+		assertThat(gatedWithoutDeclaredOrder).isEmpty();
+	}
+
+	private Set<String> autoConfigurationImports() throws IOException {
+		Set<String> candidates = new LinkedHashSet<>();
+		Enumeration<URL> resources = getClass().getClassLoader().getResources(IMPORTS_RESOURCE);
+		while (resources.hasMoreElements()) {
+			try (InputStream inputStream = resources.nextElement().openStream()) {
+				String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+				for (String line : content.split("\n")) {
+					String candidate = line.trim();
+					if (StringUtils.hasText(candidate) && candidate.startsWith("org.springdoc.")) {
+						candidates.add(candidate);
+					}
+				}
+			}
+		}
+		assertThat(candidates).isNotEmpty();
+		return candidates;
+	}
+
+	/**
+	 * Reads the annotations without loading the class, because several of these
+	 * auto-configurations reference optional types that are absent from this module's classpath.
+	 * @param candidate the auto-configuration class name as written in the imports file
+	 * @return the annotation metadata
+	 */
+	private AnnotationMetadata annotationMetadata(String candidate) throws IOException {
+		try {
+			return this.metadataReaderFactory.getMetadataReader(candidate).getAnnotationMetadata();
+		}
+		catch (IOException ex) {
+			// nested classes are written with a dot separator in the imports file
+			int lastDot = candidate.lastIndexOf('.');
+			String nested = candidate.substring(0, lastDot) + '$' + candidate.substring(lastDot + 1);
+			return this.metadataReaderFactory.getMetadataReader(nested).getAnnotationMetadata();
+		}
+	}
+
+	private boolean isConditionalOnSpringDocConfiguration(AnnotationMetadata metadata) {
+		return referencesSpringDocConfiguration(metadata.getAnnotationAttributes(ConditionalOnBean.class.getName(), true),
+				"value", "name");
+	}
+
+	private boolean declaresOrderAfterSpringDocConfiguration(AnnotationMetadata metadata) {
+		return referencesSpringDocConfiguration(metadata.getAnnotationAttributes(AutoConfigureAfter.class.getName(), true),
+				"value", "name")
+				|| referencesSpringDocConfiguration(metadata.getAnnotationAttributes(AutoConfiguration.class.getName(), true),
+						"after", "afterName");
+	}
+
+	private boolean referencesSpringDocConfiguration(Map<String, Object> attributes, String... attributeNames) {
+		if (attributes == null) {
+			return false;
+		}
+		for (String attributeName : attributeNames) {
+			Object value = attributes.get(attributeName);
+			if (value instanceof String[] values
+					&& Arrays.asList(values).contains(SpringDocConfiguration.class.getName())) {
+				return true;
+			}
+			if (value instanceof Collection<?> values && values.contains(SpringDocConfiguration.class.getName())) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/springdoc-openapi-starter-webmvc-scalar/src/main/java/org/springdoc/webmvc/scalar/ScalarConfiguration.java
+++ b/springdoc-openapi-starter-webmvc-scalar/src/main/java/org/springdoc/webmvc/scalar/ScalarConfiguration.java
@@ -34,6 +34,7 @@ import org.springdoc.core.properties.SpringDocConfigProperties;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -59,6 +60,7 @@ import static org.springdoc.scalar.ScalarConstants.DEFAULT_SCALAR_ACTUATOR_PATH;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SCALAR_ENABLED, matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.SERVLET)
 @ConditionalOnBean(SpringDocConfiguration.class)

--- a/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
+++ b/springdoc-openapi-starter-webmvc-ui/src/main/java/org/springdoc/webmvc/ui/SwaggerConfig.java
@@ -41,6 +41,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.server.ConditionalOnManagementPort;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementPortType;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -68,6 +69,7 @@ import static org.springdoc.core.utils.Constants.SPRINGDOC_USE_ROOT_PATH;
  */
 @Lazy(false)
 @Configuration(proxyBeanMethods = false)
+@AutoConfigureAfter(SpringDocConfiguration.class)
 @ConditionalOnProperty(name = SPRINGDOC_SWAGGER_UI_ENABLED, matchIfMissing = true)
 @ConditionalOnWebApplication(type = Type.SERVLET)
 @ConditionalOnBean(SpringDocConfiguration.class)


### PR DESCRIPTION
Fixes #3313

## Problem

`SpringDocWebMvcConfiguration` is gated on `@ConditionalOnBean(SpringDocConfiguration.class)` but never declares that it has to be evaluated after `SpringDocConfiguration`. The condition matches today only because `org.springdoc.core.configuration.SpringDocConfiguration` happens to sort before `org.springdoc.webmvc.core.configuration.SpringDocWebMvcConfiguration` in Spring Boot's auto-configuration sort.

Any ordinary third-party auto-configuration whose class name sorts earlier and which orders itself around a springdoc auto-configuration changes the topological sort. `SpringDocWebMvcConfiguration` is then evaluated before `SpringDocConfiguration` is registered, the `@ConditionalOnBean` does not match, and `OpenApiWebMvcResource` disappears with no error.

The same undeclared assumption exists in every other auto-configuration entry that is gated on `SpringDocConfiguration`, so this is not specific to Web MVC. The `-mcp` starters already declare it (`@AutoConfiguration(after = SpringDocConfiguration.class)`); the older `@Configuration`-based ones do not.

## Change

Added `@AutoConfigureAfter(SpringDocConfiguration.class)` to the 22 auto-configuration entries that carry `@ConditionalOnBean(SpringDocConfiguration.class)`, across the common, webmvc/webflux api, ui and scalar starters. No behaviour other than registration order is touched.

Added `SpringDocAutoConfigurationOrderTest`, which reads every `AutoConfiguration.imports` entry on the classpath with ASM (no class loading, since several entries reference optional types) and asserts that anything gated on `SpringDocConfiguration` also declares the order. On the unmodified tree it reports every affected class; it is what surfaced `SpringDocKotlinConfiguration`, which is easy to miss because it is a `.kt` file.

## Verification

Reproduced with the reporter's project from #3313 (Spring Boot 4.1.0 + Jetty, the two springdoc starters, and one third-party `@AutoConfiguration(after = SpringDocWebMvcConfiguration.class)` contributing no beans), on JDK 17 / macOS:

- springdoc 3.1.0: `OpenApiMissingWithThirdPartyAutoConfigTest` fails, `OpenApiWebMvcResource` is absent. The baseline test that excludes the third-party auto-configuration passes.
- this branch installed as 3.1.1-SNAPSHOT: both tests pass, `Tests run: 2, Failures: 0`.

`mvn install` on the full reactor passes on this branch, with two exceptions that also fail on unmodified `main` here (checked out `main` and re-ran both): `test.org.springdoc.api.v31.app193.SpringDocApp193Test` in the webmvc-api module (`components.schemas.Animal Expected: type but none found`) and `test.org.springdoc.api.v31.app3.SpringDocApp3Test` in the kotlin-webmvc-tests module (`components.schemas.Foo.properties.bar Unexpected: uniqueItems`). Every other module is green, 647 tests in webmvc-api included.

Note for reviewers: this cannot be reproduced through `ApplicationContextRunner` with `AutoConfigurations.of(...)`. I tried that first and the test passed with and without the fix, because the ordering constraint only takes effect through the real `AutoConfiguration.imports` mechanism. That is why the added test asserts the declared order instead of booting a context.
