### PR TITLE
Mark Spring Data Page properties as required

### DIFF
--- a/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageOpenAPIConverter.java
+++ b/springdoc-openapi-starter-common/src/main/java/org/springdoc/core/converters/PageOpenAPIConverter.java
@@ -123,7 +123,7 @@ public class PageOpenAPIConverter implements ModelConverter {
 		Schema schema = (chain.hasNext()) ? chain.next().resolve(type, context, chain) : null;
 
 		if (isPageType && !replacePageWithPagedModel)
-			sortPageSchemaProperties(schema, context);
+			customizePageSchema(schema, context);
 		return schema;
 	}
 
@@ -161,12 +161,12 @@ public class PageOpenAPIConverter implements ModelConverter {
 	}
 
 	/**
-	 * Sort page schema properties.
+	 * Require and sort page schema properties.
 	 *
 	 * @param schema  the schema
 	 * @param context the context
 	 */
-	private void sortPageSchemaProperties(Schema schema, ModelConverterContext context) {
+	private void customizePageSchema(Schema schema, ModelConverterContext context) {
 		Schema pageSchema = resolveReferencedSchema(schema, context);
 		if (pageSchema == null || pageSchema.getProperties() == null)
 			return;
@@ -179,6 +179,7 @@ public class PageOpenAPIConverter implements ModelConverter {
 		PAGE_PROPERTY_ORDER.forEach(property -> sortedProperties.put(property, properties.get(property)));
 		properties.forEach(sortedProperties::putIfAbsent);
 		pageSchema.setProperties(sortedProperties);
+		pageSchema.setRequired(PAGE_PROPERTY_ORDER);
 	}
 
 	/**

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app246.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app246.json
@@ -79,6 +79,19 @@
                 }
             },
             "PageHelloWorld_Hello": {
+                "required": [
+                    "content",
+                    "empty",
+                    "first",
+                    "last",
+                    "number",
+                    "numberOfElements",
+                    "pageable",
+                    "size",
+                    "sort",
+                    "totalElements",
+                    "totalPages"
+                ],
                 "type": "object",
                 "properties": {
                     "totalElements": {

--- a/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app249.json
+++ b/springdoc-openapi-starter-webmvc-api/src/test/resources/results/3.0.1/app249.json
@@ -105,6 +105,19 @@
         }
       },
       "PageHelloWorld_Hello": {
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ],
         "type": "object",
         "properties": {
           "totalPages": {

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.0.1/app24.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.0.1/app24.json
@@ -123,7 +123,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageableObject": {
         "type": "object",

--- a/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app24.json
+++ b/springdoc-openapi-tests/springdoc-openapi-data-rest-tests/src/test/resources/results/3.1.0/app24.json
@@ -123,7 +123,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageableObject": {
         "type": "object",

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v30/app10/SpringDocApp10DirectTest.java
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v30/app10/SpringDocApp10DirectTest.java
@@ -33,6 +33,7 @@ import test.org.springdoc.api.v30.AbstractSpringDocTest;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -47,6 +48,9 @@ public class SpringDocApp10DirectTest extends AbstractSpringDocTest {
 		mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.openapi", is("3.0.1")))
+				.andExpect(jsonPath("$.components.schemas.PageString.required", containsInAnyOrder(
+						"totalPages", "totalElements", "size", "content", "number", "sort", "pageable",
+						"numberOfElements", "first", "last", "empty")))
 				.andExpect(content().json(getContent("results/3.0.1/app10-direct.json"), true));
 	}
 

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v31/app10/SpringDocApp10DirectTest.java
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/java/test/org/springdoc/api/v31/app10/SpringDocApp10DirectTest.java
@@ -33,6 +33,7 @@ import test.org.springdoc.api.v31.AbstractSpringDocTest;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -47,6 +48,9 @@ public class SpringDocApp10DirectTest extends AbstractSpringDocTest {
 		mockMvc.perform(get(Constants.DEFAULT_API_DOCS_URL))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.openapi", is("3.1.0")))
+				.andExpect(jsonPath("$.components.schemas.PageString.required", containsInAnyOrder(
+						"totalPages", "totalElements", "size", "content", "number", "sort", "pageable",
+						"numberOfElements", "first", "last", "empty")))
 				.andExpect(content().json(getContent("results/3.1.0/app10-direct.json"), true));
 	}
 

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-direct.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.0.1/app10-direct.json
@@ -312,7 +312,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageableObject": {
         "type": "object",
@@ -398,7 +411,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "UserDto": {
         "type": "object",
@@ -455,7 +481,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageDummyListString": {
         "type": "object",
@@ -501,7 +540,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "DummyPageString": {
         "type": "object",

--- a/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-direct.json
+++ b/springdoc-openapi-tests/springdoc-openapi-hateoas-tests/src/test/resources/results/3.1.0/app10-direct.json
@@ -290,7 +290,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageableObject": {
         "type": "object",
@@ -374,7 +387,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "PageDummyListString": {
         "type": "object",
@@ -420,7 +446,20 @@
           "empty": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "content",
+          "empty",
+          "first",
+          "last",
+          "number",
+          "numberOfElements",
+          "pageable",
+          "size",
+          "sort",
+          "totalElements",
+          "totalPages"
+        ]
       },
       "DummyPageString": {
         "type": "object",


### PR DESCRIPTION
Marks the standard properties of directly serialized Spring Data `Page` schemas as required. Spring Data always emits these fields, but the generated schema currently leaves them optional, causing client generators to model fields such as `content` and `totalPages` as optional.

This only applies to direct `Page` serialization. `VIA_DTO` serialization remains unchanged. Regression fixtures cover OpenAPI 3.0 and 3.1.
