### PR TITLE
Fix customizer ordering

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractMultipleOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractMultipleOpenApiResource.java
@@ -128,7 +128,7 @@ public abstract class AbstractMultipleOpenApiResource<R extends AbstractOpenApiR
 		this.groupedOpenApis.forEach(groupedOpenApi -> {
 					groupedOpenApi.addAllOpenApiCustomizer(springDocCustomizers.getGlobalOpenApiCustomizersStream().toList());
 					groupedOpenApi.addAllOperationCustomizer(springDocCustomizers.getGlobalOperationCustomizersStream().toList());
-					groupedOpenApi.addAllOpenApiMethodFilter(springDocCustomizers.getGlobalOpenApiMethodFiltersStream().toList());
+					springDocCustomizers.getGlobalOpenApiMethodFilters().ifPresent(groupedOpenApi::addAllOpenApiMethodFilter);
 				}
 		);
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractMultipleOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractMultipleOpenApiResource.java
@@ -126,9 +126,9 @@ public abstract class AbstractMultipleOpenApiResource<R extends AbstractOpenApiR
 	@Override
 	public void afterPropertiesSet() {
 		this.groupedOpenApis.forEach(groupedOpenApi -> {
-					springDocCustomizers.getGlobalOpenApiCustomizers().ifPresent(groupedOpenApi::addAllOpenApiCustomizer);
-					springDocCustomizers.getGlobalOperationCustomizers().ifPresent(groupedOpenApi::addAllOperationCustomizer);
-					springDocCustomizers.getGlobalOpenApiMethodFilters().ifPresent(groupedOpenApi::addAllOpenApiMethodFilter);
+					groupedOpenApi.addAllOpenApiCustomizer(springDocCustomizers.getGlobalOpenApiCustomizersStream().toList());
+					groupedOpenApi.addAllOperationCustomizer(springDocCustomizers.getGlobalOperationCustomizersStream().toList());
+					groupedOpenApi.addAllOpenApiMethodFilter(springDocCustomizers.getGlobalOpenApiMethodFiltersStream().toList());
 				}
 		);
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/api/AbstractOpenApiResource.java
@@ -428,8 +428,8 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 				List<Server> servers = openAPI.getServers();
 				List<Server> serversCopy = cloneViaJson(servers,  new TypeReference<List<Server>>() {},  springDocProviders.jsonMapper());
 
-				openAPIService.getContext().getBeansOfType(OpenApiLocaleCustomizer.class).values().forEach(openApiLocaleCustomizer -> openApiLocaleCustomizer.customise(openAPI, finalLocale));
-				springDocCustomizers.getOpenApiCustomizers().ifPresent(apiCustomizers -> apiCustomizers.forEach(openApiCustomizer -> openApiCustomizer.customise(openAPI)));
+				openAPIService.getContext().getBeanProvider(OpenApiLocaleCustomizer.class).orderedStream().forEach(openApiLocaleCustomizer -> openApiLocaleCustomizer.customise(openAPI, finalLocale));
+				springDocCustomizers.getOpenApiCustomizersStream().forEach(openApiCustomizer -> openApiCustomizer.customise(openAPI));
 				if (!CollectionUtils.isEmpty(openAPI.getServers()) && !openAPI.getServers().equals(serversCopy))
 					openAPIService.setServersPresent(true);
 
@@ -863,13 +863,8 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 * @return the router operation
 	 */
 	private RouterOperation customizeDataRestRouterOperation(RouterOperation routerOperation) {
-		Optional<Set<DataRestRouterOperationCustomizer>> optionalDataRestRouterOperationCustomizers = springDocCustomizers.getDataRestRouterOperationCustomizers();
-		if (optionalDataRestRouterOperationCustomizers.isPresent()) {
-			Set<DataRestRouterOperationCustomizer> dataRestRouterOperationCustomizerList = optionalDataRestRouterOperationCustomizers.get();
-			for (DataRestRouterOperationCustomizer dataRestRouterOperationCustomizer : dataRestRouterOperationCustomizerList) {
-				routerOperation = dataRestRouterOperationCustomizer.customize(routerOperation);
-			}
-		}
+		for (DataRestRouterOperationCustomizer dataRestRouterOperationCustomizer : springDocCustomizers.getDataRestRouterOperationCustomizersStream().toList())
+			routerOperation = dataRestRouterOperationCustomizer.customize(routerOperation);
 		return routerOperation;
 	}
 
@@ -1115,15 +1110,11 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 * @return the operation
 	 */
 	protected Operation customizeOperation(Operation operation, Components components, HandlerMethod handlerMethod) {
-		Optional<Set<OperationCustomizer>> optionalOperationCustomizers = springDocCustomizers.getOperationCustomizers();
-		if (optionalOperationCustomizers.isPresent()) {
-			Set<OperationCustomizer> operationCustomizerList = optionalOperationCustomizers.get();
-			for (OperationCustomizer operationCustomizer : operationCustomizerList) {
-				if (operationCustomizer instanceof GlobalOperationComponentsCustomizer globalOperationComponentsCustomizer)
-					operation = globalOperationComponentsCustomizer.customize(operation, components, handlerMethod);
-				else
-					operation = operationCustomizer.customize(operation, handlerMethod);
-			}
+		for (OperationCustomizer operationCustomizer : springDocCustomizers.getOperationCustomizersStream().toList()) {
+			if (operationCustomizer instanceof GlobalOperationComponentsCustomizer globalOperationComponentsCustomizer)
+				operation = globalOperationComponentsCustomizer.customize(operation, components, handlerMethod);
+			else
+				operation = operationCustomizer.customize(operation, handlerMethod);
 		}
 		return operation;
 	}
@@ -1136,13 +1127,8 @@ public abstract class AbstractOpenApiResource extends SpecFilter {
 	 * @return the router operation
 	 */
 	protected RouterOperation customizeRouterOperation(RouterOperation routerOperation, HandlerMethod handlerMethod) {
-		Optional<Set<RouterOperationCustomizer>> optionalRouterOperationCustomizers = springDocCustomizers.getRouterOperationCustomizers();
-		if (optionalRouterOperationCustomizers.isPresent()) {
-			Set<RouterOperationCustomizer> routerOperationCustomizerList = optionalRouterOperationCustomizers.get();
-			for (RouterOperationCustomizer routerOperationCustomizer : routerOperationCustomizerList) {
-				routerOperation = routerOperationCustomizer.customize(routerOperation, handlerMethod);
-			}
-		}
+		for (RouterOperationCustomizer routerOperationCustomizer : springDocCustomizers.getRouterOperationCustomizersStream().toList())
+			routerOperation = routerOperationCustomizer.customize(routerOperation, handlerMethod);
 		return routerOperation;
 	}
 

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpringDocCustomizers.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpringDocCustomizers.java
@@ -25,11 +25,13 @@
  */
 package org.springdoc.core.customizers;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.springdoc.core.filters.GlobalOpenApiMethodFilter;
 import org.springdoc.core.filters.OpenApiMethodFilter;
@@ -38,6 +40,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.util.CollectionUtils;
 
 import static org.springdoc.core.utils.Constants.LINKS_SCHEMA_CUSTOMIZER;
@@ -170,12 +173,30 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	}
 
 	/**
+	 * Gets ordered open api customizer stream.
+	 *
+	 * @return the ordered open api customizer stream
+	 */
+	public Stream<OpenApiCustomizer> getOpenApiCustomizersStream() {
+		return orderedStream(openApiCustomizers);
+	}
+
+	/**
 	 * Gets operation customizers.
 	 *
 	 * @return the operation customizers
 	 */
 	public Optional<Set<OperationCustomizer>> getOperationCustomizers() {
 		return operationCustomizers;
+	}
+
+	/**
+	 * Gets ordered operation customizer stream.
+	 *
+	 * @return the ordered operation customizer stream
+	 */
+	public Stream<OperationCustomizer> getOperationCustomizersStream() {
+		return orderedStream(operationCustomizers);
 	}
 
 	/**
@@ -188,12 +209,30 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	}
 
 	/**
+	 * Gets ordered router operation customizer stream.
+	 *
+	 * @return the ordered router operation customizer stream
+	 */
+	public Stream<RouterOperationCustomizer> getRouterOperationCustomizersStream() {
+		return orderedStream(routerOperationCustomizers);
+	}
+
+	/**
 	 * Gets data rest router operation customizers.
 	 *
 	 * @return the data rest router operation customizers
 	 */
 	public Optional<Set<DataRestRouterOperationCustomizer>> getDataRestRouterOperationCustomizers() {
 		return dataRestRouterOperationCustomizers;
+	}
+
+	/**
+	 * Gets ordered data rest router operation customizer stream.
+	 *
+	 * @return the ordered data rest router operation customizer stream
+	 */
+	public Stream<DataRestRouterOperationCustomizer> getDataRestRouterOperationCustomizersStream() {
+		return orderedStream(dataRestRouterOperationCustomizers);
 	}
 
 	/**
@@ -220,6 +259,15 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	}
 
 	/**
+	 * Gets ordered global open api customizer stream.
+	 *
+	 * @return the ordered global open api customizer stream
+	 */
+	public Stream<GlobalOpenApiCustomizer> getGlobalOpenApiCustomizersStream() {
+		return orderedStream(globalOpenApiCustomizers);
+	}
+
+	/**
 	 * Gets global operation customizers.
 	 *
 	 * @return the global operation customizers
@@ -229,12 +277,30 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	}
 
 	/**
+	 * Gets ordered global operation customizer stream.
+	 *
+	 * @return the ordered global operation customizer stream
+	 */
+	public Stream<GlobalOperationCustomizer> getGlobalOperationCustomizersStream() {
+		return orderedStream(globalOperationCustomizers);
+	}
+
+	/**
 	 * Gets global open api method filters.
 	 *
 	 * @return the global open api method filters
 	 */
 	public Optional<Set<GlobalOpenApiMethodFilter>> getGlobalOpenApiMethodFilters() {
 		return globalOpenApiMethodFilters;
+	}
+
+	/**
+	 * Gets ordered global open api method filter stream.
+	 *
+	 * @return the ordered global open api method filter stream
+	 */
+	public Stream<GlobalOpenApiMethodFilter> getGlobalOpenApiMethodFiltersStream() {
+		return orderedStream(globalOpenApiMethodFilters);
 	}
 
 	/**
@@ -253,6 +319,13 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	 */
 	public Optional<List<ParameterCustomizer>> getParameterCustomizers() {
 		return parameterCustomizers;
+	}
+
+	private static <T> Stream<T> orderedStream(Optional<? extends Collection<T>> customizers) {
+		return customizers.stream()
+				.flatMap(Collection::stream)
+				.filter(Objects::nonNull)
+				.sorted(AnnotationAwareOrderComparator.INSTANCE);
 	}
 
 	@Override

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpringDocCustomizers.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/customizers/SpringDocCustomizers.java
@@ -295,15 +295,6 @@ public class SpringDocCustomizers implements ApplicationContextAware, Initializi
 	}
 
 	/**
-	 * Gets ordered global open api method filter stream.
-	 *
-	 * @return the ordered global open api method filter stream
-	 */
-	public Stream<GlobalOpenApiMethodFilter> getGlobalOpenApiMethodFiltersStream() {
-		return orderedStream(globalOpenApiMethodFilters);
-	}
-
-	/**
 	 * Gets optional delegating method parameter customizers.
 	 *
 	 * @return the optional delegating method parameter customizers

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/customizers/SpringDocCustomizersTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/customizers/SpringDocCustomizersTest.java
@@ -56,6 +56,29 @@ class SpringDocCustomizersTest {
 		assertThat(springDocCustomizers.getOpenApiCustomizersStream().toList()).containsExactly(firstCustomizer, lastCustomizer);
 	}
 
+	@Test
+	void globalOpenApiCustomizersStreamHonorsOrderAnnotation() {
+		GlobalOpenApiCustomizer lastCustomizer = new LastGlobalOpenApiCustomizer();
+		GlobalOpenApiCustomizer firstCustomizer = new FirstGlobalOpenApiCustomizer();
+		Set<GlobalOpenApiCustomizer> unorderedCustomizers = new LinkedHashSet<>();
+		unorderedCustomizers.add(lastCustomizer);
+		unorderedCustomizers.add(firstCustomizer);
+
+		SpringDocCustomizers springDocCustomizers = new SpringDocCustomizers(
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.of(unorderedCustomizers),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty());
+
+		assertThat(springDocCustomizers.getGlobalOpenApiCustomizersStream().toList()).containsExactly(firstCustomizer, lastCustomizer);
+	}
+
 	@Order(1)
 	private static class FirstOpenApiCustomizer implements OpenApiCustomizer {
 
@@ -66,6 +89,22 @@ class SpringDocCustomizersTest {
 
 	@Order(2)
 	private static class LastOpenApiCustomizer implements OpenApiCustomizer {
+
+		@Override
+		public void customise(OpenAPI openApi) {
+		}
+	}
+
+	@Order(1)
+	private static class FirstGlobalOpenApiCustomizer implements GlobalOpenApiCustomizer {
+
+		@Override
+		public void customise(OpenAPI openApi) {
+		}
+	}
+
+	@Order(2)
+	private static class LastGlobalOpenApiCustomizer implements GlobalOpenApiCustomizer {
 
 		@Override
 		public void customise(OpenAPI openApi) {

--- a/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/customizers/SpringDocCustomizersTest.java
+++ b/springdoc-openapi-starter-common/src/test/java/org/springdoc/core/customizers/SpringDocCustomizersTest.java
@@ -1,0 +1,74 @@
+/*
+ *
+ *  *
+ *  *  *
+ *  *  *  *
+ *  *  *  *  * Copyright 2019-2026 the original author or authors.
+ *  *  *  *  *
+ *  *  *  *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  *  *  * you may not use this file except in compliance with the License.
+ *  *  *  *  * You may obtain a copy of the License at
+ *  *  *  *  *
+ *  *  *  *  *      https://www.apache.org/licenses/LICENSE-2.0
+ *  *  *  *  *
+ *  *  *  *  * Unless required by applicable law or agreed to in writing, software
+ *  *  *  *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  *  *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  *  *  *  * See the License for the specific language governing permissions and
+ *  *  *  *  * limitations under the License.
+ *  *  *  *
+ *  *  *
+ *  *
+ *
+ */
+
+package org.springdoc.core.customizers;
+
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.annotation.Order;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringDocCustomizersTest {
+
+	@Test
+	void openApiCustomizersStreamHonorsOrderAnnotation() {
+		OpenApiCustomizer lastCustomizer = new LastOpenApiCustomizer();
+		OpenApiCustomizer firstCustomizer = new FirstOpenApiCustomizer();
+		Set<OpenApiCustomizer> unorderedCustomizers = new LinkedHashSet<>();
+		unorderedCustomizers.add(lastCustomizer);
+		unorderedCustomizers.add(firstCustomizer);
+
+		SpringDocCustomizers springDocCustomizers = new SpringDocCustomizers(
+				Optional.of(unorderedCustomizers),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty(),
+				Optional.empty());
+
+		assertThat(springDocCustomizers.getOpenApiCustomizersStream().toList()).containsExactly(firstCustomizer, lastCustomizer);
+	}
+
+	@Order(1)
+	private static class FirstOpenApiCustomizer implements OpenApiCustomizer {
+
+		@Override
+		public void customise(OpenAPI openApi) {
+		}
+	}
+
+	@Order(2)
+	private static class LastOpenApiCustomizer implements OpenApiCustomizer {
+
+		@Override
+		public void customise(OpenAPI openApi) {
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3320.

This updates Springdoc customizer execution so customizers are applied according to Spring ordering semantics such as `@Order`.

Previously, several customizer collections were stored as `Set`s and iterated directly, so the execution order could depend on set iteration order instead of Spring's ordering rules.

## Changes

- Apply `OpenApiCustomizer` instances in Spring order.
- Apply `OperationCustomizer` instances in Spring order.
- Apply `RouterOperationCustomizer` instances in Spring order.
- Apply `DataRestRouterOperationCustomizer` instances in Spring order.
- Apply `OpenApiLocaleCustomizer` beans using Spring's ordered bean stream.
- Add a focused regression test for ordered customizer execution.

## Testing

```bash
mvn -q -pl springdoc-openapi-starter-common -Dtest=SpringDocCustomizersTest test
git diff --check