### PR TITLE
Stabilize Spring Data Sort and Pageable schema property order

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageableOpenAPIConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageableOpenAPIConverter.java
@@ -27,11 +27,15 @@
 package org.springdoc.core.converters;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.converters.models.Pageable;
 import org.springdoc.core.providers.ObjectMapperProvider;
@@ -42,6 +46,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getParentTypeName;
  * The Pageable Type models converter.
  *
  * @author bnasslahsen
+ * @author dpkass
  */
 public class PageableOpenAPIConverter implements ModelConverter {
 
@@ -59,6 +64,11 @@ public class PageableOpenAPIConverter implements ModelConverter {
 	 * The constant PAGEABLE.
 	 */
 	private static final AnnotatedType PAGEABLE = new AnnotatedType(Pageable.class).resolveAsRef(true);
+
+	/**
+	 * The standard pageable response property order.
+	 */
+	private static final List<String> PAGEABLE_PROPERTY_ORDER = List.of("offset", "paged", "pageNumber", "pageSize", "sort", "unpaged");
 
 	/**
 	 * The Spring doc object mapper.
@@ -85,16 +95,43 @@ public class PageableOpenAPIConverter implements ModelConverter {
 	@Override
 	public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
 		JavaType javaType = springDocObjectMapper.jsonMapper().constructType(type.getType());
+		boolean isPageableType = false;
 		if (javaType != null) {
 			Class<?> cls = javaType.getRawClass();
-			if (PAGEABLE_TO_REPLACE.equals(cls.getCanonicalName()) || PAGE_REQUEST_TO_REPLACE.equals(cls.getCanonicalName())) {
+			isPageableType = PAGEABLE_TO_REPLACE.equals(cls.getCanonicalName()) || PAGE_REQUEST_TO_REPLACE.equals(cls.getCanonicalName());
+			if (isPageableType) {
 				if (!type.isSchemaProperty())
 					type = PAGEABLE;
 				else
 					type.name(getParentTypeName(type, cls));
 			}
 		}
-		return (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
+		Schema schema = (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
+		if (isPageableType)
+			sortSchemaProperties(schema, context);
+		return schema;
+	}
+
+	/**
+	 * Sort the response schema properties.
+	 *
+	 * @param schema  the schema
+	 * @param context the context
+	 */
+	private void sortSchemaProperties(Schema schema, ModelConverterContext context) {
+		if (schema != null && schema.get$ref() != null && schema.get$ref().startsWith(Components.COMPONENTS_SCHEMAS_REF))
+			schema = context.getDefinedModels().get(schema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length()));
+		if (schema == null || schema.getProperties() == null)
+			return;
+
+		Map<String, Schema> properties = schema.getProperties();
+		if (!properties.keySet().containsAll(PAGEABLE_PROPERTY_ORDER))
+			return;
+
+		Map<String, Schema> sortedProperties = new LinkedHashMap<>();
+		PAGEABLE_PROPERTY_ORDER.forEach(property -> sortedProperties.put(property, properties.get(property)));
+		properties.forEach(sortedProperties::putIfAbsent);
+		schema.setProperties(sortedProperties);
 	}
 
 }

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/SortOpenAPIConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/SortOpenAPIConverter.java
@@ -27,11 +27,15 @@
 package org.springdoc.core.converters;
 
 import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.databind.JavaType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.media.Schema;
 import org.springdoc.core.converters.models.Sort;
 import org.springdoc.core.providers.ObjectMapperProvider;
@@ -42,6 +46,7 @@ import static org.springdoc.core.utils.SpringDocUtils.getParentTypeName;
  * The Spring Data Sort type model converter.
  *
  * @author daniel -shuy
+ * @author dpkass
  */
 public class SortOpenAPIConverter implements ModelConverter {
 
@@ -54,6 +59,11 @@ public class SortOpenAPIConverter implements ModelConverter {
 	 * The constant SORT.
 	 */
 	private static final AnnotatedType SORT = new AnnotatedType(Sort.class).resolveAsRef(true);
+
+	/**
+	 * The standard sort response property order.
+	 */
+	private static final List<String> SORT_PROPERTY_ORDER = List.of("empty", "sorted", "unsorted");
 
 	/**
 	 * The Spring doc object mapper.
@@ -80,16 +90,43 @@ public class SortOpenAPIConverter implements ModelConverter {
 	@Override
 	public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
 		JavaType javaType = springDocObjectMapper.jsonMapper().constructType(type.getType());
+		boolean isSortType = false;
 		if (javaType != null) {
 			Class<?> cls = javaType.getRawClass();
-			if (SORT_TO_REPLACE.equals(cls.getCanonicalName())) {
+			isSortType = SORT_TO_REPLACE.equals(cls.getCanonicalName());
+			if (isSortType) {
 				if (!type.isSchemaProperty())
 					type = SORT;
 				else
 					type.name(getParentTypeName(type, cls));
 			}
 		}
-		return (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
+		Schema schema = (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
+		if (isSortType)
+			sortSchemaProperties(schema, context);
+		return schema;
+	}
+
+	/**
+	 * Sort the response schema properties.
+	 *
+	 * @param schema  the schema
+	 * @param context the context
+	 */
+	private void sortSchemaProperties(Schema schema, ModelConverterContext context) {
+		if (schema != null && schema.get$ref() != null && schema.get$ref().startsWith(Components.COMPONENTS_SCHEMAS_REF))
+			schema = context.getDefinedModels().get(schema.get$ref().substring(Components.COMPONENTS_SCHEMAS_REF.length()));
+		if (schema == null || schema.getProperties() == null)
+			return;
+
+		Map<String, Schema> properties = schema.getProperties();
+		if (!properties.keySet().containsAll(SORT_PROPERTY_ORDER))
+			return;
+
+		Map<String, Schema> sortedProperties = new LinkedHashMap<>();
+		SORT_PROPERTY_ORDER.forEach(property -> sortedProperties.put(property, properties.get(property)));
+		properties.forEach(sortedProperties::putIfAbsent);
+		schema.setProperties(sortedProperties);
 	}
 
 }


### PR DESCRIPTION
Stabilizes the property order of generated Spring Data SortObject and PageableObject schemas. This avoids noisy OpenAPI and generated-client diffs where the schema shape is unchanged but pagination properties are emitted in a different order.

This applies the same approach as https://github.com/springdoc/springdoc-openapi/pull/3281 to SortObject and PageableObject.