### PR TITLE
Replace nested Page with PagedModel when serialization mode is VIA_DTO

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageOpenAPIConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageOpenAPIConverter.java
@@ -43,8 +43,6 @@ import org.springdoc.core.providers.ObjectMapperProvider;
 import org.springframework.core.ResolvableType;
 import org.springframework.data.web.PagedModel;
 
-import static org.springdoc.core.utils.SpringDocUtils.getParentTypeName;
-
 /**
  * The Spring Data Page type model converter.
  *
@@ -119,7 +117,7 @@ public class PageOpenAPIConverter implements ModelConverter {
 				if (!type.isSchemaProperty())
 					type = resolvePagedModelType(javaType, type);
 				else
-					type.name(getParentTypeName(type, cls));
+					type.type(pagedModelType(javaType)).resolveAsRef(true);
 			}
 		}
 		Schema schema = (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
@@ -137,17 +135,29 @@ public class PageOpenAPIConverter implements ModelConverter {
 	 */
 	private AnnotatedType resolvePagedModelType(JavaType type, AnnotatedType originalType) {
 		if (type.hasGenericTypes()) {
-			JavaType innerType = type.containedType(0);
-			Type pagedModelType = ResolvableType
-					.forClassWithGenerics(PagedModel.class, ResolvableType.forType(innerType))
-					.getType();
-			return new AnnotatedType(pagedModelType)
+			return new AnnotatedType(pagedModelType(type))
 					.resolveAsRef(true)
 					.ctxAnnotations(originalType.getCtxAnnotations());
 		}
 		else {
 			return PAGED_MODEL;
 		}
+	}
+
+	/**
+	 * The PagedModel type matching the given Page type.
+	 *
+	 * @param type the page type
+	 * @return the paged model type
+	 */
+	private Type pagedModelType(JavaType type) {
+		if (type.hasGenericTypes()) {
+			JavaType innerType = type.containedType(0);
+			return ResolvableType
+					.forClassWithGenerics(PagedModel.class, ResolvableType.forType(innerType))
+					.getType();
+		}
+		return PagedModel.class;
 	}
 
 	/**

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v30/app10/HelloController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v30/app10/HelloController.java
@@ -74,6 +74,16 @@ public class HelloController {
 		return pagedModelSimple();
 	}
 
+	@GetMapping("/dummy-page-simple")
+	public Dummy<Page<String>> dummyPageSimple() {
+		return new Dummy<>(pageSimple());
+	}
+
+	@GetMapping("/dummy-page-complex")
+	public Dummy<Page<Dummy<List<String>>>> dummyPageComplex() {
+		return new Dummy<>(pageComplex());
+	}
+
 	private <T> PagedModel<T> pagedModel(T value) {
 		return new PagedModel<>(pageImpl(value));
 	}

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v31/app10/HelloController.java
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v31/app10/HelloController.java
@@ -68,6 +68,16 @@ public class HelloController {
 		return pagedModelSimple();
 	}
 
+	@GetMapping("/dummy-page-simple")
+	public Dummy<Page<String>> dummyPageSimple() {
+		return new Dummy<>(pageSimple());
+	}
+
+	@GetMapping("/dummy-page-complex")
+	public Dummy<Page<Dummy<List<String>>>> dummyPageComplex() {
+		return new Dummy<>(pageComplex());
+	}
+
 	private <T> PagedModel<T> pagedModel(T value) {
 		return new PagedModel<>(pageImpl(value));
 	}

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-direct.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-direct.json
@@ -150,6 +150,46 @@
           }
         }
       }
+    },
+    "/dummy-page-simple": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageSimple",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageString"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dummy-page-complex": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageComplex",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageDummyListString"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -460,6 +500,22 @@
           },
           "empty": {
             "type": "boolean"
+          }
+        }
+      },
+      "DummyPageString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PageString"
+          }
+        }
+      },
+      "DummyPageDummyListString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PageDummyListString"
           }
         }
       }

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-via_dto.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-via_dto.json
@@ -150,6 +150,46 @@
           }
         }
       }
+    },
+    "/dummy-page-simple": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageSimple",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageString"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dummy-page-complex": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageComplex",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageDummyListString"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -250,6 +290,22 @@
           },
           "email": {
             "type": "string"
+          }
+        }
+      },
+      "DummyPageString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PagedModelString"
+          }
+        }
+      },
+      "DummyPageDummyListString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PagedModelDummyListString"
           }
         }
       }

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-direct.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-direct.json
@@ -130,6 +130,46 @@
           }
         }
       }
+    },
+    "/dummy-page-simple": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageSimple",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageString"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dummy-page-complex": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageComplex",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageDummyListString"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -379,6 +419,22 @@
           },
           "empty": {
             "type": "boolean"
+          }
+        }
+      },
+      "DummyPageString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PageString"
+          }
+        }
+      },
+      "DummyPageDummyListString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PageDummyListString"
           }
         }
       }

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-via_dto.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-via_dto.json
@@ -130,6 +130,46 @@
           }
         }
       }
+    },
+    "/dummy-page-simple": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageSimple",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageString"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dummy-page-complex": {
+      "get": {
+        "tags": [
+          "hello-controller"
+        ],
+        "operationId": "dummyPageComplex",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DummyPageDummyListString"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -203,6 +243,22 @@
           },
           "page": {
             "$ref": "#/components/schemas/PageMetadata"
+          }
+        }
+      },
+      "DummyPageString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PagedModelString"
+          }
+        }
+      },
+      "DummyPageDummyListString": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/PagedModelDummyListString"
           }
         }
       }


### PR DESCRIPTION
Fixes #3319.

## Summary

With `spring.data.web.pageable.serialization-mode=VIA_DTO`, a `Page<T>` returned directly (or inside `ResponseEntity`) is documented as `PagedModel<T>`, but a `Page<T>` nested in another type is not:

```java
@GetMapping("/result")
public Result<Page<UserInfo>> listUserInfosWithResult() { ... }
```

The response is `{"data": {"content": [...], "page": {...}}, ...}`, while the spec documents `data` as the raw `Page` shape (`pageable`, `sort`, `first`, `last`, ...). The generated schema is also always named `PageObject`, so two wrappers with different element types share one schema and the second element type is missing from `components.schemas`.

`PageOpenAPIConverter.resolve` only swaps `Page` for `PagedModel` when the type is not a schema property. For a property it keeps `Page` and sets a name via `getParentTypeName`, which appends the parent's OpenAPI type (`"object"`) rather than the parent class.

## Change

- In the schema-property branch, swap the `AnnotatedType`'s `type` to the matching `PagedModel<T>` in place. The instance is kept, so `ctxAnnotations`, `jsonViewAnnotation`, `parent` and `propertyName` stay as they were (creating a new `AnnotatedType` here drops the `@JsonView` context from #3226).
- Extract the `PagedModel<T>` type computation into `pagedModelType(JavaType)` so both branches share it.

| Case | Before | After |
|---|---|---|
| `Page<T>` as response body, or inside `ResponseEntity` | `PagedModelT` | unchanged |
| `DIRECT` mode or property not set | raw `Page` | unchanged |
| `Page<T>` as a property of another type, `VIA_DTO` | `PageObject` (raw `Page` shape, shared name) | `PagedModelT` |

Only the last row changes. `PageObject`, `PageableObject` and `SortObject` disappear from such specs and `PagedModelXxx` takes their place. A raw `Page` in that position becomes `PagedModel`, the same as a raw `Page` returned directly.

## Test plan

- [x] Added `Dummy<Page<String>>` and `Dummy<Page<Dummy<List<String>>>>` endpoints to the `app10` hateoas test (`v30` and `v31`) and updated the four expected files. Without the fix the `VIA_DTO` variants fail with `Unexpected: PageObject, PageableObject, SortObject`; the `DIRECT` and not-specified variants pass before and after.
- [x] `mvn test` on `springdoc-openapi-starter-common`, `-webmvc-api`, `-webflux-api`, `hateoas-tests`, `data-rest-tests`, `groovy-tests` — all green.
- [x] Verified against the reporter's demo from #3319 (Boot 4.1.1) with this branch installed as a snapshot: `Result<Page<UserInfo>>` and a second `Result<Page<OtherInfo>>` now get `PagedModelUserInfo` and `PagedModelOtherInfo` respectively, and the documented field set matches the actual response for every endpoint. `DIRECT` mode produces an identical document before and after.
