### PR TITLE
fix: prevent leaking container validation annotations

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/DelegatingMethodParameter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/extractor/DelegatingMethodParameter.java
@@ -309,10 +309,10 @@ public class DelegatingMethodParameter extends MethodParameter {
 	}
 
 	/**
-	 * Gets field. If Is parameter object. then The Field should be not null
+	 * Gets field. If it is a parameter object, then The {@code Field} should be not null.
+	 * see {@link DelegatingMethodParameter#isParameterObject()}
 	 *
 	 * @return the field
-	 * @see #isParameterObject #isParameterObject#isParameterObject
 	 */
 	@Nullable
 	public Field getField() {

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/AbstractRequestService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/AbstractRequestService.java
@@ -710,17 +710,16 @@ public abstract class AbstractRequestService {
 				parameter.setSchema(schema);
 			}
 			SchemaUtils.applyValidationsToSchema(schema, annotations, openapiVersion);
-			if (schema instanceof ArraySchema && methodParameter instanceof DelegatingMethodParameter mp) {
+			if (schema instanceof ArraySchema && methodParameter instanceof DelegatingMethodParameter delegatingMethodParameter) {
 				java.lang.reflect.AnnotatedType annotatedType = null;
 				if (isParameterObject) {
-					Field field = mp.getField();
+					Field field = delegatingMethodParameter.getField();
 					if (field != null) {
 						annotatedType = field.getAnnotatedType();
 					}
 				}
 				else {
-					java.lang.reflect.Parameter param = mp.getParameter();
-					annotatedType = param.getAnnotatedType();
+					annotatedType = delegatingMethodParameter.getParameter().getAnnotatedType();
 				}
 				if (annotatedType instanceof AnnotatedParameterizedType paramType) {
 					java.lang.reflect.AnnotatedType[] typeArgs = paramType.getAnnotatedActualTypeArguments();

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/service/GenericParameterService.java
@@ -431,7 +431,7 @@ public class GenericParameterService {
 	 */
 	private TypeAndTypeAnnotations resolveTypeAndTypeAnnotationsForParameter(MethodParameter methodParameter) {
 		if (methodParameter instanceof DelegatingMethodParameter delegatingMethodParameter
-				&& delegatingMethodParameter.getField() != null) {
+            && delegatingMethodParameter.getField() != null) {
 			AnnotatedType annotated = delegatingMethodParameter.getField().getAnnotatedType();
 			Type type = GenericTypeResolver.resolveType(annotated.getType(), methodParameter.getContainingClass());
 			return new TypeAndTypeAnnotations(type, Arrays.asList(annotationsFromAnnotatedTypeArguments(annotated)));
@@ -448,7 +448,11 @@ public class GenericParameterService {
 					: new TypeAndTypeAnnotations(type, new ArrayList<>());
 		}
 
-		return new TypeAndTypeAnnotations(type, Arrays.asList(methodParameter.getParameterType().getAnnotations()));
+		AnnotatedType annotated = methodParameter.getParameter().getAnnotatedType();
+		List<Annotation> parameterAnnotations = Stream.concat(
+				Arrays.stream(annotationsFromAnnotatedTypeArguments(annotated)),
+				Arrays.stream(methodParameter.getParameterType().getAnnotations())).toList();
+		return new TypeAndTypeAnnotations(type, parameterAnnotations);
 	}
 
 	/**

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app267/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v30/app267/HelloController.java
@@ -16,16 +16,26 @@
 
 package test.org.springdoc.api.v30.app267;
 
+import jakarta.validation.constraints.Pattern;
 import org.springdoc.core.annotations.ParameterObject;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 public class HelloController {
 
-	@GetMapping("/items")
-	public String list(@ParameterObject PersonQueryFilter criteria) {
-		return "ok";
-	}
+    @GetMapping("/items")
+    public String list(@ParameterObject PersonQueryFilter criteria) {
+        return "ok";
+    }
+
+    @GetMapping("/persons")
+    public String persons(
+            List<@Pattern(regexp = "^[a-zA-Z]$") String> middleNames,
+            List<@Pattern(regexp = "^\\d+$") String> phoneNumbers) {
+        return "ok";
+    }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app267/HelloController.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app267/HelloController.java
@@ -16,16 +16,26 @@
 
 package test.org.springdoc.api.v31.app267;
 
+import jakarta.validation.constraints.Pattern;
 import org.springdoc.core.annotations.ParameterObject;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 public class HelloController {
 
-	@GetMapping("/items")
-	public String list(@ParameterObject PersonQueryFilter criteria) {
-		return "ok";
-	}
+    @GetMapping("/items")
+    public String list(@ParameterObject PersonQueryFilter criteria) {
+        return "ok";
+    }
+
+    @GetMapping("/persons")
+    public String persons(
+            List<@Pattern(regexp = "^[a-zA-Z]$") String> middleNames,
+            List<@Pattern(regexp = "^\\d+$") String> phoneNumbers) {
+        return "ok";
+    }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app267.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app267.json
@@ -1,65 +1,98 @@
 {
-  "openapi": "3.0.1",
-  "info": {
-    "title": "OpenAPI definition",
-    "version": "v0"
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "OpenAPI definition",
+    "version" : "v0"
   },
-  "servers": [
-    {
-      "url": "http://localhost",
-      "description": "Generated server url"
-    }
-  ],
-  "paths": {
-    "/items": {
-      "get": {
-        "tags": [
-          "hello-controller"
-        ],
-        "operationId": "list",
-        "parameters": [
-          {
-            "name": "firstNames",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+  "servers" : [ {
+    "url" : "http://localhost",
+    "description" : "Generated server url"
+  } ],
+  "paths" : {
+    "/persons" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "persons",
+        "parameters" : [ {
+          "name" : "middleNames",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "pattern" : "^[a-zA-Z]$",
+              "type" : "string"
             }
-          },
-          {
-            "name": "middleNames",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
+          }
+        }, {
+          "name" : "phoneNumbers",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "pattern" : "^\\d+$",
+              "type" : "string"
             }
-          },
-          {
-            "name": "phoneNumbers",
-            "in": "query",
-            "required": false,
-            "schema": {
-              "type": "array",
-              "items": {
-                "pattern": "^\\d+$",
-                "type": "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
               }
             }
           }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
+        }
+      }
+    },
+    "/items" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "list",
+        "parameters" : [ {
+          "name" : "firstNames",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "middleNames",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "phoneNumbers",
+          "in" : "query",
+          "required" : false,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "pattern" : "^\\d+$",
+              "type" : "string"
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
                 }
               }
             }
@@ -68,5 +101,5 @@
       }
     }
   },
-  "components": {}
+  "components" : { }
 }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app267.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app267.json
@@ -9,6 +9,47 @@
     "description" : "Generated server url"
   } ],
   "paths" : {
+    "/persons" : {
+      "get" : {
+        "tags" : [ "hello-controller" ],
+        "operationId" : "persons",
+        "parameters" : [ {
+          "name" : "middleNames",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "pattern" : "^[a-zA-Z]$"
+            }
+          }
+        }, {
+          "name" : "phoneNumbers",
+          "in" : "query",
+          "required" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string",
+              "pattern" : "^\\d+$"
+            }
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "*/*" : {
+                "schema" : {
+                  "type" : "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/items" : {
       "get" : {
         "tags" : [ "hello-controller" ],


### PR DESCRIPTION
Adds so that the method parameter annotations are read with `methodParameter.getParameter().getAnnotatedType()` so that it is considered when handling the schema at the resolver. 

The issue before was that the annotation was entirely missing in the resolving stage, which lead to schema being cached with the annotation present (which is an issue since the key calculation does not consider any annotations). This in turn lead to the schema being re-resolved with constraints already present, which then meant that they would all share the constraint that was last applied to the object.

The new behavior matches how the constraint annotation application done in `applyBeanValidatorAnnotations` finds the annotations that it should apply to the schema.

Fixes: https://github.com/springdoc/springdoc-openapi/issues/3318