### PR TITLE
upgrade swagger-core from 2.2.53 to 2.2.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 		<central-publishing-maven-plugin.version>0.11.0
 		</central-publishing-maven-plugin.version>
 		<flatten-maven-plugin.version>1.5.0</flatten-maven-plugin.version>
-		<swagger-api.version>2.2.53</swagger-api.version>
+		<swagger-api.version>2.2.54</swagger-api.version>
 		<swagger-ui.version>5.32.14</swagger-ui.version>
 		<gmavenplus-plugin.version>1.13.1</gmavenplus-plugin.version>
 		<jjwt.version>0.9.1</jjwt.version>

--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/utils/SpringDocUtils.java
@@ -565,13 +565,10 @@ public class SpringDocUtils {
 	 * @return the spring doc utils
 	 */
 	public SpringDocUtils initExtraSchemas() {
-		customClasses().put("java.time.Duration", PrimitiveType.STRING);
-		customClasses().put("java.time.LocalTime", PrimitiveType.STRING);
 		customClasses().put("java.time.YearMonth", PrimitiveType.STRING);
 		customClasses().put("java.time.MonthDay", PrimitiveType.STRING);
 		customClasses().put("java.time.Year", PrimitiveType.STRING);
 		customClasses().put("java.time.Period", PrimitiveType.STRING);
-		customClasses().put("java.time.OffsetTime", PrimitiveType.STRING);
 		customClasses().put("java.time.ZoneId", PrimitiveType.STRING);
 		customClasses().put("java.time.ZoneOffset", PrimitiveType.STRING);
 		customClasses().put("java.util.TimeZone", PrimitiveType.STRING);
@@ -586,13 +583,10 @@ public class SpringDocUtils {
 	 * @return the spring doc utils
 	 */
 	public SpringDocUtils resetExtraSchemas() {
-		customClasses().remove("java.time.Duration");
-		customClasses().remove("java.time.LocalTime");
 		customClasses().remove("java.time.YearMonth");
 		customClasses().remove("java.time.MonthDay");
 		customClasses().remove("java.time.Year");
 		customClasses().remove("java.time.Period");
-		customClasses().remove("java.time.OffsetTime");
 		customClasses().remove("java.time.ZoneId");
 		customClasses().remove("java.time.ZoneOffset");
 		customClasses().remove("java.util.TimeZone");

--- a/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app115/JavaTimeOperationCustomizer.java
+++ b/springdoc-openapi-starter-webmvc-api/src/test/java/test/org/springdoc/api/v31/app115/JavaTimeOperationCustomizer.java
@@ -47,7 +47,6 @@ public class JavaTimeOperationCustomizer implements OperationCustomizer {
 				Content content = response.getContent();
 				if (content.containsKey(MediaType.APPLICATION_JSON_VALUE)) {
 					Schema schema = content.get(MediaType.APPLICATION_JSON_VALUE).getSchema();
-					schema.getProperties().clear();
 					schema.types(Set.of("string"));
 				}
 			}

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app115.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app115.json
@@ -23,7 +23,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "string",
+                  "format": "duration"
                 }
               }
             }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app115.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app115.json
@@ -24,7 +24,7 @@
               "application/json": {
                 "schema": {
                   "type": "string",
-                  "properties": {}
+                  "format": "duration"
                 }
               }
             }

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app243.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.1.0/app243.json
@@ -56,7 +56,8 @@
             "format": "date"
           },
           "localTime": {
-            "type": "string"
+            "type": "string",
+            "format": "partial-time"
           },
           "yearMonth": {
             "type": "string"

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v30/app115/JavaTimeOperationCustomizer.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v30/app115/JavaTimeOperationCustomizer.java
@@ -58,7 +58,6 @@ class JavaTimeOperationCustomizer implements OperationCustomizer {
 				Content content = response.getContent();
 				if (content.containsKey(MediaType.APPLICATION_JSON_VALUE)) {
 					Schema schema = content.get(MediaType.APPLICATION_JSON_VALUE).getSchema();
-					schema.getProperties().clear();
 					schema.setType("string");
 				}
 			}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app115/JavaTimeOperationCustomizer.java
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/java/test/org/springdoc/api/v31/app115/JavaTimeOperationCustomizer.java
@@ -60,7 +60,6 @@ class JavaTimeOperationCustomizer implements OperationCustomizer {
 				if (content.containsKey(MediaType.APPLICATION_JSON_VALUE)) {
 					Schema schema = content.get(MediaType.APPLICATION_JSON_VALUE).getSchema();
 					schema.types(Set.of("string"));
-					schema.getProperties().clear();
 				}
 			}
 		}

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app115.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.0.1/app115.json
@@ -32,7 +32,7 @@
               "application/json": {
                 "schema": {
                   "type": "string",
-                  "properties": {}
+                  "format": "duration"
                 }
               }
             }

--- a/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app115.json
+++ b/springdoc-openapi-tests/springdoc-openapi-javadoc-tests/src/test/resources/results/3.1.0/app115.json
@@ -32,7 +32,7 @@
               "application/json": {
                 "schema": {
                   "type": "string",
-                  "properties": {}
+                  "format": "duration"
                 }
               }
             }


### PR DESCRIPTION
Swagger-core has implemented better handling for dates in https://github.com/swagger-api/swagger-core/pull/5184. This means that some parts of `ExtraSchemas` from https://github.com/springdoc/springdoc-openapi/commit/ec43ffbd6e316aa8fb359552f41fe2913a629fad can be removed, since they are now handled upstream.