### PR TITLE
Fix vulnerabilities: upgrade swagger-ui from 5.32.11 to 5.32.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `springdoc.ai.mcp.audit.redact` (default `true`) to mask secrets in MCP audit events
 - Document that the MCP approval flow is a confirmation step, not an authorization control
 - Document the security policy and the release versioning scheme
+- Upgrade swagger-ui to version **5.32.14**
 
 ## [3.1.0] - 2026-07-31
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
 		<swagger-api.version>2.2.52</swagger-api.version>
-		<swagger-ui.version>5.32.11</swagger-ui.version>
+		<swagger-ui.version>5.32.14</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>
 		<therapi-runtime-javadoc.version>0.15.0</therapi-runtime-javadoc.version>


### PR DESCRIPTION
Upgrades `swagger-ui` from `5.32.11` to `5.32.14` to fix CVE-2026-75838