### PR TITLE
feat: manage the swagger artifacts in the BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - #3340 – Describe `JsonNullable` values without their Java wrapper
+- #3325 – Manage the swagger artifacts in `springdoc-openapi-bom`, so that modules holding only the annotations stay in lockstep
 
 ### Changed
 

--- a/springdoc-openapi-bom/pom.xml
+++ b/springdoc-openapi-bom/pom.xml
@@ -60,6 +60,22 @@
 				<artifactId>springdoc-openapi-starter-webflux-mcp</artifactId>
 				<version>${project.version}</version>
 			</dependency>
+			<!-- swagger dependencies, so that modules holding only the annotations stay in lockstep -->
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-annotations-jakarta</artifactId>
+				<version>${swagger-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-models-jakarta</artifactId>
+				<version>${swagger-api.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.swagger.core.v3</groupId>
+				<artifactId>swagger-core-jakarta</artifactId>
+				<version>${swagger-api.version}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -82,7 +98,7 @@
 							<updatePomFile>true</updatePomFile>
 							<flattenMode>bom</flattenMode>
 							<pomElements>
-								<properties>remove</properties>
+								<properties>expand</properties>
 								<distributionManagement>remove</distributionManagement>
 								<dependencyManagement>keep</dependencyManagement>
 								<repositories>remove</repositories>


### PR DESCRIPTION
Modules that only carry the swagger annotations had no way to pick up the version springdoc resolves elsewhere: importing the BOM copies its managed dependencies, not its properties.

`swagger-annotations-jakarta`, `swagger-models-jakarta` and `swagger-core-jakarta` are now managed by `springdoc-openapi-bom`. Its flattened form has to keep the properties for `${swagger-api.version}` to be resolvable by the consumer, so `flatten-maven-plugin` switches from `<properties>remove</properties>` to `<properties>expand</properties>`.

Fixes #3325